### PR TITLE
fix for python2.6 and pip 1.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ language: python
 python:
   - "2.6"
   - "2.7"
-install: "pip install -r requirements.txt --use-mirrors"
+install: "pip install -r requirements.txt"
 script: "fab travis_ci"

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,3 @@ mock==1.0.1
 # Requirements for OpenSlides handbook/documentation in alphabetical order
 Sphinx==1.2b3
 sphinx-bootstrap-theme==0.2.4
-
-# For Python 2.6 support
-argparse==1.2.1

--- a/requirements_production.txt
+++ b/requirements_production.txt
@@ -10,3 +10,7 @@ reportlab>=2.7,<2.8
 sockjs-tornado>=1.0,<1.1
 tornado>=3.1,<3.2
 whoosh>=2.5,<2.6
+
+# For Python 2.6 support
+--allow-external argparse
+argparse==1.2.1


### PR DESCRIPTION
With pip 1.5 no external packages are installed per default. This means, that python2.6 can not install argparse 1.2.1. So we have to allow pip to install argparse from a external source.

This pull request is important for the stable and for the master branch because neither can be used with pip 1.5. It is quite important because travis fails other ways.  

See:
-  https://github.com/OpenSlides/OpenSlides/pull/1217#issuecomment-37267331
- https://github.com/OpenSlides/OpenSlides/pull/1216#discussion_r10463239
