### PR TITLE
Fixed #1191: Removed can_manage_agenda block from speakers widget.

### DIFF
--- a/openslides/agenda/templates/agenda/speaker_widget.html
+++ b/openslides/agenda/templates/agenda/speaker_widget.html
@@ -1,14 +1,5 @@
 {% load i18n %}
 
-{% if perms.agenda.can_be_speaker %}
-    <p><a href="{% url 'agenda_add_to_current_list_of_speakers' %}" class="btn"><i class="icon icon-speaker"></i> {% trans 'Put me on the current list of speakers' %}</a></p>
-{% endif %}
-
-{% if perms.agenda.can_manage_agenda %}
-    <p>
-    <a href="{% url 'agenda_next_on_current_list_of_speakers' %}" class="btn btn-mini"><i class="icon icon-bell"></i> {% trans 'Next speaker' %}</a>
-    <a href="{% url 'agenda_end_speach_on_current_list_of_speakers' %}" class="btn btn-mini"><i class="icon icon-bell"></i> {% trans 'End speach' %}</a>
-    </p>
-{% endif %}
+<p><a href="{% url 'agenda_add_to_current_list_of_speakers' %}" class="btn"><i class="icon icon-speaker"></i> {% trans 'Put me on the current list of speakers' %}</a></p>
 
 <small><p class="text-right"><a href="{% url 'agenda_current_list_of_speakers' %}"> {% trans 'Go to current list of speakers' %}...</a></p></small>


### PR DESCRIPTION
Now speakers widget is visible for users with can_be_speaker permission only.
A better manage list-of-speakers view can be created in a new widget later.
Now the agenda view is the prefered manage view.
