### PR TITLE
python 2.5 support for setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,9 @@
     :license: GNU GPL, see LICENSE for more details.
 """
 
+# for python 2.5 support
+from __future__ import with_statement
+
 from setuptools import setup
 from setuptools import find_packages
 from openslides import get_version


### PR DESCRIPTION
(Fixed install error during 'pip install openslides' on python 2.5
systems.)
