### PR TITLE
fix user status view (activate, deactivate user without js)

### DIFF
--- a/openslides/participant/views.py
+++ b/openslides/participant/views.py
@@ -147,13 +147,14 @@ class UserDeleteView(DeleteView):
             super(UserDeleteView, self).pre_post_redirect(request, *args, **kwargs)
 
 
-class SetUserStatusView(RedirectView, SingleObjectMixin):
+class SetUserStatusView(SingleObjectMixin, RedirectView):
     """
     Activate or deactivate an user.
     """
     permission_required = 'participant.can_manage_participant'
     allow_ajax = True
     url_name = 'user_overview'
+    url_name_args = []
     model = User
 
     def pre_redirect(self, request, *args, **kwargs):
@@ -164,8 +165,8 @@ class SetUserStatusView(RedirectView, SingleObjectMixin):
         elif action == 'deactivate':
             if self.object.user == self.request.user:
                 messages.error(request, _("You can not deactivate yourself."))
-                return
-            self.object.is_active = False
+            else:
+                self.object.is_active = False
         elif action == 'toggle':
             self.object.is_active = not self.object.is_active
         self.object.save()

--- a/tests/participant/test_views.py
+++ b/tests/participant/test_views.py
@@ -40,6 +40,10 @@ class UserViews(TestCase):
              'is_active': 'yes'})
         self.assertRedirects(response, '/participant/')
 
+    def test_activate(self):
+        response = self.client.get('/participant/1/status/activate/')
+        self.assertEqual(response.status_code, 302)
+
 
 class GroupViews(TestCase):
     """


### PR DESCRIPTION
The view returned a 500er when it was called with a 'normal' request. It worked fine with a ajax-requests, that way we did not noticed it before.
