### PR TITLE
Add extra directory to OpenSlides Portable Version zip file, fix #986.

### DIFF
--- a/extras/win32-portable/prepare_portable.py
+++ b/extras/win32-portable/prepare_portable.py
@@ -456,7 +456,7 @@ def main():
     prefix = os.path.dirname(sys.executable)
     libdir = os.path.join(prefix, "Lib")
     sitedir = os.path.join(libdir, "site-packages")
-    odir = "dist/openslides-{0}-portable".format(openslides.get_version())
+    odir = "dist/OpenSlides-{version}/openslides-{version}-portable".format(version=openslides.get_version())
 
     try:
         shutil.rmtree(odir)


### PR DESCRIPTION
@emanuelschuetze Please test this and don't forget to clean up the dist directory first.
