### PR TITLE
Update projector when the title of the default slide changes

### DIFF
--- a/openslides/core/signals.py
+++ b/openslides/core/signals.py
@@ -7,6 +7,7 @@ from django.utils.translation import ugettext_lazy, ugettext_noop
 
 from openslides.config.api import ConfigGroup, ConfigGroupedPage, ConfigVariable
 from openslides.config.signals import config_signal
+from openslides.projector.api import update_projector
 
 post_database_setup = Signal()
 
@@ -64,7 +65,8 @@ def setup_general_config_page(sender, **kwargs):
         form_field=forms.CharField(
             widget=forms.TextInput(),
             label=ugettext_lazy('Title'),
-            required=False))
+            required=False),
+        on_change=update_projector)
 
     welcome_text = ConfigVariable(
         name='welcome_text',


### PR DESCRIPTION
I do not check if the default-slide is active, because the default slide has no slide-id and is shown if somethink went wrong. So it is hard to check this. Also the change of the title should not be so often.

One Question. Is it right, that the text of the welcome widget is not shown on the default slide?
