### PR TITLE
Fixed TypeError caused by #1904.

### DIFF
--- a/openslides/core/static/js/core/base.js
+++ b/openslides/core/static/js/core/base.js
@@ -149,13 +149,15 @@ angular.module('OpenSlidesApp.core', [
     function (DS) {
         return function (collection, instance) {
             var Resource = DS.definitions[collection];
-            Resource.relationList.forEach(function (relationDef) {
-                if (relationDef.foreignKey) {
-                    var query = {};
-                    query[relationDef.foreignKey] = instance[Resource.idAttribute];
-                    Resource.getResource(relationDef.relation).ejectAll(query);
-                }
-            });
+            if (Resource.relationList) {
+                Resource.relationList.forEach(function (relationDef) {
+                    if (relationDef.foreignKey) {
+                        var query = {};
+                        query[relationDef.foreignKey] = instance[Resource.idAttribute];
+                        Resource.getResource(relationDef.relation).ejectAll(query);
+                    }
+                });
+            }
         }
     }
 ])


### PR DESCRIPTION
"Resource.relationList is undefinded" after activating a slide.