### PR TITLE
Updated requirements_production.txt

### DIFF
--- a/requirements_production.txt
+++ b/requirements_production.txt
@@ -5,9 +5,9 @@ djangorestframework>=3.2.0,<3.4.0
 html5lib>=0.9,<1.0
 jsonfield>=0.9.19,<1.1
 natsort>=3.2,<4.1
-reportlab>=3.0,<3.3
+PyPDF2>=1.25.0,<1.26
+reportlab>=3.0,<3.4
 roman>=2.0,<2.1
 setuptools>=2.2,<20.0
-sockjs-tornado>=1.0,<1.1
+sockjs-tornado>=1.0.1,<1.1
 Whoosh>=2.7.0,<2.8
-PyPDF2==1.25.1


### PR DESCRIPTION
reportlab 3.3 can be used
sockjs-tornado 1.0.0 is not usable. We need at least 1.0.1

