### PR TITLE
Added missing mediafile projector stylefile for pdf.js presentation.

### DIFF
--- a/openslides/mediafile/templates/mediafile/presentation_slide.html
+++ b/openslides/mediafile/templates/mediafile/presentation_slide.html
@@ -10,6 +10,8 @@
 </script>
 <script src="{% static 'js/pdf_presenter.js' %}" type="text/javascript"></script>
 
+<link href="{% static 'css/mediafile_projector.css' %}" type="text/css" rel="stylesheet">
+
 <div class="canvas-container">
   <canvas id="presentation" class="{% if fullscreen %}fullscreen{% endif %}"></canvas>
 </div>


### PR DESCRIPTION
Fixed missing fullscreen mode of pdf presentation (found in 1.6b1), caused by outsourcing css files in 1.6-dev branch. 1.5.x stable branch is not effected.
