### PR TITLE
Use get_active_version in motion.__unicode__()

### DIFF
--- a/openslides/motion/models.py
+++ b/openslides/motion/models.py
@@ -100,7 +100,7 @@ class Motion(SlideMixin, models.Model):
         """
         Return a human readable name of this motion.
         """
-        return self.active_version.title
+        return self.get_active_version().title
 
     # TODO: Use transaction
     def save(self, use_version=None, *args, **kwargs):

--- a/tests/motion/test_models.py
+++ b/tests/motion/test_models.py
@@ -146,6 +146,12 @@ class ModelTest(TestCase):
         motion.save(use_version=False)
         self.assertEqual(motion.versions.count(), 2)
 
+    def test_unicode_with_no_active_version(self):
+        motion = Motion.objects.create(title='foo', text='bar', identifier='')
+        motion.active_version = None
+        motion.save(update_fields=['active_version'])
+        self.assertEqual(str(motion), 'foo')  # motion.__unicode__() did rais an AttributeError
+
 
 class ConfigTest(TestCase):
     def test_stop_submitting(self):


### PR DESCRIPTION
Fixes the bug, that motion.**unicode**() raises an AttributeError, if the active_version
was None.

Fixes #822
