### PR TITLE
Limit selection of files to csv and txt (Fixed #2133)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,3 +19,4 @@ Authors of OpenSlides in chronological order of first contribution:
     Jörn Bensch <bensch@triagonale.de> (Template design)
     John Felipe Urrego Mejia <ingenierofelipeurrego@gmail.com> (Spanish translation)
     Erik Steenman <eriksteenman@gmail.com>
+    Sean Engelhardt <sean.f.t.engelhardt@gmail.com>

--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "angular-bootstrap": "~0.14.3",
     "angular-bootstrap-colorpicker": "~3.0.24",
     "angular-chosen-localytics": "~1.4.0",
-    "angular-csv-import": "~0.0.27",
+    "angular-csv-import": "~0.0.29",
     "angular-formly": "~7.3.9",
     "angular-formly-templates-bootstrap": "~6.2.0",
     "angular-gettext": "~2.2.0",

--- a/openslides/agenda/static/js/agenda/site.js
+++ b/openslides/agenda/static/js/agenda/site.js
@@ -417,6 +417,7 @@ angular.module('OpenSlidesApp.agenda.site', ['OpenSlidesApp.agenda'])
         $scope.separator = ',';
         $scope.encoding = 'UTF-8';
         $scope.encodingOptions = ['UTF-8', 'ISO-8859-1'];
+        $scope.accept = '.csv, .txt';
         $scope.csv = {
             content: null,
             header: true,
@@ -425,6 +426,7 @@ angular.module('OpenSlidesApp.agenda.site', ['OpenSlidesApp.agenda'])
             separatorVisible: false,
             encoding: $scope.encoding,
             encodingVisible: false,
+            accept: $scope.accept,
             result: null
         };
         // set csv file encoding

--- a/openslides/agenda/static/templates/agenda/item-import.html
+++ b/openslides/agenda/static/templates/agenda/item-import.html
@@ -59,6 +59,7 @@ Keep each item in a single line.</p>
           separator-visible="csv.separatorVisible"
           result="csv.result"
           encoding="csv.encoding"
+          accept="csv.accept"
           encoding-visible="csv.encodingVisible"></ng-csv-import>
     </div>
   </div>

--- a/openslides/motions/static/js/motions/site.js
+++ b/openslides/motions/static/js/motions/site.js
@@ -824,6 +824,7 @@ angular.module('OpenSlidesApp.motions.site', ['OpenSlidesApp.motions'])
         $scope.separator = ',';
         $scope.encoding = 'UTF-8';
         $scope.encodingOptions = ['UTF-8', 'ISO-8859-1'];
+        $scope.accept = '.csv, .txt';
         $scope.csv = {
             content: null,
             header: true,
@@ -832,6 +833,7 @@ angular.module('OpenSlidesApp.motions.site', ['OpenSlidesApp.motions'])
             separatorVisible: false,
             encoding: $scope.encoding,
             encodingVisible: false,
+            accept: $scope.accept,
             result: null
         };
         // set csv file encoding

--- a/openslides/motions/static/templates/motions/motion-import.html
+++ b/openslides/motions/static/templates/motions/motion-import.html
@@ -31,6 +31,7 @@
           separator-visible="csv.separatorVisible"
           result="csv.result"
           encoding="csv.encoding"
+          accept="csv.accept"
           encoding-visible="csv.encodingVisible"></ng-csv-import>
     </div>
   </div>

--- a/openslides/users/static/js/users/site.js
+++ b/openslides/users/static/js/users/site.js
@@ -688,6 +688,7 @@ angular.module('OpenSlidesApp.users.site', ['OpenSlidesApp.users'])
         $scope.separator = ',';
         $scope.encoding = 'UTF-8';
         $scope.encodingOptions = ['UTF-8', 'ISO-8859-1'];
+        $scope.accept = '.csv, .txt';
         $scope.csv = {
             content: null,
             header: true,
@@ -696,6 +697,7 @@ angular.module('OpenSlidesApp.users.site', ['OpenSlidesApp.users'])
             separatorVisible: false,
             encoding: $scope.encoding,
             encodingVisible: false,
+            accept: $scope.accept,
             result: null
         };
         // set csv file encoding

--- a/openslides/users/static/templates/users/user-import.html
+++ b/openslides/users/static/templates/users/user-import.html
@@ -59,6 +59,7 @@
           separator="csv.separator"
           separator-visible="csv.separatorVisible"
           result="csv.result"
+          accept="csv.accept"
           encoding="csv.encoding"
           encoding-visible="csv.encodingVisible"></ng-csv-import>
     </div>


### PR DESCRIPTION
Increases the version of angular-csv-import and uses the new "accept" function.