### PR TITLE
Fixed a lot of template bugs from irc test session

### DIFF
--- a/openslides/agenda/static/styles/agenda_sort.css
+++ b/openslides/agenda/static/styles/agenda_sort.css
@@ -54,7 +54,7 @@ ol.agenda_list {
 }
         
 .agenda_list .openclose { width: 40px; float: left; min-height: 1px; }
-.agenda_list .duration { width: 92px; float: right; min-height: 1px; padding-left: 5px; }
+.agenda_list .duration { width: 92px; float: right; min-height: 1px; padding-right: 25px; text-align: right; }
 .agenda_list .manage { width: 200px; float: right; min-height: 1px; padding-left: 5px; }
 .agenda_list .title { float: left; padding-left: 5px;}
 .agenda_list .optional { float: left; }
@@ -63,7 +63,7 @@ ol.agenda_list {
 .agenda_list .optional { float: right; width: 208px; padding-left: 8px;}
 
 #menu-overview .manage { width: 200px; }
-#menu-overview .duration { width: 75px; }
+#menu-overview .duration { width: 65px; text-align: right; padding-right: 19px;}
 #menu-overview .optional { width: 200px; }
 
 @media screen and (max-width: 1000px) {

--- a/openslides/agenda/templates/agenda/item_slide.html
+++ b/openslides/agenda/templates/agenda/item_slide.html
@@ -2,7 +2,6 @@
 
 <h1>
     {{ item }}
-    <hr>
 </h1>
 
 {% if item.text %}

--- a/openslides/agenda/templates/agenda/item_slide_list_of_speaker.html
+++ b/openslides/agenda/templates/agenda/item_slide_list_of_speaker.html
@@ -15,11 +15,13 @@
         margin-bottom: 0.5em;}
 </style>
 
-<h1>{{ title }}</h1>
-<h3>
-    {% trans 'List of speakers' %}
-    {% if item.speaker_list_closed %}(<span class="closed">{% trans 'closed' %}</span>){% endif %}
-</h3>
+<h1>
+    {{ title }}
+    <small>
+        {% trans 'List of speakers' %}
+        {% if item.speaker_list_closed %}(<span class="closed">{% trans 'closed' %}</span>){% endif %}
+    </small>
+</h1>
 
 {% if list_of_speakers %}
     <ul id="list_of_speakers">

--- a/openslides/agenda/templates/agenda/item_slide_summary.html
+++ b/openslides/agenda/templates/agenda/item_slide_summary.html
@@ -1,9 +1,14 @@
 {% load i18n %}
 
-<h1>{% if title %}{{ title }}{% else %}{% trans "Agenda" %}{% endif %}</h1>
+<h1>
+    {% if title %}{{ title }}{% else %}{% trans "Agenda" %}{% endif %}
+</h1>
 
 <ul class="itemlist">
     {% for item in items %}
-        <li{% if item.closed %} class="closed" {% endif %}>{{ item }}</li>
+        <li{% if item.closed %} class="closed" {% endif %}>
+            {{ item }}
+            <small>{{ item.get_title_supplement|safe }}</small>
+        </li>
     {% endfor %}
 </ul>

--- a/openslides/agenda/templates/agenda/overview.html
+++ b/openslides/agenda/templates/agenda/overview.html
@@ -24,22 +24,20 @@
 {% endblock %}
 
 {% block content %}
-   <form action="" method="post">{% csrf_token %}
-       {% if perms.agenda.can_manage_agenda %}
-       <div id="changed-order-message" style="display:none" class="alert alert-warning">
-           <button type="button" class="close" data-dismiss="alert">×</button>
-           <p>{% trans "Do you want to save the changed order of agenda items?" %}</p>
-           <p>
-               <button class="btn" type="submit">{% trans 'Yes' %}</button>
-               <a href="{% url 'item_overview' %}" class="btn">{% trans 'No' %}</a>
-            </p>
-       </div>
-       {% endif %}
+    <form action="" method="post">{% csrf_token %}
+        {% if perms.agenda.can_manage_agenda %}
+            <div id="changed-order-message" style="display:none" class="alert alert-warning">
+                <button type="button" class="close" data-dismiss="alert">×</button>
+                {% trans "Do you want to save the changed order of agenda items?" %}<br>
+                <button class="btn btn-mini" type="submit">{% trans 'Yes' %}</button>
+                <a href="{% url 'item_overview' %}" class="btn btn-mini">{% trans 'No' %}</a>
+            </div>
+        {% endif %}
 
         <h1>{% trans "Agenda" %}
             <small class="pull-right">
             {% if perms.agenda.can_manage_agenda %}
-            <a href="{% url 'item_new' %}" class="btn btn-mini btn-primary" rel="tooltip" data-original-title="{% trans 'New item' %}"><i class="icon-plus icon-white"></i> {% trans "New" %}</a>
+                <a href="{% url 'item_new' %}" class="btn btn-mini btn-primary" rel="tooltip" data-original-title="{% trans 'New item' %}"><i class="icon-plus icon-white"></i> {% trans "New" %}</a>
             {% endif %}
             <a href="{% url 'print_agenda' %}" class="btn btn-mini" rel="tooltip" data-original-title="{% trans 'Print agenda as PDF' %}" target="_blank"><i class="icon-print"></i> PDF</a>
             </small>

--- a/openslides/agenda/templates/agenda/view.html
+++ b/openslides/agenda/templates/agenda/view.html
@@ -46,7 +46,7 @@
     {% if not item.content_object %}
         {{ item.text|safe }}
     {% else %}
-        <a href="{{ item.content_object|absolute_url }}" class="btn btn-small">{% trans item.content_type.name %} {{ item.content_object }}</a>
+        <a href="{{ item.content_object|absolute_url }}" class="btn btn-small">{% trans item.content_type.name %}: {{ item.content_object }}</a>
     {% endif %}
 </p>
 

--- a/openslides/assignment/templates/assignment/assignment_detail.html
+++ b/openslides/assignment/templates/assignment/assignment_detail.html
@@ -147,20 +147,12 @@
     {% if polls.exists %}
         <table class="table table-striped table-bordered">
         <tr>
-            <th></th>
-            {% with ballotnumber=polls.count %}
-            <th colspan="{{ ballotnumber|add:'1' }}" style="text-align: center;">
-                {% trans "Ballot" %}
-            </th>
-            {% endwith %}
-        </tr>
-        <tr>
             <th>{% trans "Candidates" %}</th>
             {% for poll in polls %}
                 <th style="white-space:nowrap;" class="span1">
+                    {% if perms.assignment.can_manage_assignment %}<p>{% endif %}
                     {{ poll.get_ballot|ordinal|safe }} {% trans 'ballot' %}
                     {% if perms.assignment.can_manage_assignment %}
-                        <br>
                         <a class="publish_link btn btn-mini btn-danger {% if poll.published %}btn-primary{% endif %}"
                         href="{% url 'assignment_poll_publish_status' poll.id %}"
                         rel="tooltip" data-original-title="{% trans 'Publish results' %}">
@@ -170,10 +162,15 @@
                             <i class="icon-unchecked-new"></i>
                             {% endif %}
                         </a>
+                        </p>
+                        <p class="text-center">
+                        <a href="{% url 'assignment_poll_pdf' poll.id %}" class="btn btn-mini" target="_blank"
+                            rel="tooltip" data-original-title="{% trans 'Ballot paper as PDF' %}"><i class="icon-print"></i></a>
                         <a href="{% url 'assignment_poll_view' poll.id %}" class="btn btn-mini"
                             rel="tooltip" data-original-title="{% trans 'Edit' %}"><i class="icon-pencil"></i></a>
                         <a href="{% url 'assignment_poll_delete' poll.id %}" class="btn btn-mini"
                             rel="tooltip" data-original-title="{% trans 'Delete' %}"><i class="icon-remove"></i></a>
+                        </p>
                     {% endif %}
                 </th>
             {% endfor %}

--- a/openslides/assignment/templates/assignment/slide.html
+++ b/openslides/assignment/templates/assignment/slide.html
@@ -13,11 +13,9 @@
 </div>
 
 <h1>{{ assignment }}
-    <br>
     <small>
         {% trans "Election" %}
     </small>
-    <hr>
 </h1>
 
 {% if not assignment.candidates %}

--- a/openslides/motion/templates/motion/motion_detail.html
+++ b/openslides/motion/templates/motion/motion_detail.html
@@ -16,10 +16,19 @@
 <h1>
     {{ title }}
     <br>
-    <small>{% trans "Motion" %} {{ motion.identifier|default:'' }}
-    {% if motion.versions.count > 1 %}
-        | {% trans "Version" %} {{ version.version_number }}
-    {% endif %}
+    <small>
+        {% trans "Motion" %} {{ motion.identifier|default:'' }}
+        {% if motion.versions.count > 1 %}
+            | {% trans "Version" %} {{ version.version_number }}
+            {% if version == motion.active_version %}
+                <span class="badge badge-success"> {% trans 'This version is authorized' %}</span>
+            {% endif %}
+            {% if version.version_number != motion.active_version.version_number %}
+                <span class="label label-warning">
+                    <i class="icon-warning-sign icon-white"></i> {% trans "This version is not authorized." %}
+                </span>
+            {% endif %}
+        {% endif %}
     </small>
     <small class="pull-right">
         <a href="{% url 'motion_list' %}" class="btn btn-mini">
@@ -62,20 +71,17 @@
 <div class="row-fluid">
 <div class="span8">
     {# TODO: show only for workflow with versioning #}
-    {% with last_version=motion.get_last_version active_version=motion.get_active_version %}
-        {% if version.version_number != last_version.version_number %}
-            <p><span class="label label-warning">
-                <i class="icon-warning-sign icon-white"></i> {% trans "This is not the newest version." %}
-            </span>
+    {% with last_version=motion.get_last_version %}
+        {% if version.version_number != motion.active_version.version_number %}
+            <p>
+            <a href="{{ motion.active_version|absolute_url }}" class="btn btn-small">{% trans "Go to the authorized version" %}
+            (# {{ motion.active_version.version_number }})</a>
+            </p>
+        {% elif version.version_number != last_version.version_number %}
+            <p>
             <a href="{{ last_version|absolute_url }}" class="btn btn-small">{% trans "Go to the newest version" %}
-            (# {{ last_version.version_number }})</a></p>
-        {% endif %}
-        {% if version.version_number != active_version.version_number %}
-            <p><span class="label label-warning">
-                <i class="icon-warning-sign icon-white"></i> {% trans "This version is not authorized." %}
-            </span>
-            <a href="{{ active_version|absolute_url }}" class="btn btn-small">{% trans "Go to the authorized version" %}
-            (# {{ active_version.version_number }})</a></p>
+            (# {{ last_version.version_number }})</a>
+            </p>
         {% endif %}
     {% endwith %}
 
@@ -136,7 +142,7 @@
                         <a href="{{ version|absolute_url }}" title="{% trans 'Show' %}" class="btn btn-mini">
                             <i class="icon-search"></i>
                         </a>
-                        {% if version != motion.active_version %}
+                        {% if perms.motion.can_manage_motion and version != motion.active_version %}
                             <a href="{{ version|absolute_url:'delete' }}" title="{% trans 'Delete' %}" class="btn btn-mini">
                                 <i class="icon-remove"></i>
                             </a>

--- a/openslides/motion/templates/motion/motion_list.html
+++ b/openslides/motion/templates/motion/motion_list.html
@@ -62,7 +62,7 @@
                 {% with supporters=motion.supporters|length %}
                     <td class="optional">
                     {% if supporters >= 'motion_min_supporters'|get_config %}
-                        <a class="badge badge-success"  rel="tooltip" data-original-title="{% trans 'Enough supporters' %}">{{ supporters }}</a>
+                        <a class="badge badge-success" rel="tooltip" data-original-title="{% trans 'Enough supporters' %}">{{ supporters }}</a>
                     {% endif %}
                     {% if supporters < 'motion_min_supporters'|get_config %}
                         <a class="badge badge-warning" rel="tooltip" data-original-title="{% trans 'Needs supporters' %}">{{ supporters }}</a>
@@ -70,7 +70,12 @@
                     </td>
                 {% endwith %}
             {% endif %}
-            <td class="optional">{{ motion.get_last_version.creation_time }}</td>
+            <td class="optional">{{ motion.get_last_version.creation_time }}
+                {% if motion.get_last_version.version_number != motion.active_version.version_number %}
+                    <a href="{{ motion.get_last_version|absolute_url }}" class="label label-warning" rel="tooltip" data-original-title="{% trans 'There is a newer (unauthorized) version.' %}">
+                        <i class="icon-warning-sign icon-white"></i>
+                    </a>
+                {% endif %}</td>
             <td>
                 <span style="width: 1px; white-space: nowrap;">
                 {% if perms.projector.can_manage_projector %}

--- a/openslides/motion/templates/motion/slide.html
+++ b/openslides/motion/templates/motion/slide.html
@@ -55,12 +55,10 @@
 
 <h1>
     {{ motion.active_version.title }}
-    <br>
     <small>
         {% trans "Motion" %} {{ motion.identifier|default:'' }}
         {% if motion.get_active_version.version_number > 1 %} | {% trans 'Version' %} {{ motion.active_version.version_number }}{% endif %}
     </small>
-    <hr>
 </h1>
 
 <div class="text">{{ motion.active_version.text|safe }}</div>

--- a/openslides/participant/forms.py
+++ b/openslides/participant/forms.py
@@ -42,7 +42,7 @@ class UserUpdateForm(UserCreateForm):
     user edits himself and removes the last group containing the permission
     to manage participants.
     """
-    user_name = forms.CharField()
+    user_name = forms.CharField(label=ugettext_lazy('Username'))
     """
     Field to save the username.
 
@@ -145,7 +145,7 @@ class GroupForm(forms.ModelForm, CssClassMixin):
 
 
 class UsersettingsForm(CssClassMixin, forms.ModelForm):
-    user_name = forms.CharField()
+    user_name = forms.CharField(label=ugettext_lazy('Username'))
     """
     Field to save the username.
 
@@ -153,7 +153,8 @@ class UsersettingsForm(CssClassMixin, forms.ModelForm):
     allow whitespaces and umlauts.
     """
 
-    language = forms.ChoiceField(choices=settings.LANGUAGES)
+    language = forms.ChoiceField(
+        choices=settings.LANGUAGES, label=ugettext_lazy('Language'))
 
     def __init__(self, *args, **kwargs):
         kwargs['initial'] = kwargs.get('initial', {})

--- a/openslides/participant/pdf.py
+++ b/openslides/participant/pdf.py
@@ -46,7 +46,6 @@ def participants_to_pdf(pdf):
         ('ROWBACKGROUNDS', (0, 1), (-1, -1),
             (colors.white, (.9, .9, .9)))])
     t._argW[0] = 0.75 * cm
-    t._argW[1] = 1 * cm
     pdf.append(t)
     return pdf
 

--- a/openslides/participant/templates/participant/group_overview.html
+++ b/openslides/participant/templates/participant/group_overview.html
@@ -29,6 +29,7 @@
         <tr>
             <th class="mini_width">{% trans "ID" %}</th>
             <th>{% trans "Group" %}</th>
+            <th>{% trans "Members" %}</th>
             <th class="mini_width">{% trans "Actions" %}</th>
         </tr>
     </thead>
@@ -41,6 +42,9 @@
             </td>
             <td>
                 <a href="{{ group|absolute_url }}">{% trans group.name %}</a>
+            </td>
+            <td>
+                <span class="badge badge-info">{{ group.user_set.all.count }}</span>
             </td>
             <td>
                 <span style="width: 1px; white-space: nowrap;">

--- a/openslides/participant/templates/participant/group_slide.html
+++ b/openslides/participant/templates/participant/group_slide.html
@@ -2,7 +2,13 @@
 
 <h1>
     {% trans group.name %}
-    <hr>
+    <small>{% trans "Group" %}</small>
 </h1>
 
-<i>{{ group.user_set.all.count }} {% trans "participants" %}</i>
+<p><i>{{ group.user_set.all.count }} {% trans "participants" %}</i></p>
+
+<ol>
+{% for member in group.user_set.all %}
+    <li>{{ member }}</li>
+{% endfor %}
+</ol>

--- a/openslides/participant/templates/participant/user_slide.html
+++ b/openslides/participant/templates/participant/user_slide.html
@@ -3,7 +3,6 @@
 <h1>
     {{ shown_user.clean_name }}<br>
     <small>{{ shown_user.structure_level }}</small>
-    <hr>
 </h1>
 
 {% if shown_user.committee %}

--- a/openslides/projector/static/styles/projector.css
+++ b/openslides/projector/static/styles/projector.css
@@ -71,9 +71,13 @@ h1 {
     font-size: 2.25em;
     margin-bottom: 40px;
     line-height: 0.95em;
+    padding-bottom: 10px;
+    border-bottom: 1px solid #e6e6e6;
 }
 h1 small {
     font-size: 0.55em;
+    margin-top: 15px;
+    display: block;
 }
 h3 {
     font-size: 1.2em;

--- a/openslides/projector/templates/projector.html
+++ b/openslides/projector/templates/projector.html
@@ -32,6 +32,7 @@
                     background-image: -webkit-linear-gradient(top, {{ 'projector_backgroundcolor1'|get_config }}, {{ 'projector_backgroundcolor2'|get_config }});
                     background-image: -o-linear-gradient(top, {{ 'projector_backgroundcolor1'|get_config }}, {{ 'projector_backgroundcolor2'|get_config }});
                     background-image: linear-gradient(top, {{ 'projector_backgroundcolor1'|get_config }}, {{ 'projector_backgroundcolor2'|get_config }});
+                    -ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr='{{ 'projector_backgroundcolor1'|get_config }}', encColorstr='{{ 'projector_backgroundcolor2'|get_config }}')"; /* IE 8+ */
                 {% else %}
                     background-color: {{ 'projector_backgroundcolor1'|get_config }};
                 {% endif %}

--- a/openslides/projector/templates/projector/default_slide.html
+++ b/openslides/projector/templates/projector/default_slide.html
@@ -1,3 +1,6 @@
 {% load tags %}
 
-<h1>{{ 'welcome_title'|get_config }}</h1>
+<h1>
+    {{ 'welcome_title'|get_config }}
+    <hr>
+</h1>

--- a/openslides/projector/templates/projector/projectorslide_slide.html
+++ b/openslides/projector/templates/projector/projectorslide_slide.html
@@ -1,6 +1,9 @@
 {% load i18n %}
 
-<h1>{{ slide.title }}</h1>
+<h1>
+    {{ slide.title }}
+    <hr>
+</h1>
 
 {% if slide.text %}
     <span>{{ slide.text|safe|linebreaks }}</span>


### PR DESCRIPTION
- agenda overview: Text align right for duration column.
- item summary slide: Show 'get_title_supplement' after each related agenda item.
- item detail view: Add ":" in button after item content_type
- projector: Show <hr> below title/subtitle line.
- motion view: Check manage permission for delete version button in version history table.
- motion detail view: Update version authorized badges and go to buttons.
- motion list: Link warning icon to newest version.
- assignment detail view: Added ballot paper pdf button.
- Group slide and overview: Show members.
- Use dynamic title column width in participants pdf.
- Fixed missing translations in user settings form.
- IE8/9 fix for projector template style.
