### PR TITLE
Use tinymce instead of CKEditor.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,15 +27,22 @@
     "js-data": "~2.8.2",
     "js-data-angular": "~3.1.0",
     "ng-file-upload": "~11.2.3",
-    "ckeditor": "4.5.6",
-    "angular-ckeditor": "~1.0.3",
+    "angular-ui-tinymce": "~0.0.13",
     "angular-pdf": "~1.3.0",
     "roboto-condensed": "~0.3.0",
-    "open-sans-fontface": "https://github.com/OpenSlides/open-sans.git#1.4.2.post1"
+    "open-sans-fontface": "https://github.com/OpenSlides/open-sans.git#1.4.2.post1",
+    "tinymce-i18n": "OpenSlides/tinymce-i18n"
   },
   "overrides": {
     "pdfjs-dist": {
       "main": "build/pdf.combined.js"
+    },
+    "tinymce-dist": {
+      "main": [
+          "tinymce.js",
+          "themes/modern/theme.js",
+          "plugins/*/plugin.js"
+      ]
     }
   },
   "resolutions": {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,6 +25,7 @@ var argv = require('yargs').argv,
     jshint = require('gulp-jshint'),
     mainBowerFiles = require('main-bower-files'),
     path = require('path'),
+    rename = require('gulp-rename'),
     through = require('through2'),
     uglify = require('gulp-uglify'),
     vsprintf = require('sprintf-js').vsprintf;
@@ -67,10 +68,27 @@ gulp.task('fonts-libs', function() {
         .pipe(gulp.dest(path.join(output_directory, 'fonts')));
 });
 
-// Extra task only for CKEditor
-gulp.task('ckeditor', function () {
-    return gulp.src(path.join('bower_components', 'ckeditor', '**'))
-        .pipe(gulp.dest(path.join(output_directory, 'ckeditor')));
+// Catches all skins files for TinyMCE editor.
+gulp.task('tinymce-skins', function () {
+    return gulp.src(path.join('bower_components', 'tinymce-dist', 'skins', '**'))
+        .pipe(gulp.dest(path.join(output_directory, 'tinymce', 'skins')));
+});
+
+// Catches all required i18n files for TinyMCE editor.
+gulp.task('tinymce-i18n', function () {
+    return gulp.src([
+            'bower_components/tinymce-i18n/langs/cs.js',
+            'bower_components/tinymce-i18n/langs/de.js',
+            'bower_components/tinymce-i18n/langs/es.js',
+            'bower_components/tinymce-i18n/langs/fr_FR.js',
+            'bower_components/tinymce-i18n/langs/pt_PT.js',
+            ])
+        .pipe(rename(function (path) {
+            if (path.basename === 'pt_PT') {path.basename = 'pt'}
+            if (path.basename === 'fr_FR') {path.basename = 'fr'}
+        }))
+        .pipe(gulpif(argv.production, uglify()))
+        .pipe(gulp.dest(path.join(output_directory, 'tinymce', 'i18n')));
 });
 
 // Compiles translation files (*.po) to *.json and saves them in the directory
@@ -84,7 +102,7 @@ gulp.task('translations', function () {
 });
 
 // Gulp default task. Runs all other tasks before.
-gulp.task('default', ['js-libs', 'css-libs', 'fonts-libs', 'ckeditor', 'translations'], function () {});
+gulp.task('default', ['js-libs', 'css-libs', 'fonts-libs', 'tinymce-skins', 'tinymce-i18n', 'translations'], function () {});
 
 
 /**

--- a/openslides/agenda/static/js/agenda/site.js
+++ b/openslides/agenda/static/js/agenda/site.js
@@ -75,9 +75,10 @@ angular.module('OpenSlidesApp.agenda.site', ['OpenSlidesApp.agenda'])
     'operator',
     'ngDialog',
     'Agenda',
+    'CustomslideForm',
     'AgendaTree',
     'Projector',
-    function($scope, $http, $state, DS, operator, ngDialog, Agenda, AgendaTree, Projector) {
+    function($scope, $http, $state, DS, operator, ngDialog, Agenda, CustomslideForm, AgendaTree, Projector) {
         // Bind agenda tree to the scope
         $scope.$watch(function () {
             return Agenda.lastModified();
@@ -110,11 +111,7 @@ angular.module('OpenSlidesApp.agenda.site', ['OpenSlidesApp.agenda'])
         };
         // open new dialog
         $scope.newDialog = function () {
-            ngDialog.open({
-                template: 'static/templates/core/customslide-form.html',
-                controller: 'CustomslideCreateCtrl',
-                className: 'ngdialog-theme-default wide-form'
-            });
+            ngDialog.open(CustomslideForm.getDialog());
         };
         // open edit dialog
         $scope.editDialog = function (item) {

--- a/openslides/core/static/js/core/base.js
+++ b/openslides/core/static/js/core/base.js
@@ -424,34 +424,15 @@ angular.module('OpenSlidesApp.core', [
     }
 ])
 
-/* Options for CKEditor used in various create and edit views. */
-.value('CKEditorOptions', {
-    allowedContent:
-        'h1 h2 h3 p pre b i u strike strong em blockquote;' +
-        'a[!href];' +
-        'img[!src,alt]{width,height,float};' +
-        'table tr th td caption;' +
-        'li ol ul{list-style};' +
-        'span{color,background-color};',
-    extraPlugins: 'colorbutton',
-    toolbarGroups: [
-        { name: 'clipboard', groups: [ 'clipboard', 'undo' ] },
-        { name: 'editing', groups: [ 'find', 'selection', 'spellchecker', 'editing' ] },
-        { name: 'forms', groups: [ 'forms' ] },
-        { name: 'tools', groups: [ 'tools' ] },
-        { name: 'about', groups: [ 'about' ] },
-        { name: 'document', groups: [ 'mode', 'document', 'doctools' ] },
-        { name: 'others', groups: [ 'others' ] },
-        '/',
-        { name: 'styles', groups: [ 'styles' ] },
-        { name: 'basicstyles', groups: [ 'basicstyles', 'cleanup' ] },
-        { name: 'paragraph', groups: [ 'list', 'indent', 'blocks', 'align', 'bidi', 'paragraph' ] },
-        { name: 'links', groups: [ 'links' ] },
-        { name: 'insert', groups: [ 'insert' ] },
-        { name: 'colors', groups: [ 'colors' ] }
-    ],
-    removeButtons: 'Anchor,SpecialChar,Subscript,Superscript,Styles,RemoveFormat,HorizontalRule'
-})
+// mark HTML as "trusted"
+.filter('trusted', [
+    '$sce',
+    function ($sce) {
+        return function(text) {
+            return $sce.trustAsHtml(text);
+        };
+    }
+])
 
 // Make sure that the DS factories are loaded by making them a dependency
 .run([

--- a/openslides/core/static/templates/core/customslide-detail.html
+++ b/openslides/core/static/templates/core/customslide-detail.html
@@ -30,7 +30,7 @@
 </div>
 
 <div class="details">
-  <div ng-bind-html="customslide.text"></div>
+  <div ng-bind-html="customslide.text | trusted"></div>
   <h3 ng-if="customslide.attachments.length > 0" translate>Attachments</h3>
   <ul>
     <li ng-repeat="attachment in customslide.attachments">

--- a/openslides/core/static/templates/core/editor.html
+++ b/openslides/core/static/templates/core/editor.html
@@ -1,0 +1,2 @@
+<!-- custom angular formly template for tinymce textarea field -->
+<textarea ui-tinymce="options.data.tinymceOption" ng-model="model[options.key]" class="form-control"></textarea>

--- a/openslides/core/static/templates/core/slide_customslide.html
+++ b/openslides/core/static/templates/core/slide_customslide.html
@@ -1,4 +1,4 @@
 <div ng-controller="SlideCustomSlideCtrl" class="content scrollcontent">
   <h1>{{ customslide.agenda_item.getTitle() }}</h1>
-  <div ng-bind-html="customslide.text"></div>
+  <div ng-bind-html="customslide.text | trusted"></div>
 </div>

--- a/openslides/core/static/templates/index.html
+++ b/openslides/core/static/templates/index.html
@@ -10,7 +10,6 @@
 <link rel="stylesheet" href="static/css/app.css">
 <link rel="icon" href="/static/img/favicon.png">
 <script src="static/js/openslides-libs.js"></script>
-<script src="static/ckeditor/ckeditor.js"></script>
 
 <div id="wrapper" ng-cloak>
 

--- a/openslides/mediafiles/static/js/mediafiles/base.js
+++ b/openslides/mediafiles/static/js/mediafiles/base.js
@@ -12,6 +12,15 @@ angular.module('OpenSlidesApp.mediafiles', [])
         return DS.defineResource({
             name: name,
             useClass: jsDataModel,
+            getAllImages: function () {
+                var images = []
+                angular.forEach(this.getAll(), function(file) {
+                    if (file.is_image) {
+                        images.push({title: file.title, value: file.mediafileUrl});
+                    }
+                });
+                return images;
+            },
             methods: {
                 getResourceName: function () {
                     return name;
@@ -29,6 +38,10 @@ angular.module('OpenSlidesApp.mediafiles', [])
                 is_presentable: ['filetype', function (filetype) {
                     var PRESENTABLE_FILE_TYPES = ['application/pdf'];
                     return _.contains(PRESENTABLE_FILE_TYPES, filetype);
+                }],
+                is_image: ['filetype', function (filetype) {
+                    var IMAGE_FILE_TYPES = ['image/png', 'image/jpeg', 'image/gif'];
+                    return _.contains(IMAGE_FILE_TYPES, filetype);
                 }],
                 mediafileUrl: [function () {
                     return this.media_url_prefix + this.mediafile.name;

--- a/openslides/motions/static/js/motions/site.js
+++ b/openslides/motions/static/js/motions/site.js
@@ -152,18 +152,20 @@ angular.module('OpenSlidesApp.motions.site', ['OpenSlidesApp.motions'])
 .factory('MotionForm', [
     'gettextCatalog',
     'operator',
+    'Editor',
     'Category',
     'Config',
     'Mediafile',
     'Tag',
     'User',
     'Workflow',
-    function (gettextCatalog, operator, Category, Config, Mediafile, Tag, User, Workflow) {
+    function (gettextCatalog, operator, Editor, Category, Config, Mediafile, Tag, User, Workflow) {
         return {
             // ngDialog for motion form
             getDialog: function (motion) {
+                var resolve = {}
                 if (motion) {
-                    var resolve = {
+                    resolve = {
                         motion: function() {
                             return motion;
                         },
@@ -172,6 +174,7 @@ angular.module('OpenSlidesApp.motions.site', ['OpenSlidesApp.motions'])
                         }
                     };
                 }
+                resolve.mediafiles = function(Mediafile) {return Mediafile.findAll();}
                 return {
                     template: 'static/templates/motions/motion-form.html',
                     controller: (motion) ? 'MotionUpdateCtrl' : 'MotionCreateCtrl',
@@ -187,6 +190,7 @@ angular.module('OpenSlidesApp.motions.site', ['OpenSlidesApp.motions'])
                 angular.forEach(workflows, function(workflow) {
                     workflow.name = gettextCatalog.getString(workflow.name);
                 });
+                var images = Mediafile.getAllImages();
                 return [
                 {
                     key: 'identifier',
@@ -220,20 +224,24 @@ angular.module('OpenSlidesApp.motions.site', ['OpenSlidesApp.motions'])
                 },
                 {
                     key: 'text',
-                    type: 'textarea',
+                    type: 'editor',
                     templateOptions: {
                         label: gettextCatalog.getString('Text'),
                         required: true
                     },
-                    ngModelElAttrs: {'ckeditor': 'CKEditorOptions'}
+                    data: {
+                        tinymceOption: Editor.getOptions(images)
+                    }
                 },
                 {
                     key: 'reason',
-                    type: 'textarea',
+                    type: 'editor',
                     templateOptions: {
-                        label: gettextCatalog.getString('Reason')
+                        label: gettextCatalog.getString('Reason'),
                     },
-                    ngModelElAttrs: {'ckeditor': 'CKEditorOptions'}
+                    data: {
+                        tinymceOption: Editor.getOptions(images)
+                    }
                 },
                 {
                     key: 'disable_versioning',

--- a/openslides/motions/static/templates/motions/motion-detail.html
+++ b/openslides/motions/static/templates/motions/motion-detail.html
@@ -218,12 +218,12 @@
   <div class="row">
     <div class="col-sm-8">
       <h3 translate>Text</h3>
-      <div ng-bind-html="motion.getText(version)"></div>
+      <div ng-bind-html="motion.getText(version) | trusted"></div>
 
       <!-- reason -->
       <div ng-if="motion.getReason(version) != ''">
         <h3 translate>Reason</h3>
-        <div ng-bind-html="motion.getReason()"></div>
+        <div ng-bind-html="motion.getReason() | trusted"></div>
       </div>
 
       <!-- attachments -->

--- a/openslides/motions/static/templates/motions/motion-form.html
+++ b/openslides/motions/static/templates/motions/motion-form.html
@@ -15,4 +15,3 @@
     </button>
   </formly-form>
 </form>
-

--- a/openslides/motions/static/templates/motions/slide_motion.html
+++ b/openslides/motions/static/templates/motions/slide_motion.html
@@ -62,9 +62,9 @@
   </div>
 
   <!-- Text -->
-  <div ng-bind-html="motion.getText()"></div>
+  <div ng-bind-html="motion.getText() | trusted"></div>
 
   <!-- Reason -->
   <h3 ng-if="motion.getReason()" translate>Reason</h3>
-  <div ng-bind-html="motion.getReason()"></div>
+  <div ng-bind-html="motion.getReason() | trusted"></div>
 </div>

--- a/openslides/users/static/js/users/site.js
+++ b/openslides/users/static/js/users/site.js
@@ -235,8 +235,10 @@ angular.module('OpenSlidesApp.users.site', ['OpenSlidesApp.users'])
 .factory('UserForm', [
     '$http',
     'gettextCatalog',
+    'Editor',
     'Group',
-    function ($http, gettextCatalog, Group) {
+    'Mediafile',
+    function ($http, gettextCatalog, Editor, Group, Mediafile) {
         return {
             // ngDialog for user form
             getDialog: function (user) {
@@ -256,6 +258,7 @@ angular.module('OpenSlidesApp.users.site', ['OpenSlidesApp.users'])
             },
             // angular-formly fields for user form
             getFormFields: function (hideOnCreateForm) {
+                var images = Mediafile.getAllImages();
                 return [
                 {
                     key: 'username',
@@ -334,12 +337,13 @@ angular.module('OpenSlidesApp.users.site', ['OpenSlidesApp.users'])
                 },
                 {
                     key: 'about_me',
-                    type: 'textarea',
+                    type: 'editor',
                     templateOptions: {
                         label: gettextCatalog.getString('About me'),
-                        description: gettextCatalog.getString('Profile text.')
                     },
-                    ngModelElAttrs: {'ckeditor': 'CKEditorOptions'}
+                    data: {
+                        tinymceOption: Editor.getOptions(images)
+                    }
                 },
                 {
                     key: 'is_present',
@@ -549,10 +553,12 @@ angular.module('OpenSlidesApp.users.site', ['OpenSlidesApp.users'])
 .controller('UserProfileCtrl', [
     '$scope',
     '$state',
+    'Editor',
     'User',
     'user',
-    function($scope, $state, User, user) {
+    function($scope, $state, Editor, User, user) {
         $scope.user = user;  // autoupdate is not activated
+        $scope.tinymceOption = Editor.getOptions();
         $scope.save = function (user) {
             User.save(user, { method: 'PATCH' }).then(
                 function(success) {

--- a/openslides/users/static/templates/users/user-detail-profile.html
+++ b/openslides/users/static/templates/users/user-detail-profile.html
@@ -37,7 +37,7 @@
     </div>
     <div class="form-group">
       <label for="textAbout" translate>About me</label>
-      <textarea ng-model="user.about_me" class="form-control" name="textAbout" />
+      <textarea ng-model="user.about_me" ui-tinymce="tinymceOption" class="form-control" name="textAbout" />
     </div>
 
     <button type="submit" ng-click="save(user)" class="btn btn-primary" translate>

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "gulp-cssnano": "~2.1.0",
     "gulp-if": "~2.0.0",
     "gulp-jshint": "~2.0.0",
+    "gulp-rename": "~1.2.2",
     "gulp-uglify": "~1.5.2",
     "main-bower-files": "~2.11.1",
     "po2json": "~0.4.1",


### PR DESCRIPTION
The main reason of switching to tinymce:
The data loss problem with MS Word is still unfixed in CKEditor, see https://dev.ckeditor.com/ticket/13174. Also the integration into angular-formly is easier with tinymce. And ui-tinymce looks more active than angular-ckeditor (e.g. Edge support with angular-ckeditor seems to be still open).

What I changed:
- better integration of tinymce in bower and gulp
- Improve support for html tags in reportlab's motion pdf.
- Now paste from word works without problems.
- The editor is now used for customslides (text), motions (text,
  reason) and users (about).