### PR TITLE
Reduce the usage of bsmselect jquery pluin.

### DIFF
--- a/openslides/core/templates/base.html
+++ b/openslides/core/templates/base.html
@@ -136,7 +136,7 @@
     <script type="text/javascript" src="{% static 'js/jquery/jquery.bsmselect.js' %}"></script>
     <script type="text/javascript">
         // use jquery-bsmselect for all <select multiple> form elements
-        $("select[multiple]").bsmSelect({
+        $("select[multiple]:not(.dont_use_bsmselect)").bsmSelect({
           removeLabel: '<sup><b>X</b></sup>',
           containerClass: 'bsmContainer',
           listClass: 'bsmList-custom',

--- a/openslides/participant/forms.py
+++ b/openslides/participant/forms.py
@@ -84,10 +84,11 @@ class UserUpdateForm(UserCreateForm):
 
 class GroupForm(forms.ModelForm, CssClassMixin):
     permissions = LocalizedModelMultipleChoiceField(
-        queryset=Permission.objects.all(), label=ugettext_lazy('Permissions'),
-        required=False)
+        queryset=Permission.objects.all(), label=ugettext_lazy('Permissions'), required=False,
+        widget=forms.SelectMultiple(attrs={'class': 'dont_use_bsmselect'}))
     users = forms.ModelMultipleChoiceField(
-        queryset=User.objects.all(), label=ugettext_lazy('Participants'), required=False)
+        queryset=User.objects.all(), label=ugettext_lazy('Participants'), required=False,
+        widget=forms.SelectMultiple(attrs={'class': 'dont_use_bsmselect'}))
 
     class Meta:
         model = Group


### PR DESCRIPTION
Use the plugin only for specific <select multiple> form fields.
E.g. not for the group permissions field.

Partly reverted changes from pull request #1381.