### PR TITLE
Set reuse address option (fixes #1043)

### DIFF
--- a/openslides/utils/main.py
+++ b/openslides/utils/main.py
@@ -296,6 +296,7 @@ def get_port(address, port):
     """
     s = socket.socket()
     try:
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         s.bind((address, port))
         s.listen(-1)
     except socket.error:


### PR DESCRIPTION
When the server is killed there may still be client-sockets connected in
the TIME_WAIT state, causing the bind() call to fail. With the
REUSEADDR option we can reuse the address immediately unless another
process is actually _listening_ on the same address.
that we want to reuse the address
