### PR TITLE
Modify user in form dialog without updating list/detail view.

### DIFF
--- a/openslides/users/static/templates/users/user-form.html
+++ b/openslides/users/static/templates/users/user-form.html
@@ -1,6 +1,10 @@
 <h1 ng-if="model.id" translate>Edit participant</h1>
 <h1 ng-if="!model.id" translate>New participant</h1>
 
+<alert ng-show="alert.show" type="{{ alert.type }}" ng-click="alert={}" close="alert={}">
+  {{ alert.msg }}
+</alert>
+
 <form name="userForm" ng-submit="save(model)">
   <formly-form model="model" fields="formFields">
     <button type="submit" ng-disabled="userForm.$invalid" class="btn btn-primary" translate>


### PR DESCRIPTION
Create deep copy of user object before modify user in form dialog.
So list/detail view is not updated while editing.
Before saving inject the changed user (copy) object back into DS
store. Refresh user from DB is save request fails.