### PR TITLE
Support setuptools 20

### DIFF
--- a/requirements_production.txt
+++ b/requirements_production.txt
@@ -8,6 +8,6 @@ natsort>=3.2,<4.1
 PyPDF2>=1.25.0,<1.26
 reportlab>=3.0,<3.4
 roman>=2.0,<2.1
-setuptools>=2.2,<20.0
+setuptools>=2.2,<21.0
 sockjs-tornado>=1.0.1,<1.1
 Whoosh>=2.7.0,<2.8


### PR DESCRIPTION
Fixes #2078

I did not test this. This has to be tested when a new release is created because setuptools is only used by the "openslides" command.