### PR TITLE
Extend css style optinos in CKEditor

### DIFF
--- a/openslides/motion/pdf.py
+++ b/openslides/motion/pdf.py
@@ -189,6 +189,8 @@ def convert_html_to_reportlab(pdf, text):
         tag.unwrap()
     for tag in soup.find_all('li'):
         tag.unwrap()
+    for tag in soup.find_all('span'):
+        tag.unwrap()
     # print paragraphs with numbers
     text = soup.body.contents
     paragraph_number = 1

--- a/openslides/static/javascript/ckeditor-config.js
+++ b/openslides/static/javascript/ckeditor-config.js
@@ -11,7 +11,7 @@ var ck_options = {
         bodyClass: "ckeditor_html",
 
         allowedContent:
-                'h1 h2 h3 pre blockquote b i u strike;' +
+                'h1 h2 h3 pre b i u strike em;' +
 
                 // A workaround for the problem described in http://dev.ckeditor.com/ticket/10192
                 // Hopefully, the problem will be solved in the final version of CKEditor 4.1
@@ -19,10 +19,9 @@ var ck_options = {
                 'p{margin-left};' +
 
                 'a[!href];' +
-                'table tr th td caption;' +
-                'ol ul li;' +
-                'span{!font-family};' +
-                'span{!color};',
+                'ol ul{list-style};' +
+                'li;' +
+                'span{color,background-color};',
         removePlugins: "save, print, preview, pagebreak, templates, showblocks, magicline",
 
         // Not part of the standard package of CKEditor
@@ -37,7 +36,7 @@ var ck_options = {
                 { name: 'basicstyles', items : [ 'Bold','Italic','Underline','Strike','Subscript','Superscript','-','RemoveFormat' ] },
                 { name: 'paragraph',   items : [ 'NumberedList','BulletedList','-','Pre','InsertPre','CreateDiv','-','JustifyLeft','JustifyCenter','JustifyRight','JustifyBlock','-','BidiLtr','BidiRtl' ] },
                 { name: 'links',       items : [ 'Link','Unlink','Anchor' ] },
-                { name: 'styles',      items : [ 'Format','FontSize' ] },
+                { name: 'styles',      items : [ 'Format','FontSize','TextColor','BGColor' ] },
                 { name: 'tools',       items : [ 'Maximize', 'ShowBlocks','-','About' ] }
         ],
         toolbar: 'Full'

--- a/openslides/utils/forms.py
+++ b/openslides/utils/forms.py
@@ -27,9 +27,10 @@ HTML_TAG_WHITELIST = ('a',
 
 HTML_ATTRIBUTES_WHITELIST = {
     'a': ['href'],
+    '*': ['style'],
 }
 
-HTML_STYLES_WHITELIST = ()
+HTML_STYLES_WHITELIST = ('color', 'background-color', 'list-style')
 
 
 class CssClassMixin(object):

--- a/tests/forms/test_clean_html.py
+++ b/tests/forms/test_clean_html.py
@@ -40,14 +40,13 @@ class CleanHtmlTest(TestCase):
         self.clean_html('<p href="evil.com">good?</p>', '<p>good?</p>')
         self.clean_html('<p onclick="javascript:evil();">Not evil</p>', '<p>Not evil</p>')
         self.clean_html('<div style="margin-top: 100000em;">evil</div>', 'evil')
-        self.clean_html('<p style="font-weight:bold;">bad</p>', '<p>bad</p>')
         self.clean_html('<table><tbody><tr><td>OK</td></tr></tbody></table>', 'OK')
-        self.clean_html('<blockquote>OK</blockquote>', 'OK')
-        self.clean_html('<p style="text-decoration: underline;">OK</p>', '<p>OK</p>')
+        self.clean_html('<p style="text-decoration: underline;">OK</p>', '<p style="">OK</p>')
 
         # Allowed tags and attributes
         self.clean_html('<a href="evil.com">good?</a>')
         self.clean_html('<p>OK</p>')
         self.clean_html('<p><strong>OK</strong></p>')
         self.clean_html('<pre>OK</pre>')
-        self.clean_html('<ul><li>OK</li></ul>')
+        self.clean_html('<ul style="list-style: circle inside;"><li>OK</li></ul>')
+        self.clean_html('<span style="color: red;">OK</span>')


### PR DESCRIPTION
- Fixed #957 (Allow list-style in CKEditor).
- Allowed additional css styles 'color' and 'background-color' for span html fields in ck-editor (and bleach) - for backend/projector view only (not for pdf)
