### PR TITLE
Change the z-index of `.fullscreen` to 199.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,3 +18,4 @@ Authors of OpenSlides in chronological order of first contribution:
     René von der Haar <rene.vonderhaar@medienweite.de> (Logo design)
     Jörn Bensch <bensch@triagonale.de> (Template design)
     John Felipe Urrego Mejia <ingenierofelipeurrego@gmail.com> (Spanish translation)
+	Erik Steenman <eriksteenman@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -18,4 +18,4 @@ Authors of OpenSlides in chronological order of first contribution:
     René von der Haar <rene.vonderhaar@medienweite.de> (Logo design)
     Jörn Bensch <bensch@triagonale.de> (Template design)
     John Felipe Urrego Mejia <ingenierofelipeurrego@gmail.com> (Spanish translation)
-	Erik Steenman <eriksteenman@gmail.com>
+    Erik Steenman <eriksteenman@gmail.com>

--- a/openslides/core/static/css/projector.css
+++ b/openslides/core/static/css/projector.css
@@ -91,7 +91,7 @@ body{
     left: 0;
     width: 100%;
     height: 100%;
-    z-index: 1000;
+    z-index: 100;
     background-color: black;
 }
 .fullscreen canvas {


### PR DESCRIPTION
Z-Index 199 places the fullscreen content just below the various
projector overlays, such as messages and timers.

Fixes #2096.