### PR TITLE
Pin the version of html5lib

### DIFF
--- a/requirements_production.txt
+++ b/requirements_production.txt
@@ -5,4 +5,5 @@ pillow==2.0.0
 qrcode==2.7
 tornado==3.0.1
 bleach==1.2.1
+html5lib==0.95
 beautifulsoup4==4.1.3


### PR DESCRIPTION
The last version of html5lib, 1.0b1 is installed by bleach (>=0.95) but that version has removed the simpletree walker, so nothing works anymore. If you'd prefer to wait for an update to bleach, ignore this pull request

See also https://github.com/jsocol/bleach/issues/94
