### PR TITLE
Added new class RESTElement to configure our REST api

### DIFF
--- a/openslides/agenda/apps.py
+++ b/openslides/agenda/apps.py
@@ -11,18 +11,15 @@ class AgendaAppConfig(AppConfig):
     def ready(self):
         # Load projector elements.
         # Do this by just importing all from these files.
-        from . import projector  # noqa
+        from . import projector, rest_api  # noqa
 
         # Import all required stuff.
         from django.db.models.signals import pre_delete
         from openslides.core.signals import config_signal
-        from openslides.utils.rest_api import router
         from .signals import setup_agenda_config, listen_to_related_object_delete_signal
-        from .views import ItemViewSet
 
         # Connect signals.
         config_signal.connect(setup_agenda_config, dispatch_uid='setup_agenda_config')
-        pre_delete.connect(listen_to_related_object_delete_signal, dispatch_uid='agenda_listen_to_related_object_delete_signal')
-
-        # Register viewsets.
-        router.register('agenda/item', ItemViewSet)
+        pre_delete.connect(
+            listen_to_related_object_delete_signal,
+            dispatch_uid='agenda_listen_to_related_object_delete_signal')

--- a/openslides/agenda/rest_api.py
+++ b/openslides/agenda/rest_api.py
@@ -1,0 +1,7 @@
+from openslides.utils.rest_api import RESTElement
+
+from . import views
+
+
+class ItemRESTElement(RESTElement):
+    viewset = views.ItemViewSet

--- a/openslides/assignments/apps.py
+++ b/openslides/assignments/apps.py
@@ -11,17 +11,11 @@ class AssignmentsAppConfig(AppConfig):
     def ready(self):
         # Load projector elements.
         # Do this by just importing all from these files.
-        from . import projector  # noqa
+        from . import projector, rest_api  # noqa
 
         # Import all required stuff.
         from openslides.core.signals import config_signal
-        from openslides.utils.rest_api import router
         from .signals import setup_assignment_config
-        from .views import AssignmentViewSet, AssignmentPollViewSet
 
         # Connect signals.
         config_signal.connect(setup_assignment_config, dispatch_uid='setup_assignment_config')
-
-        # Register viewsets.
-        router.register('assignments/assignment', AssignmentViewSet)
-        router.register('assignments/assignmentpoll', AssignmentPollViewSet)

--- a/openslides/assignments/rest_api.py
+++ b/openslides/assignments/rest_api.py
@@ -1,0 +1,11 @@
+from openslides.utils.rest_api import RESTElement
+
+from . import views
+
+
+class AssignmentRESTElement(RESTElement):
+    viewset = views.AssignmentViewSet
+
+
+class AssignmentPollRESTElement(RESTElement):
+    viewset = views.AssignmentPollViewSet

--- a/openslides/core/apps.py
+++ b/openslides/core/apps.py
@@ -11,29 +11,16 @@ class CoreAppConfig(AppConfig):
     def ready(self):
         # Load projector elements.
         # Do this by just importing all from these files.
-        from . import projector  # noqa
+        from . import projector, rest_api  # noqa
 
         # Import all required stuff.
         from django.db.models import signals
         from openslides.core.signals import config_signal
         from openslides.utils.autoupdate import inform_changed_data_receiver
-        from openslides.utils.rest_api import router
         from .signals import setup_general_config
-        from .views import (
-            ConfigViewSet,
-            CustomSlideViewSet,
-            ProjectorViewSet,
-            TagViewSet,
-        )
 
         # Connect signals.
         config_signal.connect(setup_general_config, dispatch_uid='setup_general_config')
-
-        # Register viewsets.
-        router.register('core/projector', ProjectorViewSet)
-        router.register('core/customslide', CustomSlideViewSet)
-        router.register('core/tag', TagViewSet)
-        router.register('core/config', ConfigViewSet, 'config')
 
         # Update data when any model of any installed app is saved or deleted.
         # TODO: Test if the m2m_changed signal is also needed.

--- a/openslides/core/rest_api.py
+++ b/openslides/core/rest_api.py
@@ -1,0 +1,21 @@
+from openslides.utils.rest_api import RESTElement
+
+from . import views
+
+
+class CustomSlideRESTElement(RESTElement):
+    viewset = views.CustomSlideViewSet
+
+
+class ProjectorRestElement(RESTElement):
+    viewset = views.ProjectorViewSet
+
+
+class TagRestElement(RESTElement):
+    viewset = views.TagViewSet
+
+
+class ConfigRestElement(RESTElement):
+    viewset = views.ConfigViewSet
+    router_prefix = 'config'
+    app_label = 'core'

--- a/openslides/mediafiles/apps.py
+++ b/openslides/mediafiles/apps.py
@@ -11,11 +11,4 @@ class MediafilesAppConfig(AppConfig):
     def ready(self):
         # Load projector elements.
         # Do this by just importing all from these files.
-        from . import projector  # noqa
-
-        # Import all required stuff.
-        from openslides.utils.rest_api import router
-        from .views import MediafileViewSet
-
-        # Register viewsets.
-        router.register('mediafiles/mediafile', MediafileViewSet)
+        from . import projector, rest_api  # noqa

--- a/openslides/mediafiles/rest_api.py
+++ b/openslides/mediafiles/rest_api.py
@@ -1,0 +1,7 @@
+from openslides.utils.rest_api import RESTElement
+
+from . import views
+
+
+class MediafileRESTElement(RESTElement):
+    viewset = views.MediafileViewSet

--- a/openslides/motions/apps.py
+++ b/openslides/motions/apps.py
@@ -12,19 +12,12 @@ class MotionsAppConfig(AppConfig):
     def ready(self):
         # Load projector elements.
         # Do this by just importing all from these files.
-        from . import projector  # noqa
+        from . import projector, rest_api  # noqa
 
         # Import all required stuff.
         from openslides.core.signals import config_signal
-        from openslides.utils.rest_api import router
         from .signals import create_builtin_workflows, setup_motion_config
-        from .views import CategoryViewSet, MotionViewSet, WorkflowViewSet
 
         # Connect signals.
         config_signal.connect(setup_motion_config, dispatch_uid='setup_motion_config')
         post_migrate.connect(create_builtin_workflows, dispatch_uid='motion_create_builtin_workflows')
-
-        # Register viewsets.
-        router.register('motions/category', CategoryViewSet)
-        router.register('motions/motion', MotionViewSet)
-        router.register('motions/workflow', WorkflowViewSet)

--- a/openslides/motions/rest_api.py
+++ b/openslides/motions/rest_api.py
@@ -1,0 +1,15 @@
+from openslides.utils.rest_api import RESTElement
+
+from . import views
+
+
+class CategoryRESTElement(RESTElement):
+    viewset = views.CategoryViewSet
+
+
+class MotionRESTElement(RESTElement):
+    viewset = views.MotionViewSet
+
+
+class WorkflowRESTElement(RESTElement):
+    viewset = views.WorkflowViewSet

--- a/openslides/users/apps.py
+++ b/openslides/users/apps.py
@@ -11,13 +11,11 @@ class UsersAppConfig(AppConfig):
     def ready(self):
         # Load projector elements.
         # Do this by just importing all from these files.
-        from . import projector  # noqa
+        from . import projector, rest_api  # noqa
 
         # Import all required stuff.
         from openslides.core.signals import config_signal, post_permission_creation
-        from openslides.utils.rest_api import router
         from .signals import create_builtin_groups_and_admin, setup_users_config
-        from .views import GroupViewSet, UserViewSet
 
         # Connect signals.
         config_signal.connect(
@@ -26,7 +24,3 @@ class UsersAppConfig(AppConfig):
         post_permission_creation.connect(
             create_builtin_groups_and_admin,
             dispatch_uid='create_builtin_groups_and_admin')
-
-        # Register viewsets.
-        router.register('users/user', UserViewSet)
-        router.register('users/group', GroupViewSet)

--- a/openslides/users/rest_api.py
+++ b/openslides/users/rest_api.py
@@ -1,0 +1,13 @@
+from openslides.utils.rest_api import RESTElement
+
+from . import views
+
+
+class UserRESTElement(RESTElement):
+    viewset = views.UserViewSet
+
+
+class GroupRESTElement(RESTElement):
+    viewset = views.GroupViewSet
+    app_label = 'users'
+    router_prefix = 'group'

--- a/openslides/utils/class_register.py
+++ b/openslides/utils/class_register.py
@@ -1,0 +1,46 @@
+class RegisterSubclasses(type):
+    """
+    Metaclass to register subclasses of a class.
+
+    The metaclass adds an attribute 'subclasses' to the base class. This
+    attribute is a set containing all derivated classes.
+
+    After a new subclass is created, the classmethod on_subclass_created is
+    called.
+
+    Example:
+    class Base(metaclass=RegisterSubclasses):
+        pass
+
+    class Child(Base):
+        pass
+
+    assert Child in Base.subclasses
+    """
+
+    def __init__(cls, *args, **kwargs):
+        # Try to add the cls to cls.subclasses. If it does not have the
+        # attribute subclasses, then this is the base class, which should not
+        # be registered
+        try:
+            cls.subclasses.add(cls)
+        except AttributeError:
+            cls.subclasses = set()
+        else:
+            try:
+                cls.on_subclass_created()
+            except Exception as exception:
+                # If on_subclass_created() raises any exception, then the class
+                # should not be in cls.subclasses.
+                cls.subclasses.remove(cls)
+                # Raise the exception afterwards
+                raise exception
+        super().__init__(*args, **kwargs)
+
+    def on_subclass_created(cls):
+        """
+        This method is called when a new subclass is created.
+
+        Do nothing as default.
+        """
+        pass

--- a/openslides/utils/models.py
+++ b/openslides/utils/models.py
@@ -39,3 +39,18 @@ class RESTModelMixin:
         root_instance = self.get_root_rest_element()
         rest_url = '%s-detail' % type(root_instance)._meta.object_name.lower()
         return reverse(rest_url, args=[str(root_instance.pk)])
+
+    @classmethod
+    def get_collection_name(cls):
+        """
+        Returns the name of the collection.
+
+        This is usualy the name of the django app and the name of the model
+        combined with a slash.
+
+        The collection_name is used to identify an object inside of
+        openslides. For example in the rest api or in the search.
+        """
+        return "{app_name}/{model_name}".format(
+            app_name=cls._meta.app_label,
+            model_name=cls._meta.model_name)

--- a/openslides/utils/rest_api.py
+++ b/openslides/utils/rest_api.py
@@ -19,12 +19,14 @@ from rest_framework.serializers import (  # noqa
     SerializerMethodField,
     ValidationError,
 )
-from rest_framework.viewsets import GenericViewSet as _GenericViewSet  # noqa
-from rest_framework.viewsets import ModelViewSet as _ModelViewSet  # noqa
+from rest_framework.viewsets import GenericViewSet as _GenericViewSet
+from rest_framework.viewsets import ModelViewSet as _ModelViewSet
 from rest_framework.viewsets import \
-    ReadOnlyModelViewSet as _ReadOnlyModelViewSet  # noqa
-from rest_framework.viewsets import ViewSet as _ViewSet  # noqa
+    ReadOnlyModelViewSet as _ReadOnlyModelViewSet
+from rest_framework.viewsets import ViewSet as _ViewSet
+from rest_framework.viewsets import ViewSetMixin
 
+from .class_register import RegisterSubclasses
 from .exceptions import OpenSlidesError
 
 router = DefaultRouter()
@@ -87,6 +89,95 @@ class ReadOnlyModelViewSet(PermissionMixin, _ReadOnlyModelViewSet):
 
 class ViewSet(PermissionMixin, _ViewSet):
     pass
+
+
+class RESTElement(metaclass=RegisterSubclasses):
+    """
+    Element of our REST api.
+
+    Each element bundels a viewset, a route and optionally a model together.
+    """
+
+    viewset = None
+    """
+    A django REST framework viewset class used in the router.
+    """
+
+    router_prefix = None
+    """
+    This attribute has to be set if the defined viewset has no queryset. It is
+    used as prefix for the django REST framework router. See:
+
+    http://www.django-rest-framework.org/api-guide/routers/#usage
+
+    It is also used as second part of the collection_name if the specified
+    viewset has no queryset attribute.
+    """
+
+    app_label = None
+    """
+    This attribute has to be set if the defined viewset has no queryset. It is
+    used to generate the collection name.
+    """
+
+    @classmethod
+    def get_model(cls):
+        """
+        Returns the model used in the viewset.
+        """
+        viewset = cls.viewset
+        try:
+            queryset = viewset.queryset
+        except AttributeError:
+            # If there is no queryset in the viewset, then there is no model to use
+            return None
+        else:
+            return queryset.model
+
+    @classmethod
+    def on_subclass_created(cls):
+        """
+        Register a router when a new RESTElement is created.
+        """
+        # Make sure that the class has the attribute viewset. Fail early in other respects
+        if not isinstance(cls.viewset, type) or not issubclass(cls.viewset, ViewSetMixin):
+            raise NotImplementedError(
+                "{}.viewset is {}. It has to be a subclass of ViewSetMixin."
+                .format(cls, cls.viewset))
+
+        cls.register_router()
+
+    @classmethod
+    def get_collection_name(cls):
+        """
+        Returns the name of the collection.
+
+        Returns the collection_name of model class attribute as default.
+        """
+        model = cls.get_model()
+        try:
+            collection_name = model.get_collection_name()
+        except AttributeError:
+            # This error is raised if the viewset has no model or if the model does
+            # not have the method get_collection_name().
+            if cls.router_prefix is None or cls.app_label is None:
+                raise NotImplementedError(
+                    "The used viewset does not use a RESTModelMixin as model. "
+                    "You have to set the Attributes app_label and router_prefix.")
+            collection_name = "{app_label}/{router_prefix}".format(
+                app_label=cls.app_label,
+                router_prefix=cls.router_prefix)
+        return collection_name
+
+    @classmethod
+    def register_router(cls):
+        """
+        Register a django REST framework router for this REST element.
+        """
+        if cls.get_model() is None:
+            router.register(cls.get_collection_name(), cls.viewset, cls.router_prefix)
+        else:
+            router.register(cls.get_collection_name(), cls.viewset)
 
 
 def get_collection_and_id_from_url(url):

--- a/tests/unit/utils/test_class_register.py
+++ b/tests/unit/utils/test_class_register.py
@@ -1,0 +1,15 @@
+from unittest import TestCase
+
+from openslides.utils.class_register import RegisterSubclasses
+
+
+class RegisterSubclassesTest(TestCase):
+    def test_subclass(self):
+        class Base(metaclass=RegisterSubclasses):
+            pass
+
+        class Subclass(Base):
+            pass
+
+        self.assertIn(Subclass, Base.subclasses)
+        self.assertNotIn(Base, Base.subclasses)

--- a/tests/unit/utils/test_rest_api.py
+++ b/tests/unit/utils/test_rest_api.py
@@ -1,0 +1,35 @@
+from unittest import TestCase
+
+from openslides.utils.rest_api import RESTElement, ViewSet
+
+
+class RESTElementTest(TestCase):
+    def test_viewset_attribute_not_set(self):
+        """
+        Tests, an error is raised, when the attribute viewset is not set.
+        """
+        # Save subclasses to reset it after this test
+        RESTElement_subclasses = RESTElement.subclasses
+        RESTElement.subclasses = set()
+
+        with self.assertRaises(NotImplementedError):
+            class TestRESTElement(RESTElement):
+                pass
+
+        self.assertSetEqual(
+            RESTElement.subclasses,
+            set(),
+            "RESTElement should not have any subclasses")
+
+        RESTElement.subclasses = RESTElement_subclasses
+
+    def test_viewset_attribute_set_to_ViewSet(self):
+        """
+        Tests, that it is ok to set the viewset attribute to ViewSet.
+        """
+        class TestRESTElement(RESTElement):
+            viewset = ViewSet
+            register_router = lambda: None  # Do not register any router
+
+        # Clean up and make sure the test class was registered
+        RESTElement.subclasses.remove(TestRESTElement)


### PR DESCRIPTION
This pull requests adds a new class RESTElement to define elements that can be accessed via the REST api.

I would like this new way for the search implementation because I want to use the collection name and do not like to get this name from the django rest framework router (through the django reverse function). So I created the RESTElement class where all methods can be defined, which a REST element should have. For now, it is only used for the method get_collection_name().

To do this, I also implemented an alternative to utils.dispatch.SignalConnectMetaClass. The SignalConnectMetaClass implemented some functionality that I did not need (like check_permission) and I don't like to use django signals where a simple set() can do the job. The new metaclass RegisterSubclasses is simple (only 10 lines of code) and the Base class on which it is used does not need any extra attributes or methods.

This pull request is a blocker for the implementation of the search.