### PR TITLE
Change the Workflow of a motion in CreateView.

### DIFF
--- a/openslides/motion/forms.py
+++ b/openslides/motion/forms.py
@@ -140,17 +140,17 @@ class MotionIdentifierMixin(forms.ModelForm):
         fields = ('identifier',)
 
 
-class MotionSetWorkflowMixin(forms.ModelForm):
+class MotionWorkflowMixin(forms.ModelForm):
     """
-    Mixin to let the user change the workflow of the motion. When he does
-    so, the motion's state is reset.
+    Mixin to let the user change the workflow of the motion.
     """
 
-    set_workflow = LocalizedModelChoiceField(
+    workflow = LocalizedModelChoiceField(
         queryset=Workflow.objects.all(),
-        required=False,
+        empty_label=None,
         label=ugettext_lazy('Workflow'),
-        help_text=ugettext_lazy('Set a specific workflow to switch to it. If you do so, the state of the motion will be reset.'))
+        help_text=ugettext_lazy('Set a specific workflow to switch to it. '
+                                'If you do so, the state of the motion will be reset.'))
 
 
 class MotionImportForm(CssClassMixin, forms.Form):

--- a/openslides/motion/models.py
+++ b/openslides/motion/models.py
@@ -133,7 +133,7 @@ class Motion(SlideMixin, models.Model):
 
         # Solves the problem, that there can only be one motion with an empty
         # string as identifier.
-        if self.identifier is '':
+        if not self.identifier and isinstance(self.identifier, basestring):
             self.identifier = None
 
         super(Motion, self).save(*args, **kwargs)
@@ -432,7 +432,7 @@ class Motion(SlideMixin, models.Model):
         """
         Set the state of the motion.
 
-        State can be the id of a state object or a state object.
+        'state' can be the id of a state object or a state object.
         """
         if type(state) is int:
             state = State.objects.get(pk=state)
@@ -445,10 +445,15 @@ class Motion(SlideMixin, models.Model):
         """
         Set the state to the default state.
 
+        'workflow' can be a workflow, an id of a workflow or None.
+
         If the motion is new and workflow is None, it chooses the default
         workflow from config.
         """
-        if workflow:
+        if type(workflow) is int:
+            workflow = Workflow.objects.get(pk=workflow)
+
+        if workflow is not None:
             new_state = workflow.first_state
         elif self.state:
             new_state = self.state.workflow.first_state

--- a/tests/motion/test_views.py
+++ b/tests/motion/test_views.py
@@ -85,7 +85,7 @@ class TestMotionCreateView(MotionViewTestCase):
         response = self.admin_client.post(self.url, {'title': 'new motion',
                                                      'text': 'motion text',
                                                      'reason': 'motion reason',
-                                                     'submitter': self.admin.person_id})
+                                                     'workflow': 1})
         self.assertEqual(response.status_code, 302)
         self.assertTrue(Motion.objects.filter(versions__title='new motion').exists())
 
@@ -151,7 +151,8 @@ class TestMotionUpdateView(MotionViewTestCase):
         response = self.admin_client.post(self.url, {'title': 'new motion_title',
                                                      'text': 'motion text',
                                                      'reason': 'motion reason',
-                                                     'submitter': self.admin.person_id})
+                                                     'submitter': self.admin.person_id,
+                                                     'workflow': 1})
         self.assertRedirects(response, '/motion/1/')
         motion = Motion.objects.get(pk=1)
         self.assertEqual(motion.title, 'new motion_title')
@@ -172,7 +173,8 @@ class TestMotionUpdateView(MotionViewTestCase):
 
     def test_versioning(self):
         self.assertFalse(self.motion1.state.versioning)
-        versioning_state = State.objects.create(name='automatic_versioning', workflow=self.motion1.state.workflow, versioning=True)
+        workflow = self.motion1.state.workflow
+        versioning_state = State.objects.create(name='automatic_versioning', workflow=workflow, versioning=True)
         self.motion1.state = versioning_state
         self.motion1.save()
         motion = Motion.objects.get(pk=self.motion1.pk)
@@ -182,6 +184,7 @@ class TestMotionUpdateView(MotionViewTestCase):
         response = self.admin_client.post(self.url, {'title': 'another new motion_title',
                                                      'text': 'another motion text',
                                                      'reason': 'another motion reason',
+                                                     'workflow': workflow.pk,
                                                      'submitter': self.admin.person_id})
         self.assertRedirects(response, '/motion/1/')
         motion = Motion.objects.get(pk=self.motion1.pk)
@@ -189,7 +192,8 @@ class TestMotionUpdateView(MotionViewTestCase):
 
     def test_disable_versioning(self):
         self.assertFalse(self.motion1.state.versioning)
-        versioning_state = State.objects.create(name='automatic_versioning', workflow=self.motion1.state.workflow, versioning=True)
+        workflow = self.motion1.state.workflow
+        versioning_state = State.objects.create(name='automatic_versioning', workflow=workflow, versioning=True)
         self.motion1.state = versioning_state
         self.motion1.save()
         motion = Motion.objects.get(pk=self.motion1.pk)
@@ -201,6 +205,7 @@ class TestMotionUpdateView(MotionViewTestCase):
                                                      'text': 'another motion text',
                                                      'reason': 'another motion reason',
                                                      'submitter': self.admin.person_id,
+                                                     'workflow': workflow.pk,
                                                      'disable_versioning': 'true'})
         self.assertRedirects(response, '/motion/1/')
         motion = Motion.objects.get(pk=self.motion1.pk)
@@ -208,7 +213,8 @@ class TestMotionUpdateView(MotionViewTestCase):
 
     def test_no_versioning_without_new_data(self):
         self.assertFalse(self.motion1.state.versioning)
-        versioning_state = State.objects.create(name='automatic_versioning', workflow=self.motion1.state.workflow, versioning=True)
+        workflow = self.motion1.state.workflow
+        versioning_state = State.objects.create(name='automatic_versioning', workflow=workflow, versioning=True)
         self.motion1.state = versioning_state
         self.motion1.title = 'Chah4kaaKasiVuishi5x'
         self.motion1.text = 'eedieFoothae2iethuo3'
@@ -221,6 +227,7 @@ class TestMotionUpdateView(MotionViewTestCase):
         response = self.admin_client.post(self.url, {'title': 'Chah4kaaKasiVuishi5x',
                                                      'text': 'eedieFoothae2iethuo3',
                                                      'reason': 'ier2laiy1veeGoo0mau2',
+                                                     'workflow': workflow.pk,
                                                      'submitter': self.admin.person_id})
         self.assertRedirects(response, '/motion/1/')
         motion = Motion.objects.get(pk=self.motion1.pk)
@@ -235,7 +242,7 @@ class TestMotionUpdateView(MotionViewTestCase):
         response = self.admin_client.post(self.url, {'title': 'oori4KiaghaeSeuzaim2',
                                                      'text': 'eequei1Tee1aegeNgee0',
                                                      'submitter': self.admin.person_id,
-                                                     'set_workflow': 2})
+                                                     'workflow': 2})
         self.assertRedirects(response, '/motion/1/')
         self.assertEqual(Motion.objects.get(pk=self.motion1.pk).state.workflow.pk, 2)
 


### PR DESCRIPTION
The Manager can choose the workflow in the createview. The default value is the workflow from the config.

In the UpdateView the workflow in which the motion is, is choosen by default.

The workflow will only be reset, if it is changed.
