### PR TITLE
Remove 'can_see_extra_data' permission from registered and anonymous groups

### DIFF
--- a/openslides/users/models.py
+++ b/openslides/users/models.py
@@ -146,7 +146,7 @@ class User(RESTModelMixin, PermissionsMixin, AbstractBaseUser):
         default_permissions = ()
         permissions = (
             ('can_see_name', 'Can see names of users'),
-            ('can_see_extra_data', 'Can see extra data of users'),
+            ('can_see_extra_data', 'Can see extra data of users (e.g. present and comment)'),
             ('can_manage', 'Can manage users'),
         )
         ordering = ('last_name', 'first_name', 'username', )

--- a/openslides/users/signals.py
+++ b/openslides/users/signals.py
@@ -147,7 +147,6 @@ def create_builtin_groups_and_admin(**kwargs):
         permission_dict['core.can_see_projector'],
         permission_dict['mediafiles.can_see'],
         permission_dict['motions.can_see'],
-        permission_dict['users.can_see_extra_data'],
         permission_dict['users.can_see_name'], )
     group_anonymous = Group.objects.create(name='Guests', pk=1)
     group_anonymous.permissions.add(*base_permissions)
@@ -180,15 +179,15 @@ def create_builtin_groups_and_admin(**kwargs):
         permission_dict['mediafiles.can_upload'],
         permission_dict['motions.can_create'],
         permission_dict['motions.can_manage'],
-        permission_dict['users.can_manage'], )
+        permission_dict['users.can_manage'],
+        permission_dict['users.can_see_extra_data'],)
     group_staff = Group.objects.create(name='Staff', pk=4)
     group_staff.permissions.add(*staff_permissions)
 
-    # Add users.can_see_name and users.can_see_extra_data permissions to staff
+    # Add users.can_see_name permission to staff
     # group to ensure proper management possibilities
     # TODO: Remove this redundancy after cleanup of the permission system.
     group_staff.permissions.add(
-        permission_dict['users.can_see_extra_data'],
         permission_dict['users.can_see_name'])
 
     # Create or reset admin user

--- a/openslides/users/static/js/users/site.js
+++ b/openslides/users/static/js/users/site.js
@@ -820,6 +820,9 @@ angular.module('OpenSlidesApp.users.site', ['OpenSlidesApp.users'])
         $scope.permissions = permissions;
         $scope.group = {};
         $scope.save = function (group) {
+            if (!group.permissions) {
+                group.permissions = [];
+            }
             Group.create(group).then(
                 function(success) {
                     $state.go('users.group.list');

--- a/openslides/users/static/templates/users/group-form.html
+++ b/openslides/users/static/templates/users/group-form.html
@@ -19,7 +19,7 @@
     </div>
     <div class="form-group">
       <label for="selectPermissions" translate>Permissions</label>
-      <select multiple size="15" ng-model="group.permissions" class="form-control" id="selectPermissions" required>
+      <select multiple size="15" ng-model="group.permissions" class="form-control" id="selectPermissions">
           <option value="{{ permission.value }}" ng-repeat="permission in permissions">{{ permission.display_name | translate }}</option>
       </select>
     </div>

--- a/openslides/users/static/templates/users/user-list.html
+++ b/openslides/users/static/templates/users/user-list.html
@@ -56,7 +56,7 @@
                placeholder="{{ 'Search' | translate}}">
           </div>
         </div>
-        <button os-perms="users.can_see_extra_data" class="btn btn-default" ng-click="$parent.isFilterOpen = !$parent.isFilterOpen"
+        <button class="btn btn-default" ng-click="$parent.isFilterOpen = !$parent.isFilterOpen"
             ng-class="$parent.isFilterOpen ? 'btn-primary' : 'btn-default'">
           <i class="fa fa-filter"></i>
           <translate>Filter ...</translate>
@@ -64,7 +64,7 @@
       </div>
     </div>
   </div>
-  <div os-perms="users.can_see_extra_data" uib-collapse="!$parent.isFilterOpen" class="row spacer">
+  <div uib-collapse="!$parent.isFilterOpen" class="row spacer">
     <div class="col-sm-6 text-right"></div>
     <div class="col-sm-6 text-right form-inline">
       <!-- group filter -->
@@ -73,8 +73,10 @@
         <option ng-repeat="group in groups" value="{{ group.id }}">{{ group.name | translate }}</option>
       </select>
       <!-- isPresent filter -->
-      <input type="checkbox" ng-model="filterPresent" ng-false-value="''">
-      <translate>Is present</translate>
+      <span os-perms="users.can_see_extra_data">
+        <input  type="checkbox" ng-model="$parent.filterPresent" ng-false-value="''">
+        <translate>Is present</translate>
+      </span>
     </div>
   </div>
   <div uib-collapse="!isSelectMode" class="row spacer">
@@ -120,12 +122,15 @@
     {{(users|filter:{selected:true}).length}} {{ "selected" | translate }}</span>
   </div>
 
-  <!-- set filtered users (for user with/without can_see_extra_data permissions-->
-  <div os-perms="users.can_see_extra_data"
-      ng-repeat="user in usersFiltered = (users | filter: filter.search | filter: {groups: groupFilter} |
-          filter: {is_present: filterPresent} | orderBy: sortColumn:reverse)"></div>
+  <!-- filter users (for user with 'can_see_extra_data' permission) - consider present filter -->
+  <div os-perms="users.can_see_extra_data">
+    <span ng-repeat="user in $parent.usersFiltered = (users | filter: filter.search | filter: {groups: groupFilter} |
+          filter: {is_present: filterPresent} | orderBy: sortColumn:reverse)"></span>
+  </div>
+  <!-- filter users (for user without 'can_see_extra_data' permission) -->
   <div os-perms="!users.can_see_extra_data"
-      ng-repeat="user in usersFiltered = (users | filter: filter.search | orderBy: sortColumn:reverse)"></div>
+      ng-repeat="user in $parent.usersFiltered = (users | filter: filter.search | filter: {groups_id: groupFilter} |
+          orderBy: sortColumn:reverse)"></div>
 
   <table class="table table-striped table-bordered table-hover">
     <thead>
@@ -151,7 +156,7 @@
           <i class="pull-right fa" ng-show="sortColumn === 'groups' && header.sortable != false"
               ng-class="reverse ? 'fa-sort-desc' : 'fa-sort-asc'">
           </i>
-        <th ng-click="toggleSort('is_present')" class="sortable minimum">
+        <th os-perms="users.can_see_extra_data" ng-click="toggleSort('is_present')" class="sortable minimum">
           <translate>Present</translate>
           <i class="pull-right fa" ng-show="sortColumn === 'is_present' && header.sortable != false"
               ng-class="reverse ? 'fa-sort-desc' : 'fa-sort-asc'">
@@ -185,10 +190,14 @@
           </div>
         <td class="optional">{{ user.structure_level }}
         <td class="optional">
-          <div ng-repeat="group in user.groups">
+          <div os-perms="users.can_manage" ng-repeat="group in user.groups">
             {{ (groups | filter: {id: group})[0].name | translate }}
           </div>
-        <td>
+          <!-- TODO: normal users can't use user.groups but users.groups_id -->
+          <div os-perms="!users.can_manage" ng-repeat="group in user.groups_id">
+            {{ (groups | filter: {id: group})[0].name | translate }}
+          </div>
+        <td os-perms="users.can_see_extra_data">
           <span os-perms="!users.can_manage">
             <i ng-if="user.is_present" class="fa fa-check-square-o"></i>
           </span>


### PR DESCRIPTION
Now, only staff users has this permission by default. (Fixed #2004.)

Some more work on users/groups template:
- Added description to permission string to show that only 'present' and
  'comment' fields are affected by this permission.
- Allowed to create groups without permissions.
- Fixed showing group names in users lists view for staff and normal users.