### PR TITLE
rest cache

### DIFF
--- a/openslides/agenda/serializers.py
+++ b/openslides/agenda/serializers.py
@@ -1,6 +1,6 @@
-from django.core.urlresolvers import reverse
+from django.core.urlresolvers import reverse, NoReverseMatch
 
-from openslides.utils.rest_api import get_collection_and_id_from_url, serializers
+from openslides.utils.rest_api import get_collection_and_id_from_url, serializers, root_rest_for
 
 from .models import Item, Speaker
 
@@ -29,11 +29,16 @@ class RelatedItemRelatedField(serializers.RelatedField):
         of this object.
         """
         view_name = '%s-detail' % type(value)._meta.object_name.lower()
-        url = reverse(view_name, kwargs={'pk': value.pk})
-        collection, obj_id = get_collection_and_id_from_url(url)
+        try:
+            url = reverse(view_name, kwargs={'pk': value.pk})
+        except NoReverseMatch:
+            collection, obj_id = 'unknown', value.pk
+        else:
+            collection, obj_id = get_collection_and_id_from_url(url)
         return {'collection': collection, 'id': obj_id}
 
 
+@root_rest_for(Item)
 class ItemSerializer(serializers.ModelSerializer):
     """
     Serializer for agenda.models.Item objects.

--- a/openslides/agenda/views.py
+++ b/openslides/agenda/views.py
@@ -25,7 +25,7 @@ from openslides.projector.api import (
     get_overlays)
 from openslides.utils.exceptions import OpenSlidesError
 from openslides.utils.pdf import stylesheet
-from openslides.utils.rest_api import viewsets
+from openslides.utils.rest_api import ModelViewSet
 from openslides.utils.utils import html_strong
 from openslides.utils.views import (
     AjaxMixin,
@@ -775,7 +775,7 @@ class ItemCSVImportView(CSVImportView):
     template_name = 'agenda/item_form_csv_import.html'
 
 
-class ItemViewSet(viewsets.ModelViewSet):
+class ItemViewSet(ModelViewSet):
     """
     API endpoint to list, retrieve, create, update and destroy agenda items.
     """

--- a/openslides/assignment/serializers.py
+++ b/openslides/assignment/serializers.py
@@ -1,4 +1,4 @@
-from openslides.utils.rest_api import serializers
+from openslides.utils.rest_api import serializers, root_rest_for
 
 from .models import (
     models,
@@ -99,6 +99,7 @@ class AssignmentShortPollSerializer(AssignmentAllPollSerializer):
             'votescast',)
 
 
+@root_rest_for(Assignment)
 class AssignmentFullSerializer(serializers.ModelSerializer):
     """
     Serializer for assignment.models.Assignment objects. With all polls.
@@ -120,6 +121,7 @@ class AssignmentFullSerializer(serializers.ModelSerializer):
             'tags',)
 
 
+@root_rest_for(Assignment)
 class AssignmentShortSerializer(AssignmentFullSerializer):
     """
     Serializer for assignment.models.Assignment objects. Without unpublished poll.

--- a/openslides/assignment/views.py
+++ b/openslides/assignment/views.py
@@ -15,7 +15,7 @@ from openslides.config.api import config
 from openslides.users.models import Group, User  # TODO: remove this
 from openslides.poll.views import PollFormView
 from openslides.utils.pdf import stylesheet
-from openslides.utils.rest_api import viewsets
+from openslides.utils.rest_api import ModelViewSet
 from openslides.utils.utils import html_strong
 from openslides.utils.views import (CreateView, DeleteView, DetailView,
                                     ListView, PDFView, PermissionMixin,
@@ -190,7 +190,7 @@ class AssignmentRunOtherDeleteView(SingleObjectMixin, QuestionView):
         self.is_blocked = self.get_object().is_blocked(self.person)
 
 
-class AssignmentViewSet(viewsets.ModelViewSet):
+class AssignmentViewSet(ModelViewSet):
     """
     API endpoint to list, retrieve, create, update and destroy assignments.
     """

--- a/openslides/core/apps.py
+++ b/openslides/core/apps.py
@@ -11,10 +11,8 @@ class CoreAppConfig(AppConfig):
         from . import main_menu, widgets  # noqa
 
         # Import all required stuff.
-        from django.db.models import signals
         from openslides.config.signals import config_signal
         from openslides.projector.api import register_slide_model
-        from openslides.utils.autoupdate import inform_changed_data_receiver
         from openslides.utils.rest_api import router
         from .signals import setup_general_config
         from .views import CustomSlideViewSet, TagViewSet
@@ -29,12 +27,3 @@ class CoreAppConfig(AppConfig):
         # Register viewsets.
         router.register('core/customslide', CustomSlideViewSet)
         router.register('core/tag', TagViewSet)
-
-        # Update data when any model of any installed app is saved or deleted.
-        # TODO: Test if the m2m_changed signal is also needed.
-        signals.post_save.connect(
-            inform_changed_data_receiver,
-            dispatch_uid='inform_changed_data_receiver')
-        signals.post_delete.connect(
-            inform_changed_data_receiver,
-            dispatch_uid='inform_changed_data_receiver')

--- a/openslides/core/serializers.py
+++ b/openslides/core/serializers.py
@@ -1,8 +1,9 @@
-from openslides.utils.rest_api import serializers
+from openslides.utils.rest_api import serializers, root_rest_for
 
 from .models import CustomSlide, Tag
 
 
+@root_rest_for(CustomSlide)
 class CustomSlideSerializer(serializers.ModelSerializer):
     """
     Serializer for core.models.CustomSlide objects.
@@ -12,6 +13,7 @@ class CustomSlideSerializer(serializers.ModelSerializer):
         fields = ('id', 'title', 'text', 'weight',)
 
 
+@root_rest_for(Tag)
 class TagSerializer(serializers.ModelSerializer):
     """
     Serializer for core.models.Tag objects.

--- a/openslides/core/views.py
+++ b/openslides/core/views.py
@@ -16,7 +16,7 @@ from openslides import get_git_commit_id, RELEASE
 from openslides.config.api import config
 from openslides.utils import views as utils_views
 from openslides.utils.plugins import get_plugin_description, get_plugin_verbose_name, get_plugin_version
-from openslides.utils.rest_api import viewsets
+from openslides.utils.rest_api import ModelViewSet
 from openslides.utils.signals import template_manipulation
 from openslides.utils.widgets import Widget
 
@@ -235,7 +235,7 @@ class CustomSlideDeleteView(CustomSlideViewMixin, utils_views.DeleteView):
     pass
 
 
-class CustomSlideViewSet(viewsets.ModelViewSet):
+class CustomSlideViewSet(ModelViewSet):
     """
     API endpoint to list, retrieve, create, update and destroy custom slides.
     """
@@ -330,7 +330,7 @@ class TagListView(utils_views.AjaxMixin, utils_views.ListView):
             **context)
 
 
-class TagViewSet(viewsets.ModelViewSet):
+class TagViewSet(ModelViewSet):
     """
     API endpoint to list, retrieve, create, update and destroy tags.
     """

--- a/openslides/users/serializers.py
+++ b/openslides/users/serializers.py
@@ -1,8 +1,9 @@
-from openslides.utils.rest_api import serializers
+from openslides.utils.rest_api import serializers, root_rest_for
 
 from .models import Group, User  # TODO: Don't import Group from models but from core.models.
 
 
+@root_rest_for(User)
 class UserShortSerializer(serializers.ModelSerializer):
     """
     Serializer for users.models.User objects.
@@ -21,6 +22,7 @@ class UserShortSerializer(serializers.ModelSerializer):
             'groups',)
 
 
+@root_rest_for(User)
 class UserFullSerializer(serializers.ModelSerializer):
     """
     Serializer for users.models.User objects.

--- a/openslides/users/views.py
+++ b/openslides/users/views.py
@@ -6,7 +6,7 @@ from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _, ugettext_lazy, activate
 
 from openslides.config.api import config
-from openslides.utils.rest_api import viewsets
+from openslides.utils.rest_api import ModelViewSet
 from openslides.utils.utils import delete_default_permissions, html_strong
 from openslides.utils.views import (
     CreateView, CSVImportView, DeleteView, DetailView, FormView, ListView,
@@ -261,7 +261,7 @@ class ResetPasswordView(SingleObjectMixin, QuestionView):
         return _('The Password for %s was successfully reset.') % html_strong(self.get_object())
 
 
-class UserViewSet(viewsets.ModelViewSet):
+class UserViewSet(ModelViewSet):
     """
     API endpoint to list, retrieve, create, update and delete users.
     """
@@ -291,7 +291,7 @@ class UserViewSet(viewsets.ModelViewSet):
         return serializer_class
 
 
-class GroupViewSet(viewsets.ModelViewSet):
+class GroupViewSet(ModelViewSet):
     """
     API endpoint to list, retrieve, create, update and delete groups.
     """

--- a/openslides/utils/autoupdate.py
+++ b/openslides/utils/autoupdate.py
@@ -19,8 +19,6 @@ from tornado.web import (
 )
 from tornado.wsgi import WSGIContainer
 
-from .rest_api import get_collection_and_id_from_url
-
 
 class DjangoStaticFileHandler(StaticFileHandler):
     """
@@ -76,6 +74,7 @@ class OpenSlidesSockJSConnection(SockJSConnection):
         This method is called after succesful response of AsyncHTTPClient().
         See send_object().
         """
+        from .rest_api import get_collection_and_id_from_url
         collection, obj_id = get_collection_and_id_from_url(response.request.url)
         data = {
             'url': response.request.url,
@@ -170,10 +169,3 @@ def inform_changed_data(*args):
     else:
         pass
         # TODO: Implement big varainte with Apache or Nginx as wsgi webserver.
-
-
-def inform_changed_data_receiver(sender, instance, **kwargs):
-    """
-    Receiver for the inform_changed_data function to use in a signal.
-    """
-    inform_changed_data(instance)

--- a/openslides/utils/rest_api.py
+++ b/openslides/utils/rest_api.py
@@ -1,19 +1,69 @@
 import re
+from collections import OrderedDict
 
 from urllib.parse import urlparse
 
+from django.core.cache import cache
 from django.core.urlresolvers import reverse
-from rest_framework import response, routers, serializers, viewsets  # noqa
+from rest_framework import permissions, response, routers, serializers, viewsets  # noqa
+from rest_framework.response import Response
 
 from .exceptions import OpenSlidesError
+from .autoupdate import inform_changed_data
 
 router = routers.DefaultRouter()
+
+
+class ModelViewSet(viewsets.ModelViewSet):
+    """
+    Viewset that unses the cache.
+    """
+    # TODO: cache get_serializer_class() because it is now called twice and there
+    #       could be db-queries in it.
+
+    def retrieve(self, request, *args, **kwargs):
+        # Try to get the data from the cache
+        cache_key = self.model.get_rest_cache_key(
+            self.kwargs['pk'],
+            self.get_serializer_class())
+        data = cache.get(cache_key)
+
+        if data is None:
+            # If the data is not in the cache then get it from the db and save it into the cache
+            instance = self.get_object()
+            data = self.get_serializer(instance).data
+            # To cache the data, it has to be converted to OrderedDict
+            data = OrderedDict(data)
+            cache.set(cache_key, data)
+
+        return Response(data)
+
+    def list(self, request, *args, **kwargs):
+        # TODO: use the cache here. Maybe be getting only the pks from the
+        #       database and receiving the actual data with cache.set_many.
+        #       This should still be faster.
+        # This is the code from super()
+        instance = self.filter_queryset(self.get_queryset())
+        page = self.paginate_queryset(instance)
+        if page is not None:
+            serializer = self.get_pagination_serializer(page)
+        else:
+            serializer = self.get_serializer(instance, many=True)
+        return Response(serializer.data)
 
 
 class RESTModelMixin:
     """
     Mixin for django models which are used in our rest api.
     """
+
+    def save(self, *args, **kwargs):
+        super().save(*args, **kwargs)
+        self.changed()
+
+    def delete(self, *args, **kwargs):
+        super().delete(*args, **kwargs)
+        self.changed()
 
     def get_root_rest_element(self):
         """
@@ -32,6 +82,77 @@ class RESTModelMixin:
         root_instance = self.get_root_rest_element()
         rest_url = '%s-detail' % type(root_instance)._meta.object_name.lower()
         return reverse(rest_url, args=[str(root_instance.pk)])
+
+    @classmethod
+    def get_rest_cache_key(cls, pk, Serializer):
+        """
+        Returns the name of the key cache that should be used for this element.
+
+        The default is: json.MODEL.PK.SERIALIZER
+        E. g.: json.Assignment.5.AssignmentFullSerializer
+        """
+        return 'json.%s.%s.%s' % (
+            cls.__name__,
+            pk,
+            Serializer.__name__)
+
+    def update_rest_cache(self, root_instance=None, serializer=None):
+        """
+        Updates the cache.
+
+        root_instance is the rest_root_instance to use.
+
+        serializer is the serializer class which is used to gether the data.
+        if serializer is None, all serializers for the root_instance are used.
+        """
+        if root_instance is None:
+            root_instance = self.get_root_rest_element()
+
+        if root_instance.pk is None:
+            # Do not cache objects that are not in the database
+            return
+
+        if serializer is None:
+            try:
+                serializer_list = root_instance.serializers
+            except AttributeError:
+                # If there are no known serializers, do nothing
+                return
+        else:
+            serializer_list = [serializer]
+
+        for Serializer in serializer_list:
+            key = type(root_instance).get_rest_cache_key(root_instance.pk, Serializer)
+            data = Serializer(root_instance).data
+            # To cache the data, it has to be converted to OrderedDict
+            data = OrderedDict(data)
+            cache.set(key, data)
+
+    def changed(self):
+        """
+        Call this method if the data of the object has changed.
+
+        This will automaticly called in save() and delete(). This has only be
+        called manualy in situations, where save() is not called, for example after a
+        bulk_create().
+        """
+        root_rest_element = self.get_root_rest_element()
+        self.update_rest_cache(root_rest_element)
+        inform_changed_data(root_rest_element)
+
+
+def root_rest_for(model):
+    """
+    Decorator to mark serializers, that there are the root serializers for a
+    specific model.
+    """
+    def decorator(serializer_class):
+        try:
+            model.serializers.append(serializer_class)
+        except AttributeError:
+            model.serializers = [serializer_class]
+        return serializer_class
+    return decorator
 
 
 def get_collection_and_id_from_url(url):


### PR DESCRIPTION
open for discussion. I make this pull request ready when this way of caching is reviewed.

When a retrieve-view from a ModelViewSet is called for the first time, the cache is created and returned on later request of the same view.

When a model is changed, the cache is also recreated. For that, all Serializers of the root_rest_element are used.

To know the list of Serializers for a root_rest_element, I tag the serializers with a decorator. An alternative would be to set the list of serializers manually in the model.