### PR TITLE
Make sure QuestionView.get_question_message is in a unicode context.

### DIFF
--- a/openslides/utils/views.py
+++ b/openslides/utils/views.py
@@ -355,7 +355,7 @@ class QuestionView(RedirectView):
         """
         Returns the question.
         """
-        return self.question_message
+        return unicode(self.question_message)
 
     def get_answer_options(self):
         """
@@ -376,16 +376,13 @@ class QuestionView(RedirectView):
             for option in self.get_answer_options()])
         messages.warning(
             self.request,
-            """
-            %(message)s
-            <form action="%(url)s" method="post">
-                <input type="hidden" value="%(csrf)s" name="csrfmiddlewaretoken">
-                %(option_fields)s
-            </form>
-            """ % {'message': self.get_question_message(),
-                   'url': self.request.path,
-                   'csrf': csrf(self.request)['csrf_token'],
-                   'option_fields': option_fields})
+            '%(message)s<form action="%(url)s" method="post">'
+            '<input type="hidden" value="%(csrf)s" name="csrfmiddlewaretoken">'
+            '%(option_fields)s</form>' % {
+                'message': self.get_question_message(),
+                'url': self.request.path,
+                'csrf': csrf(self.request)['csrf_token'],
+                'option_fields': option_fields})
 
     def pre_post_redirect(self, request, *args, **kwargs):
         """

--- a/tests/utils/test_views.py
+++ b/tests/utils/test_views.py
@@ -164,6 +164,9 @@ class QuestionViewTest(ViewTestCase):
         view.question_message = 'new_question'
         self.assertEqual(get_question_message(), 'new_question')
 
+        # Make sure it is unicode, so ugettext_lazy can work
+        self.assertIsInstance(get_question_message(), unicode)
+
     def test_get_answer_options(self):
         view = views.QuestionView()
         get_answer_options = view.get_answer_options
@@ -185,6 +188,9 @@ class QuestionViewTest(ViewTestCase):
         confirm_form()
 
         self.assertTrue(mock_messages.warning.called)
+
+        question = mock_messages.warning.call_args[0][1]
+        self.assertIn('the question', question)
 
 
 def set_context(sender, request, context, **kwargs):


### PR DESCRIPTION
This is important if the attribute question_message is set with
ugettext_lazy which needs an unicode context

Fixes #1066
