### PR TITLE
Altered ui-router definitions

### DIFF
--- a/openslides/core/static/js/core.js
+++ b/openslides/core/static/js/core.js
@@ -1,6 +1,9 @@
 angular.module('OpenSlidesApp.core', [])
 
-.config(function($stateProvider) {
+.config(function($stateProvider, $urlMatcherFactoryProvider) {
+    // Make the trailing slash optional
+    $urlMatcherFactoryProvider.strictMode(false)
+
     // Use stateProvider.decorator to give default values to our states
     $stateProvider.decorator('views', function(state, parent) {
         var result = {},
@@ -56,7 +59,9 @@ angular.module('OpenSlidesApp.core', [])
                     create: '/new',
                     update: '/edit',
                     list: '',
-                    detail: '/:id',
+                    // The id is expected to be an integer, if not, the url has to
+                    // be defined manually
+                    detail: '/{id:int}',
                 };
 
             defaultUrl = defaultUrls[_.last(patterns)];


### PR DESCRIPTION
1. Allow trailing slash in urls
2. Use integer ids for detail views as default