### PR TITLE
Issue #539 Default config value in agenda app

### DIFF
--- a/openslides/agenda/__init__.py
+++ b/openslides/agenda/__init__.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+"""
+    openslides.agenda
+    ~~~~~~~~~~~~~~~~~
+
+    The OpenSlides agenda app appends the functionality to OpenSlides to
+    manage agendas.
+
+    :copyright: (c) 2011-2013 by the OpenSlides team, see AUTHORS.
+    :license: GNU GPL, see LICENSE for more details.
+"""
+
+import openslides.agenda.signals

--- a/openslides/agenda/signals.py
+++ b/openslides/agenda/signals.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+    openslides.agenda.signals
+    ~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Signals for the agenda app.
+
+    :copyright: (c) 2011-2013 by the OpenSlides team, see AUTHORS.
+    :license: GNU GPL, see LICENSE for more details.
+"""
+
+from django.dispatch import receiver
+
+from openslides.config.signals import default_config_value
+
+
+@receiver(default_config_value, dispatch_uid="agenda_default_config")
+def default_config(sender, key, **kwargs):
+    """Return the default config values for the agenda app."""
+    return {
+        'agenda_start_event_date_time': ''}.get(key)


### PR DESCRIPTION
agenda_start_event_date_time defaults to empty string.
