### PR TITLE
Protection for participant managers, Issue #122

### DIFF
--- a/openslides/participant/views.py
+++ b/openslides/participant/views.py
@@ -116,6 +116,11 @@ class UserUpdateView(UpdateView):
     form_class = UserUpdateForm
     success_url_name = 'user_overview'
 
+    def get_form_kwargs(self, *args, **kwargs):
+        form_kwargs = super(UserUpdateView, self).get_form_kwargs(*args, **kwargs)
+        form_kwargs.update({'request': self.request})
+        return form_kwargs
+
 
 class UserDeleteView(DeleteView):
     """


### PR DESCRIPTION
Raises a validation error, if a non-superuser user edits himself and
removes the last group containing the permission to manage participants
