### PR TITLE
Changed development settings path.

### DIFF
--- a/openslides/__main__.py
+++ b/openslides/__main__.py
@@ -153,7 +153,7 @@ def createsettings(args):
         if settings_path is None:
             settings_path = get_development_settings_path()
         context = {
-            'openslides_user_data_path': repr(os.path.join(os.getcwd(), 'development')),
+            'openslides_user_data_path': repr(os.path.join(os.getcwd(), 'development', 'var')),
             'debug': 'True'}
 
     settings_path = write_settings(settings_path, **context)

--- a/openslides/utils/main.py
+++ b/openslides/utils/main.py
@@ -86,9 +86,9 @@ def get_development_settings_path():
     """
     Returns the path to a local development settings.
 
-    On Unix systems: 'development/settings.py'
+    On Unix systems: 'development/var/settings.py'
     """
-    return os.path.join('development', 'settings.py')
+    return os.path.join('development', 'var', 'settings.py')
 
 
 def setup_django_settings_module(settings_path=None, development=None):

--- a/tests/old/utils/test_main.py
+++ b/tests/old/utils/test_main.py
@@ -56,7 +56,7 @@ class TestFunctions(TestCase):
                          'portable/openslides/settings.py')
 
     def test_get_development_settings_path(self):
-        self.assertEqual(main.get_development_settings_path(), os.sep.join(('development', 'settings.py')))
+        self.assertEqual(main.get_development_settings_path(), os.sep.join(('development', 'var', 'settings.py')))
 
     def test_setup_django_settings_module(self):
         main.setup_django_settings_module('test_dir_dhvnghfjdh456fzheg2f/test_path_bngjdhc756dzwncshdfnx.py')


### PR DESCRIPTION
Settings and user data live now at development/var/.
Move your existing directory or create new settings and database.

As discussed in #1481.