### PR TITLE
Fixed #1197: Use big heading for custom slides without text.

### DIFF
--- a/openslides/core/static/css/dashboard.css
+++ b/openslides/core/static/css/dashboard.css
@@ -129,6 +129,12 @@
     z-index: 1;
 }
 
+/* Projector control panel */
+.notNull {
+    color: red;
+    font-weight: bold;
+}
+
 /*** misc ***/
 .custom-btn-mini {
     width: 20px;

--- a/openslides/core/static/js/dashboard.js
+++ b/openslides/core/static/js/dashboard.js
@@ -73,13 +73,22 @@ $(function() {
             url: link.attr('href'),
             dataType: 'json',
             success: function(data) {
+                // change scale level number
                 $('#scale_level').html(data['scale_level']);
+                if ( data['scale_level'] != 0 )
+                    $('#scale_level').addClass('notNull');
+                else
+                    $('#scale_level').removeClass('notNull');
+                // change scroll level number
                 $('#scroll_level').html(data['scroll_level']);
-                if ( data['scroll_level'] === 0 )
-                    $('#scroll_up_button').addClass('disabled');
-                else {
+                if ( data['scroll_level'] != 0 ) {
+                    $('#scroll_level').addClass('notNull');
                     if ( $('#scroll_up_button').hasClass('disabled') )
                         $('#scroll_up_button').removeClass('disabled');
+                }
+                else {
+                    $('#scroll_level').removeClass('notNull');
+                    $('#scroll_up_button').addClass('disabled');
                 }
             }
         });

--- a/openslides/core/templates/core/customslide_slide.html
+++ b/openslides/core/templates/core/customslide_slide.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 
-<h1>
+<h1 {% if not slide.text %}class="title_only"{% endif %}>
     {{ slide.title }}
 </h1>
 

--- a/openslides/projector/static/css/projector.css
+++ b/openslides/projector/static/css/projector.css
@@ -67,9 +67,17 @@ body{
 h1 {
     font-size: 2.25em;
     margin-bottom: 40px;
-    line-height: 0.95em;
+    line-height: 1.1em;
     padding-bottom: 10px;
     border-bottom: 1px solid #e6e6e6;
+}
+h1.title_only {
+    text-align: center;
+    font-size: 2.75em;
+    line-height: 1.3em;
+    border: 0px;
+    padding: 40px;
+    margin-left: -35px; /* see #content position 'left' - 'right' for real centering */
 }
 h1 small {
     font-size: 0.55em;

--- a/openslides/projector/templates/projector/default_slide.html
+++ b/openslides/projector/templates/projector/default_slide.html
@@ -1,5 +1,5 @@
 {% load tags %}
 
-<h1>
+<h1 class="title_only">
     {{ 'welcome_title'|get_config }}
 </h1>

--- a/openslides/projector/templates/projector/widget_live_view.html
+++ b/openslides/projector/templates/projector/widget_live_view.html
@@ -25,7 +25,8 @@
         <a class="projector_edit btn" href="{% url 'projector_clean_scale' %}" title="{% trans 'Reset zoom level' %}">
             <i class="icon-resize-small"></i>
         </a>
-        {% trans "Zoom level" %}: <span id="scale_level">{{ 'projector_scale'|get_config }}</span>
+        {% trans "Zoom level" %}:
+        <span id="scale_level" {% if 'projector_scale'|get_config != 0 %}class="notNull"{% endif %}>{{ 'projector_scale'|get_config }}</span>
     </p>
     <p>
         <a class="projector_edit btn {% if 'projector_scroll'|get_config == 0 %}disabled{% endif %}" id="scroll_up_button"
@@ -38,7 +39,8 @@
         <a class="projector_edit btn" href="{% url 'projector_clean_scroll' %}" title="{% trans 'Reset scroll level' %}">
             <i class="icon-resize-small"></i>
         </a>
-        {% trans "Scroll level" %}: <span id="scroll_level">{{ 'projector_scroll'|get_config }}</span>
+        {% trans "Scroll level" %}:
+        <span id="scroll_level" {% if 'projector_scroll'|get_config != 0 %}class="notNull"{% endif %}>{{ 'projector_scroll'|get_config }}</span>
     </p>
 {% endif %}
 

--- a/openslides/projector/views.py
+++ b/openslides/projector/views.py
@@ -60,8 +60,6 @@ class ActivateView(RedirectView):
                 {'calls': {'load_pdf': {'url': url, 'page_num': kwargs['page_num']}}})
         else:
             set_active_slide(kwargs['callback'], **dict(request.GET.items()))
-        config['projector_scroll'] = config.get_default('projector_scroll')
-        config['projector_scale'] = config.get_default('projector_scale')
         call_on_projector({'scroll': config['projector_scroll'],
                            'scale': config['projector_scale']})
 

--- a/tests/projector/test_views.py
+++ b/tests/projector/test_views.py
@@ -2,7 +2,7 @@
 
 from django.contrib.auth.models import AnonymousUser
 from django.test.client import Client, RequestFactory
-from mock import call, MagicMock, patch
+from mock import MagicMock, patch
 
 from openslides.config.api import config
 from openslides.projector import views
@@ -54,9 +54,8 @@ class ActivateViewTest(TestCase):
 
         mock_set_active_slide.assert_called_with('some_callback',
                                                  **{'some_key': 'some_value'})
-        mock_config.get_default.assert_has_calls([call('projector_scroll'),
-                                                  call('projector_scale')])
-        self.assertEqual(mock_config.__setitem__.call_count, 2)
+        mock_config.get_default.assert_has_calls([])
+        self.assertEqual(mock_config.__setitem__.call_count, 0)
         self.assertTrue(mock_call_on_projector.called)
 
 


### PR DESCRIPTION
Does not changed the agenda slides. Only for custom slides. But keep also last projector scale/scroll values after activate new slide which helps to use same scale value on several slides.
