### PR TITLE
Disable interactive mode of the syncdb command, fixed #696

### DIFF
--- a/openslides/utils/management/commands/syncdb.py
+++ b/openslides/utils/management/commands/syncdb.py
@@ -20,6 +20,15 @@ class Command(_Command):
     Setup the database and sends the signal post_database_setup.
     """
     def handle_noargs(self, *args, **kwargs):
-        return_value = super(Command, self).handle_noargs(*args, **kwargs)
+        """
+        Calls Django's syncdb command but always in non-interactive mode. After
+        this it sends our post_database_setup signal.
+        """
+        interactive = kwargs.pop('interactive')
+        return_value = super(Command, self).handle_noargs(*args, interactive=False, **kwargs)
         post_database_setup.send(sender=self)
+        if interactive:
+            print('Interactive mode (e. g. creating a superuser) is not possibile '
+                  'via this command. To create a superuser use the --reset-admin '
+                  'option of the main script.')
         return return_value


### PR DESCRIPTION
I decided not to reinsert an automatic creating of a superuser for several reasons:
The superuser is created by Django only when the auth app (database tables) is installed the first time, but I do not want to hack deep into Django's code to get the info whether this happened or not and to submit this info to our syncdb file (handle method). On the other hand I do not want to create a new super user every time because this is not the expected Django default. And I do not want to spend too much time to write the code to detect whether a superuser not exists and so to guess that the user wants to create one. We have to rework the whole thing when we rework the main script, the person api and the participant app for OpenSlides 1.5.

I hope you agree.  
