### PR TITLE
Move run_tornado import into runserver function because its imports need...

### DIFF
--- a/openslides/__main__.py
+++ b/openslides/__main__.py
@@ -23,7 +23,6 @@ from openslides.utils.main import (
     setup_django_settings_module,
     start_browser,
     write_settings)
-from openslides.utils.tornado_webserver import run_tornado
 
 
 def main():
@@ -231,6 +230,9 @@ def runserver(settings, args):
     if args.start_browser:
         browser_url = get_browser_url(address=args.address, port=port)
         start_browser(browser_url)
+
+    # Now the settings is available and the function can be imported.
+    from openslides.utils.tornado_webserver import run_tornado
     run_tornado(args.address, port, not args.no_reload)
 
 

--- a/tests/utils/test_main.py
+++ b/tests/utils/test_main.py
@@ -131,7 +131,7 @@ class TestOtherFunctions(TestCase):
         mock_runserver.assert_called_with(None, mock_args)
 
     @patch('openslides.__main__.get_port')
-    @patch('openslides.__main__.run_tornado')
+    @patch('openslides.utils.tornado_webserver.run_tornado')
     @patch('openslides.__main__.start_browser')
     def test_runserver(self, mock_start_browser, mock_run_tornado, mock_get_port):
         mock_get_port.return_value = 8000


### PR DESCRIPTION
...s settings (new in Django 1.6).
