### PR TITLE
Speed up travis with cache for pip and node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
 language: python
+sudo: false
+cache:
+  directories:
+    - node_modules
+    - $HOME/virtualenv/python$TRAVIS_PYTHON_VERSION/lib/python$TRAVIS_PYTHON_VERSION/site-packages/
+    - $HOME/virtualenv/python$TRAVIS_PYTHON_VERSION/bin/
 python:
   - "3.3"
   - "3.4"
 install:
-  - "pip install -r requirements.txt"
+  - "pip install --upgrade --requirement requirements.txt"
   - "npm install"
   - "node_modules/.bin/bower install"
   - "node_modules/.bin/gulp --production"


### PR DESCRIPTION
Changed travis to cache the installed python and node packages.

"sudo: false" tells travis to run the commands in a container-based-infrastructure (in which sudo does not work). See http://docs.travis-ci.com/user/workers/container-based-infrastructure/

Added the 'upgrade' argument to pip install, so it does installs new version of python packages if available. This will update the cache.

If we want to 'uninstall' dependencies (which should not be neccessary) the cache can be deleted on the travis webpage.

See also: docs.travis-ci.com/user/caching/ 