### PR TITLE
Hide superuser from participants lists

### DIFF
--- a/openslides/assignment/views.py
+++ b/openslides/assignment/views.py
@@ -564,9 +564,9 @@ class AssignmentPollPDF(PDFView):
 
         # set number of ballot papers
         if ballot_papers_selection == "NUMBER_OF_DELEGATES":
-            number = User.objects.filter(type__iexact="delegate").count()
+            number = User.objects.filter(groups__pk = 3).count()
         elif ballot_papers_selection == "NUMBER_OF_ALL_PARTICIPANTS":
-            number = int(User.objects.count())
+            number = int(User.objects.exclude(is_superuser = 1).count())
         else:  # ballot_papers_selection == "CUSTOM_NUMBER"
             number = int(ballot_papers_number)
         number = max(1, number)

--- a/openslides/participant/views.py
+++ b/openslides/participant/views.py
@@ -59,7 +59,7 @@ class UserOverview(ListView):
     context_object_name = 'users'
 
     def get_queryset(self):
-        query = User.objects
+        query = User.objects.exclude(is_superuser = 1)
         if config['participant_sort_users_by_first_name']:
             query = query.order_by('first_name')
         else:
@@ -68,10 +68,8 @@ class UserOverview(ListView):
 
     def get_context_data(self, **kwargs):
         context = super(UserOverview, self).get_context_data(**kwargs)
-        all_users = User.objects.count()
         # context vars
         context.update({
-            'allusers': all_users,
             'request_user': self.request.user})
         return context
 
@@ -181,7 +179,7 @@ class ParticipantsListPDF(PDFView):
         else:
             sort = 'last_name'
         counter = 0
-        for user in User.objects.all().order_by(sort):
+        for user in User.objects.exclude(is_superuser = 1).order_by(sort):
             counter += 1
             groups = ''
             for group in user.groups.all():
@@ -238,7 +236,7 @@ class ParticipantsPasswordsPDF(PDFView):
             img_stream.seek(0)
             size = 2*cm
             I = Image(img_stream, width=size, height=size)
-        for user in User.objects.all().order_by(sort):
+        for user in User.objects.exclude(is_superuser = 1).order_by(sort):
             cell = []
             cell.append(Spacer(0, 0.8 * cm))
             cell.append(Paragraph(_("Account for OpenSlides"),
@@ -490,7 +488,7 @@ def get_user_widget(request):
         name='user',
         display_name=_('Participants'),
         template='participant/user_widget.html',
-        context={'users': User.objects.all()},
+        context={'users': User.objects.exclude(is_superuser = 1)},
         permission_required='projector.can_manage_projector',
         default_column=1)
 


### PR DESCRIPTION
... only for overview table, participants PDF (list and password) and participants widget.
It makes no changes for PersonFormFields, e.g. motions submitter/supporter list, assignment candidates and group member list, because this could be more effort to change it.

See also http://mail.openslides.org/pipermail/users-de/2013-April/000140.html
