### PR TITLE
Removed the projector App

### DIFF
--- a/openslides/agenda/models.py
+++ b/openslides/agenda/models.py
@@ -11,7 +11,6 @@ from django.utils.translation import ugettext_lazy, ugettext_noop
 
 from openslides.core.config import config
 from openslides.core.models import Tag
-from openslides.projector.models import SlideMixin
 from openslides.users.models import User
 from openslides.utils.exceptions import OpenSlidesError
 from openslides.utils.models import RESTModelMixin
@@ -82,7 +81,7 @@ class ItemManager(models.Manager):
                 weight=weight)
 
 
-class Item(RESTModelMixin, SlideMixin, models.Model):
+class Item(RESTModelMixin, models.Model):
     """
     An Agenda Item
     """
@@ -302,19 +301,6 @@ class Item(RESTModelMixin, SlideMixin, models.Model):
         except IndexError:
             # The list of speakers is empty.
             return None
-
-    def is_active_slide(self):
-        """
-        Returns True if the slide is active. If the slide is a related item,
-        Returns True if the related object is active.
-        """
-        if super(Item, self).is_active_slide():
-            value = True
-        elif self.content_object and isinstance(self.content_object, SlideMixin):
-            value = self.content_object.is_active_slide()
-        else:
-            value = False
-        return value
 
     @property
     def item_no(self):

--- a/openslides/assignments/models.py
+++ b/openslides/assignments/models.py
@@ -14,7 +14,6 @@ from openslides.poll.models import (
     CollectDefaultVotesMixin,
     PublishPollMixin,
 )
-from openslides.projector.models import SlideMixin
 from openslides.users.models import User
 from openslides.utils.exceptions import OpenSlidesError
 from openslides.utils.models import RESTModelMixin
@@ -55,7 +54,7 @@ class AssignmentRelatedUser(RESTModelMixin, models.Model):
         return self.assignment
 
 
-class Assignment(RESTModelMixin, SlideMixin, models.Model):
+class Assignment(RESTModelMixin, models.Model):
     slide_callback_name = 'assignment'
 
     PHASE_SEARCH = 0
@@ -338,7 +337,7 @@ class AssignmentOption(RESTModelMixin, BaseOption):
         return self.poll.assignment
 
 
-class AssignmentPoll(RESTModelMixin, SlideMixin, CollectDefaultVotesMixin,
+class AssignmentPoll(RESTModelMixin, CollectDefaultVotesMixin,
                      PublishPollMixin, BasePoll):
     slide_callback_name = 'assignmentpoll'
     option_class = AssignmentOption

--- a/openslides/mediafiles/models.py
+++ b/openslides/mediafiles/models.py
@@ -4,12 +4,11 @@ from django.db import models
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy, ugettext_noop
 
-from openslides.projector.models import SlideMixin
 from openslides.users.models import User
 from openslides.utils.models import RESTModelMixin
 
 
-class Mediafile(RESTModelMixin, SlideMixin, models.Model):
+class Mediafile(RESTModelMixin, models.Model):
     """
     Class for uploaded files which can be delivered under a certain url.
     """

--- a/openslides/motions/models.py
+++ b/openslides/motions/models.py
@@ -15,14 +15,13 @@ from openslides.poll.models import (
     BaseVote,
     CollectDefaultVotesMixin,
 )
-from openslides.projector.models import SlideMixin
 from openslides.users.models import User
 from openslides.utils.models import RESTModelMixin
 
 from .exceptions import WorkflowError
 
 
-class Motion(RESTModelMixin, SlideMixin, models.Model):
+class Motion(RESTModelMixin, models.Model):
     """
     The Motion Class.
 
@@ -660,8 +659,7 @@ class MotionOption(RESTModelMixin, BaseOption):
         return self.poll.motion
 
 
-class MotionPoll(RESTModelMixin, SlideMixin, CollectDefaultVotesMixin,
-                 BasePoll):
+class MotionPoll(RESTModelMixin, CollectDefaultVotesMixin, BasePoll):
     """The Class to saves the vote result for a motion poll."""
 
     slide_callback_name = 'motionpoll'

--- a/openslides/projector/__init__.py
+++ b/openslides/projector/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = 'openslides.projector.apps.ProjectorAppConfig'

--- a/openslides/projector/models.py
+++ b/openslides/projector/models.py
@@ -1,8 +1,0 @@
-class SlideMixin(object):
-    """
-    Deprecated.
-
-    Will be reused or removed when more slides are implemented for the
-    OpenSlides 2.0 projector API
-    """
-    pass

--- a/openslides/users/models.py
+++ b/openslides/users/models.py
@@ -14,7 +14,6 @@ from django.db import models
 from django.utils.translation import ugettext_lazy, ugettext_noop
 
 from openslides.core.config import config
-from openslides.projector.models import SlideMixin
 from openslides.utils.models import RESTModelMixin
 
 from .exceptions import UserError
@@ -87,7 +86,7 @@ class UserManager(BaseUserManager):
         return ''.join([choice(chars) for i in range(size)])
 
 
-class User(RESTModelMixin, SlideMixin, PermissionsMixin, AbstractBaseUser):
+class User(RESTModelMixin, PermissionsMixin, AbstractBaseUser):
     """
     Model for users in OpenSlides. A client can login as a user with
     credentials. A user can also just be used as representation for a person


### PR DESCRIPTION
The projector app does nothing at the moment. It does not seem, that we need the SlideMixin anymore. If we remove this app before the merge of #1580 then the imports from the projector app can be removed in the initial migration files