### PR TITLE
Fixed tooltip and duration in agenda.

### DIFF
--- a/openslides/agenda/templates/agenda/item_row.html
+++ b/openslides/agenda/templates/agenda/item_row.html
@@ -45,9 +45,9 @@
     <div class="duration">
         {% if node.duration %}
             {{ node.duration }} h
-            {% if start and end %}
+            {% if node.tooltip %}
                 <a class="btn btn-mini" rel="tooltip" data-original-title="{% trans 'End' %}:
-                {{ end|date:"DATETIME_FORMAT" }}"><i class="icon-clock"></i>
+                {{ node.tooltip|date:"DATETIME_FORMAT" }}"><i class="icon-clock"></i>
                 </a>
             {% endif %}
         {% endif %}

--- a/openslides/agenda/templates/agenda/overview.html
+++ b/openslides/agenda/templates/agenda/overview.html
@@ -111,7 +111,7 @@
         {% if items %}
         <ol class="agenda_list {% if perms.agenda.can_manage_agenda %}sortable{% endif %}">
             {% recursetree items %}
-            <li class="draggable{% if item.active %} activeline{% endif %}{% if item.closed %} offline{% endif %}">
+            <li class="draggable">
                 {% include "agenda/item_row.html" %}
                 {% if not node.is_leaf_node %}
                 <ol>

--- a/openslides/agenda/views.py
+++ b/openslides/agenda/views.py
@@ -59,8 +59,8 @@ class Overview(TemplateView):
         duration = timedelta()
 
         for item in items:
-            if not item.closed and (item.duration is not None
-                                    and len(item.duration) > 0):
+            if (item.duration is not None and
+                    len(item.duration) > 0):
                 duration_list = item.duration.split(':')
                 duration += timedelta(hours=int(duration_list[0]),
                                       minutes=int(duration_list[1]))


### PR DESCRIPTION
The tooltip did not show the end of an agenda item, but of the hole event.

If a item was closed, it was not used to calculate the end of the event.

Fixed #833
