### PR TITLE
Use always user.groups_id (Fixes #2081)

### DIFF
--- a/openslides/users/serializers.py
+++ b/openslides/users/serializers.py
@@ -4,8 +4,8 @@ from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
 
 from ..utils.rest_api import (
+    IdPrimaryKeyRelatedField,
     ModelSerializer,
-    PrimaryKeyRelatedField,
     RelatedField,
     ValidationError,
 )
@@ -40,7 +40,7 @@ class UserFullSerializer(ModelSerializer):
 
     Serializes all relevant fields.
     """
-    groups = PrimaryKeyRelatedField(
+    groups = IdPrimaryKeyRelatedField(
         many=True,
         queryset=Group.objects.exclude(pk__in=(1, 2)),
         help_text=ugettext_lazy('The groups this user belongs to. A user will '

--- a/openslides/users/static/js/users/base.js
+++ b/openslides/users/static/js/users/base.js
@@ -122,8 +122,8 @@ angular.module('OpenSlidesApp.users', [])
                 getPerms: function() {
                     var allPerms = [];
                     var allGroups = [];
-                    if (this.groups) {
-                        allGroups = this.groups.slice(0);
+                    if (this.groups_id) {
+                        allGroups = this.groups_id.slice(0);
                     }
                     // Add registered group
                     allGroups.push(2);
@@ -146,6 +146,14 @@ angular.module('OpenSlidesApp.users', [])
                     return "Participant";
                 },
             },
+            relations: {
+                hasMany: {
+                    'users/group': {
+                        localField: 'groups',
+                        localKey: 'groups_id',
+                    }
+                }
+            }
         });
     }
 ])

--- a/openslides/users/static/js/users/site.js
+++ b/openslides/users/static/js/users/site.js
@@ -319,7 +319,7 @@ angular.module('OpenSlidesApp.users.site', ['OpenSlidesApp.users'])
                     }
                 },
                 {
-                    key: 'groups',
+                    key: 'groups_id',
                     type: 'select-multiple',
                     templateOptions: {
                         label: gettextCatalog.getString('Groups'),
@@ -672,7 +672,7 @@ angular.module('OpenSlidesApp.users.site', ['OpenSlidesApp.users'])
                 var user = {
                     first_name: first_name,
                     last_name: last_name,
-                    groups: []
+                    groups_id: []
                 };
                 User.create(user).then(
                     function(success) {
@@ -741,7 +741,7 @@ angular.module('OpenSlidesApp.users.site', ['OpenSlidesApp.users'])
                 // groups
                 if (user.groups) {
                     var csvGroups = user.groups.replace(quotionRe, '$1').split(",");
-                    user.groups = [];
+                    user.groups_id = [];
                     user.groupnames = [];
                     if (csvGroups !== '') {
                         // All group objects are already loaded via the resolve statement from ui-router.
@@ -749,14 +749,14 @@ angular.module('OpenSlidesApp.users.site', ['OpenSlidesApp.users'])
                         csvGroups.forEach(function(csvGroup) {
                             allGroups.forEach(function (allGroup) {
                                 if (csvGroup == allGroup.id) {
-                                    user.groups.push(allGroup.id);
+                                    user.groups_id.push(allGroup.id);
                                     user.groupnames.push(allGroup.name);
                                 }
                             });
                         });
                     }
                 } else {
-                    user.groups = [];
+                    user.groups_id = [];
                 }
                 // comment
                 if (user.comment) {

--- a/openslides/users/static/templates/users/user-detail.html
+++ b/openslides/users/static/templates/users/user-detail.html
@@ -31,8 +31,8 @@
       <label translate>Structure level</label>
         {{ user.structure_level }}
       <label translate>Groups</label>
-        <div ng-repeat="group in user.groups">
-          {{ (groups | filter: {id: group})[0].name }}
+        <div ng-repeat="group in user.groups_id">
+          {{ (groups | filter: {id: group})[0].name | translate }}
         </div>
       <label translate>About me</label>
         <div ng-bind-html="user.about_me"></div>

--- a/openslides/users/static/templates/users/user-list.html
+++ b/openslides/users/static/templates/users/user-list.html
@@ -124,7 +124,7 @@
 
   <!-- filter users (for user with 'can_see_extra_data' permission) - consider present filter -->
   <div os-perms="users.can_see_extra_data">
-    <span ng-repeat="user in $parent.usersFiltered = (users | filter: filter.search | filter: {groups: groupFilter} |
+    <span ng-repeat="user in $parent.usersFiltered = (users | filter: filter.search | filter: {groups_id: groupFilter} |
           filter: {is_present: filterPresent} | orderBy: sortColumn:reverse)"></span>
   </div>
   <!-- filter users (for user without 'can_see_extra_data' permission) -->
@@ -190,11 +190,7 @@
           </div>
         <td class="optional">{{ user.structure_level }}
         <td class="optional">
-          <div os-perms="users.can_manage" ng-repeat="group in user.groups">
-            {{ (groups | filter: {id: group})[0].name | translate }}
-          </div>
-          <!-- TODO: normal users can't use user.groups but users.groups_id -->
-          <div os-perms="!users.can_manage" ng-repeat="group in user.groups_id">
+          <div ng-repeat="group in user.groups_id">
             {{ (groups | filter: {id: group})[0].name | translate }}
           </div>
         <td os-perms="users.can_see_extra_data">

--- a/tests/integration/users/test_viewset.py
+++ b/tests/integration/users/test_viewset.py
@@ -49,7 +49,7 @@ class UserCreate(TestCase):
         self.client.post(
             reverse('user-list'),
             {'last_name': 'Test name aedah1iequoof0Ashed4',
-             'groups': group_pks})
+             'groups_id': group_pks})
 
         user = User.objects.get(username='Test name aedah1iequoof0Ashed4')
         self.assertTrue(user.groups.filter(pk=group_pks[0]).exists())
@@ -64,10 +64,10 @@ class UserCreate(TestCase):
         response = self.client.post(
             reverse('user-list'),
             {'last_name': 'Test name aedah1iequoof0Ashed4',
-             'groups': group_pks})
+             'groups_id': group_pks})
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(response.data, {'groups': ["Invalid pk \"%d\" - object does not exist." % group_pks[0]]})
+        self.assertEqual(response.data, {'groups_id': ["Invalid pk \"%d\" - object does not exist." % group_pks[0]]})
 
 
 class UserUpdate(TestCase):


### PR DESCRIPTION
- Fix rest api: send always groups_id (instead of groups).
- Fix JS-Data-Store: Add hasMany relations for user.groups.
- Fix templates: use field 'groups_id' instead of 'groups'.