### PR TITLE
Fix pagination when agenda got >100 entrys (Fixes #2156)

### DIFF
--- a/openslides/agenda/static/templates/agenda/item-list.html
+++ b/openslides/agenda/static/templates/agenda/item-list.html
@@ -230,7 +230,7 @@
             <a href="" ng-click="editDialog(item)" class="pull-right"><translate>Edit ...</translate></a>
           </div>
   </table>
-  <uib-pagination ng-if="itemsFiltered.length > itemsPerPage" total-items="itemsFiltered.length" items-per-page="itemsPerPage" ng-model="currentPage"
+  <uib-pagination ng-show="itemsFiltered.length > itemsPerPage" total-items="itemsFiltered.length" items-per-page="itemsPerPage" ng-model="currentPage"
       ng-change="pageChanged()"
       class="pagination-sm" direction-links="false" boundary-links="true" first-text="&laquo;" last-text="&raquo;">
   </uib-pagination>


### PR DESCRIPTION
changed the ng-if to ng-show in the uib-pagination of
openslides/agenda/static/templates/agenda/item-list.html

@emanuelschuetze 