### PR TITLE
Template fixes

### DIFF
--- a/openslides/core/static/css/app.css
+++ b/openslides/core/static/css/app.css
@@ -661,7 +661,7 @@ img {
 }
 
 /* angular-chosen: override default width of select fields in quickmode */
-.quickmode .chosen-container {
+.chosen-container {
     width: 100% !important;
 }
 

--- a/openslides/core/static/templates/config.html
+++ b/openslides/core/static/templates/config.html
@@ -10,15 +10,15 @@
     <!-- generate config groups -->
     <div ng-repeat="group in configGroups">
       <div class="panel panel-default">
-        <div class="panel-heading" role="tab" id="heading-{{ group.name }}">
+        <div class="panel-heading" role="tab" id="heading-group{{ $index }}">
           <h4 class="panel-title">
-            <a data-toggle="collapse" data-parent="#accordion" href="#{{ group.name }}"
-                aria-expanded="false" aria-controls="{{ group.name }}">
+            <a data-toggle="collapse" data-parent="#accordion" href="#group{{ $index }}"
+                aria-expanded="false" aria-controls="group{{ $index }}">
               {{ group.name | translate }}
             </a>
           </h4>
         </div> <!-- heading -->
-        <div id="{{ group.name }}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading-{{ group.name }}">
+        <div id="group{{ $index }}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading-group{{ $index }}">
           <div class="panel-body">
             <div ng-repeat="subgroup in group.subgroups">
               <h3>{{ subgroup.name }}</h3>


### PR DESCRIPTION
- Fix config groups. Use group index instead of group names (with blanks).
- Use 100% width for all chosen fields.