### PR TITLE
Refactored MotionPoll.

### DIFF
--- a/openslides/motions/serializers.py
+++ b/openslides/motions/serializers.py
@@ -116,21 +116,6 @@ class MotionPollSerializer(ModelSerializer):
             'votes',
             'has_votes')
 
-    def to_representation(self, obj):
-        """
-        Overrides the output of this serializer. Replaces vote values -1
-        through the translated string 'majority' and -2 through the
-        translated string 'undocumented'.
-        """
-        result = super().to_representation(obj)
-        for key in result:
-            if key in ('yes', 'no', 'abstain', 'votesvalid', 'votesinvalid', 'votescast'):
-                if result[key] == -1:
-                    result[key] = _('majority')
-                elif result[key] == -2:
-                    result[key] = _('undocumented')
-        return result
-
     def get_yes(self, obj):
         try:
             result = obj.get_votes().get(value='Yes').weight

--- a/openslides/motions/static/js/motions/base.js
+++ b/openslides/motions/static/js/motions/base.js
@@ -52,8 +52,9 @@ angular.module('OpenSlidesApp.motions', ['OpenSlidesApp.users'])
 
 .factory('MotionPoll', [
     'DS',
+    'gettextCatalog',
     'Config',
-    function (DS, Config) {
+    function (DS, gettextCatalog, Config) {
         return DS.defineResource({
             name: 'motions/motionpoll',
             relations: {
@@ -65,92 +66,40 @@ angular.module('OpenSlidesApp.motions', ['OpenSlidesApp.users'])
                 }
             },
             methods: {
-                getYesPercent: function (valueOnly) {
+                // returns object with value and percent
+                getVote: function (vote) {
+                    if (!this.has_votes || !vote) {
+                        return;
+                    }
+                    var value = '';
+                    switch (vote) {
+                        case -1:
+                            value = gettextCatalog.getString('majority');
+                            break;
+                        case -2:
+                            value = gettextCatalog.getString('undocumented');
+                            break;
+                        default:
+                            value = vote;
+                            break;
+                    }
+                    // calculate percent value
                     var config = Config.get('motions_poll_100_percent_base').value;
-                    var returnvalue;
-                    if (config == "WITHOUT_INVALID" && this.votesvalid > 0 && this.yes >= 0) {
-                        returnvalue = Math.round(this.yes * 100 / this.votesvalid * 10) / 10;
-                    } else if (config == "WITH_INVALID" && this.votescast > 0 && this.yes >= 0) {
-                        returnvalue = Math.round(this.yes * 100 / (this.votescast) * 10) / 10;
-                    } else {
-                        returnvalue = null;
+                    var percentStr, percentNumber;
+                    if (config == "WITHOUT_INVALID" && this.votesvalid > 0 && vote >= 0) {
+                        percentNumber = Math.round(vote * 100 / this.votesvalid * 10) / 10;
+                    } else if (config == "WITH_INVALID" && this.votescast > 0 && vote >= 0) {
+                        percentNumber = Math.round(vote * 100 / (this.votescast) * 10) / 10;
                     }
-                    if (!valueOnly && returnvalue != null) {
-                        returnvalue = "(" + returnvalue + "%)";
+                    if (percentNumber) {
+                        percentStr = "(" + percentNumber + "%)";
                     }
-                    return returnvalue;
+                    return {
+                        'value': value,
+                        'percentStr': percentStr,
+                        'percentNumber': percentNumber
+                    };
                 },
-                getNoPercent: function (valueOnly) {
-                    var config = Config.get('motions_poll_100_percent_base').value;
-                    var returnvalue;
-                    if (config == "WITHOUT_INVALID" && this.votesvalid > 0 && this.no >= 0) {
-                        returnvalue = Math.round(this.no * 100 / this.votesvalid * 10) / 10;
-                    } else if (config == "WITH_INVALID" && this.votescast > 0 && this.no >= 0) {
-                        returnvalue = Math.round(this.no * 100 / (this.votescast) * 10) / 10;
-                    } else {
-                        returnvalue = null;
-                    }
-                    if (!valueOnly && returnvalue != null) {
-                        returnvalue = "(" + returnvalue + "%)";
-                    }
-                    return returnvalue;
-                },
-                getAbstainPercent: function (valueOnly) {
-                    var config = Config.get('motions_poll_100_percent_base').value;
-                    var returnvalue;
-                    if (config == "WITHOUT_INVALID" && this.votesvalid > 0 && this.abstain >= 0) {
-                        returnvalue = Math.round(this.abstain * 100 / this.votesvalid * 10) / 10;
-                    } else if (config == "WITH_INVALID" && this.votescast > 0 && this.abstain >= 0) {
-                        returnvalue = Math.round(this.abstain * 100 / (this.votescast) * 10) / 10;
-                    } else {
-                        returnvalue = null;
-                    }
-                    if (!valueOnly && returnvalue != null) {
-                        returnvalue = "(" + returnvalue + "%)";
-                    }
-                    return returnvalue;
-                },
-                getVotesValidPercent: function (valueOnly) {
-                    var config = Config.get('motions_poll_100_percent_base').value;
-                    var returnvalue;
-                    if (config == "WITHOUT_INVALID" && this.votevalid >= 0) {
-                        returnvalue = 100;
-                    } else if (config == "WITH_INVALID" && this.votevalid >= 0) {
-                        returnvalue = Math.round(this.votesvalid * 100 / (this.votescast) * 10) / 10;
-                    } else {
-                        returnvalue = null;
-                    }
-                    if (!valueOnly && returnvalue != null) {
-                        returnvalue = "(" + returnvalue + "%)";
-                    }
-                    return returnvalue;
-                },
-                getVotesInvalidPercent: function (valueOnly) {
-                    var config = Config.get('motions_poll_100_percent_base').value;
-                    var returnvalue;
-                    if (config == "WITH_INVALID" && this.voteinvalid >= 0) {
-                        returnvalue = Math.round(this.votesinvalid * 100 / (this.votescast) * 10) / 10;
-                    } else {
-                        returnvalue = null;
-                    }
-                    if (!valueOnly && returnvalue != null) {
-                        returnvalue = "(" + returnvalue + "%)";
-                    }
-                    return returnvalue;
-                },
-                getVotesCastPercent: function (valueOnly) {
-                    var config = Config.get('motions_poll_100_percent_base').value;
-                    var returnvalue;
-                    if (config == "WITH_INVALID" && this.votecast >= 0) {
-                        returnvalue = 100;
-                    } else {
-                        returnvalue = null;
-                    }
-                    if (!valueOnly && returnvalue != null) {
-                        returnvalue = "(" + returnvalue + "%)";
-                    }
-                    return returnvalue;
-                }
             }
         });
     }

--- a/openslides/motions/static/templates/motions/motion-detail.html
+++ b/openslides/motions/static/templates/motions/motion-detail.html
@@ -138,53 +138,71 @@
                   <tr>
                     <td class="icon">
                       <i class="fa fa-thumbs-up fa-2x"></i>
-                    <td>
+                    <td ng-init="voteYes = poll.getVote(poll.yes)">
                       <span class="result_label"><translate>Yes</translate>:</span>
-                      <span class="result_value">{{ poll.yes }} {{ poll.getYesPercent() }}</span>
-                      <div ng-if="poll.getYesPercent(true)">
-                        <uib-progressbar value="poll.getYesPercent(true)" type="success"></uib-progressbar>
+                      <span class="result_value">
+                        {{ voteYes.value }} {{ voteYes.percentStr }}
+                      </span>
+                      <div ng-if="voteYes.percentNumber">
+                        <uib-progressbar value="voteYes.percentNumber" type="success"></uib-progressbar>
                       </div>
                   <!-- no -->
                   <tr>
                     <td class="icon">
                       <i class="fa fa-thumbs-down fa-2x"></i>
-                    <td>
+                    <td ng-init="voteNo = poll.getVote(poll.no)">
                       <span class="result_label"><translate>No</translate>:</span>
-                      <span class="result_value">{{ poll.no }} {{ poll.getNoPercent() }}</span>
-                      <div ng-if="poll.getNoPercent(true)">
-                        <uib-progressbar value="poll.getNoPercent(true)" type="danger"></uib-progressbar>
+                      <span class="result_value" >
+                        {{ voteNo.value }} {{ voteNo.percentStr }}
+                      </span>
+                      <div ng-if="voteNo.percentNumber">
+                        <uib-progressbar value="voteNo.percentNumber" type="danger"></uib-progressbar>
                       </div>
                   <!-- abstain -->
                   <tr>
                     <td class="icon">
                       <strong style="font-size: 26px">&empty;</strong>
-                    <td>
+                    <td ng-init="voteAbstain = poll.getVote(poll.abstain)">
                       <span class="result_label"><translate>Abstain</translate>:</span>
-                      <span class="result_value">{{ poll.abstain }} {{ poll.getAbstainPercent() }}</span>
-                      <div ng-if="poll.getAbstainPercent(true)">
-                        <uib-progressbar value="poll.getAbstainPercent(true)" type="warning"></uib-progressbar>
+                      <span class="result_value">
+                        {{ voteAbstain.value }} {{ voteAbstain.percentStr }}
+                      </span>
+                      <div ng-if="voteAbstain.percentNumber">
+                        <uib-progressbar value="voteAbstain.percentNumber" type="warning"></uib-progressbar>
                       </div>
                   <!-- valid votes -->
                   <tr>
                     <td class="icon">
                       <i class="fa fa-check fa-lg"></i>
-                    <td>
+                    <td ng-init="votesValid = poll.getVote(poll.votesvalid)">
                       <span class="result_label"><translate>Valid votes</translate>:</span>
-                      <span class="result_value">{{ poll.votesvalid }} {{ poll.getVotesValidPercent() }}</span>
+                      <span class="result_value">
+                        {{ votesValid.value }} {{ votesValid.percentStr }}
+                      </span>
                   <!-- invalid votes -->
                   <tr>
                     <td class="icon">
                       <i class="fa fa-ban fa-lg"></i>
-                    <td>
+                    <td ng-init="votesInvalid = poll.getVote(poll.votesinvalid)">
                       <span class="result_label"><translate>Invalid votes</translate>:</span>
-                      <span class="result_value">{{ poll.votesinvalid }} {{ poll.getVotesInvalidPercent() }}</span>
+                      <span class="result_value">
+                        {{ votesInvalid.value }}
+                        <span ng-if="config('motions_poll_100_percent_base') == 'WITH_INVALID'">
+                          {{ votesInvalid.percentStr }}
+                        </span>
+                      </span>
                   <!-- votes cast -->
                   <tr class="total">
                     <td class="icon">
                       <strong style="font-size: 16px">&sum;</strong>
-                    <td>
+                    <td ng-init="votesCast = poll.getVote(poll.votescast)">
                       <span class="result_label"><translate>Votes cast</translate>:</span>
-                      <span class="result_value">{{ poll.votescast }} {{ poll.getVotesCastPercent() }}</span>
+                      <span class="result_value">
+                        {{ votesCast.value }}
+                        <span ng-if="config('motions_poll_100_percent_base') == 'WITH_INVALID'">
+                          {{ votesCast.percentStr }}
+                        </span>
+                      </span>
                 </table>
           </ol>
           <button ng-if="motion.isAllowed('create_poll')" ng-click="create_poll()" class="btn btn-default btn-sm">


### PR DESCRIPTION
Use new getVotes function for vote value and percent value.
Remove 'to_representation' function in motion serializer.py to get
special values in numbers (-1,-2) instead of translated strings.