### PR TITLE
Fixed #1326: Rearranged assignment pdf table cells to prevent a LayoutError

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,8 +15,7 @@ Motions:
 - Fixed motion detail view template. Added block to enable extra content via
   plugins.
 Assignments:
-- Fixed PDF when an assignment has a lot of posts. Used only 7 signature
-  lines.
+- Fixed PDF build error when an election has more than 20 posts or candidates.
 Participants:
 - Fixed participant csv import with group ids:
   * Allowed to add multiple groups in csv group id field, e. g. "3,4".


### PR DESCRIPTION
This is a 2nd fix in this issue. Initally it looks like the error was caused by >20 posts only. But same LayoutError also affected if you added more than 20 candiadates to an assignment.
Now it is fixed by rearranged table (every candidate in one cell/row) to prevent that one cell is not higher than one page.

Note: The main diff of this pull request is caused by new indentation (`if posts:`) and rename cell name. 
Please review and merge.
