### PR TITLE
Motion: Change default numbering method

### DIFF
--- a/openslides/motion/signals.py
+++ b/openslides/motion/signals.py
@@ -104,14 +104,14 @@ def setup_motion_config_page(sender, **kwargs):
             choices=[(workflow.pk, ugettext_lazy(workflow.name)) for workflow in Workflow.objects.all()]))
     motion_identifier = ConfigVariable(
         name='motion_identifier',
-        default_value='serially_numbered',
+        default_value='per_category',
         form_field=forms.ChoiceField(
             widget=forms.Select(),
             required=True,
             label=ugettext_lazy('Identifier'),
             choices=[
-                ('serially_numbered', ugettext_lazy('Serially numbered')),
                 ('per_category', ugettext_lazy('Numbered per category')),
+                ('serially_numbered', ugettext_lazy('Serially numbered')),
                 ('manually', ugettext_lazy('Set it manually'))]))
 
     return ConfigPage(title=ugettext_noop('Motion'),


### PR DESCRIPTION
If people don't use the category feature the default ordering would be like 'serially_numbered' because all motions are in the same category (i. e. None).
