### PR TITLE
Fixed gulp jshint task.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -134,7 +134,8 @@ gulp.task('jshint', function () {
             path.join( 'openslides', '*', 'static', '**', '*.js' ),
         ])
         .pipe(jshint())
-        .pipe(jshint.reporter('default'));
+        .pipe(jshint.reporter('default'))
+        .pipe(jshint.reporter('fail'));
 });
 
 // Extracts names, URLs and licensed of all uses bower components and prints

--- a/openslides/agenda/static/js/agenda/projector.js
+++ b/openslides/agenda/static/js/agenda/projector.js
@@ -52,8 +52,9 @@ angular.module('OpenSlidesApp.agenda.projector', ['OpenSlidesApp.agenda'])
                 var startIndex = tree.indexOf($scope.rootItem);
                 tree = tree.slice(startIndex);
                 // define delta to move the whole subtree to level 0
+                var parentCountDelta = 0;
                 if (tree[0]) {
-                    var parentCountDelta = tree[0].parentCount;
+                    parentCountDelta = tree[0].parentCount;
                 }
                 $scope.items = [];
                 for (var i = 1; i < tree.length; i++) {


### PR DESCRIPTION
@emanuelschuetze Please check the implementation in projector.js. I think the `if (tree[0])` clause might be strange.