### PR TITLE
Fix typo in INSTALL.txt. Set next release from 1.3.1a0 to 1.3.1a1

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -127,7 +127,7 @@ II. Installation on GNU/Linux and MacOSX using the sources
   6. Restart OpenSlides:
 
         To restart OpenSlides after closing the terminal activate the
-        virtual environment (see 4.) before starting the server (see 6.).
+        virtual environment (see 3.) before starting the server (see 5.).
 
 
 III. Installation on Windows (32bit) using the Python Package Index (PyPI)

--- a/openslides/__init__.py
+++ b/openslides/__init__.py
@@ -5,7 +5,7 @@
     :license: GNU GPL, see LICENSE for more details.
 """
 
-VERSION = (1, 3, 1, 'alpha', 0)  # During development it is the next release
+VERSION = (1, 3, 1, 'alpha', 1)  # During development it is the next release
 RELEASE = False
 
 


### PR DESCRIPTION
 because 0 is not an ordinal number.
