### PR TITLE
config "calculate % without abstains" (motions) (Issue #2182)

### DIFF
--- a/openslides/assignments/static/js/assignments/base.js
+++ b/openslides/assignments/static/js/assignments/base.js
@@ -42,7 +42,7 @@ angular.module('OpenSlidesApp.assignments', [])
                         } else if (config == "WITH_INVALID" && poll.votescast > 0 && vote.weight >= 0) {
                             percentNumber = Math.round(vote.weight * 100 / (poll.votescast) * 10) / 10;
                         }
-                        if (percentNumber >=0 ) {
+                        if (percentNumber >= 0 ) {
                             percentStr = "(" + percentNumber + "%)";
                         }
                         votes.push({

--- a/openslides/assignments/views.py
+++ b/openslides/assignments/views.py
@@ -510,7 +510,7 @@ class AssignmentPollPDF(PDFView):
                                  'yes': _("Yes"),
                                  'no': _("No"),
                                  'abstain': _("Abstain")},
-                               stylesheet['Ballot_option_circle_YNA']))
+                                stylesheet['Ballot_option_circle_YNA']))
                 else:
                     cell.append(Paragraph(
                         "&nbsp;", stylesheet['Ballot_option_suffix_YNA']))

--- a/openslides/motions/config_variables.py
+++ b/openslides/motions/config_variables.py
@@ -1,4 +1,5 @@
 from django.core.validators import MinValueValidator
+from django.utils.translation import ugettext_lazy
 
 from openslides.core.config import ConfigVariable
 from openslides.poll.models import PERCENT_BASE_CHOICES
@@ -23,6 +24,10 @@ def get_config_variables():
     papers' and 'PDF'. The generator has to be evaluated during app loading
     (see apps.py).
     """
+    percent_base_choices_motion = PERCENT_BASE_CHOICES
+    percent_base_choices_motion += ({
+        'value': "WITHOUT_ABSTAIN",
+        'display_name': ugettext_lazy('Yes and No votes')},)
     # General
     yield ConfigVariable(
         name='motions_workflow',
@@ -148,7 +153,7 @@ def get_config_variables():
         default_value='WITHOUT_INVALID',
         input_type='choice',
         label='The 100 % base of a voting result consists of',
-        choices=PERCENT_BASE_CHOICES,
+        choices=percent_base_choices_motion,
         weight=355,
         group='Motions',
         subgroup='Voting and ballot papers')

--- a/openslides/motions/static/js/motions/base.js
+++ b/openslides/motions/static/js/motions/base.js
@@ -71,7 +71,7 @@ angular.module('OpenSlidesApp.motions', [
             },
             methods: {
                 // returns object with value and percent
-                getVote: function (vote) {
+                getVote: function (vote, type) {
                     if (!this.has_votes) {
                         return;
                     }
@@ -89,13 +89,18 @@ angular.module('OpenSlidesApp.motions', [
                     }
                     // calculate percent value
                     var config = Config.get('motions_poll_100_percent_base').value;
-                    var percentStr, percentNumber;
+                    var percentStr;
+                    var percentNumber = null;
                     if (config == "WITHOUT_INVALID" && this.votesvalid > 0 && vote >= 0) {
                         percentNumber = Math.round(vote * 100 / this.votesvalid * 10) / 10;
                     } else if (config == "WITH_INVALID" && this.votescast > 0 && vote >= 0) {
                         percentNumber = Math.round(vote * 100 / (this.votescast) * 10) / 10;
+                    } else if (config == "WITHOUT_ABSTAIN" && this.votesvalid > 0 && vote >= 0){
+		                if (type == 'yes' || type == 'no') {
+                            percentNumber = Math.round(vote * 100 / (this.yes + this.no) * 10) / 10;
+                        }
                     }
-                    if (percentNumber) {
+                    if (percentNumber !== null) {
                         percentStr = "(" + percentNumber + "%)";
                     }
                     return {
@@ -103,7 +108,7 @@ angular.module('OpenSlidesApp.motions', [
                         'percentStr': percentStr,
                         'percentNumber': percentNumber
                     };
-                },
+                }
             }
         });
     }

--- a/openslides/motions/static/js/motions/site.js
+++ b/openslides/motions/static/js/motions/site.js
@@ -70,14 +70,15 @@ angular.module('OpenSlidesApp.motions.site', ['OpenSlidesApp.motions', 'OpenSlid
                     results = function() {
                         return motion.polls.map(function(poll, index) {
                             var id = index + 1,
-                                yes = poll.yes,
-                                yesRelative = (poll.yes) * 100 / (poll.votescast),
-                                no = poll.no,
-                                noRelative = (poll.no) * 100 / (poll.votescast),
-                                abstain = poll.abstain,
-                                abstainRelative = (poll.abstain) * 100 / (poll.votescast),
+                                yes = poll.yes ? poll.yes : 0, // if no poll.yes is given, set it to 0
+                                yesRelative = poll.getVote(poll.yes, 'yes').percentStr,
+                                no = poll.no ? poll.no : 0,
+                                noRelative = poll.getVote(poll.no, 'no').percentStr,
+                                abstain = poll.abstain ? poll.abstain : 0,
+                                abstainrelativeGet = poll.getVote(poll.abstain, 'abstain').percentStr,
+                                abstainRelative = abstainrelativeGet? abstainrelativeGet : "",
                                 valid = poll.votesvalid,
-                                validRelative = (poll.votesvalid) * 100 / (poll.votescast),
+                                validRelative = poll.getVote(poll.votesvalid, 'votesvalid').percentStr,
                                 number = {
                                     text: id + ".",
                                     width: "5%"
@@ -100,7 +101,7 @@ angular.module('OpenSlidesApp.motions.site', ['OpenSlidesApp.motions', 'OpenSlid
                                     var indexColumn = converter.createElement("text");
                                     var nameColumn = converter.createElement("text", "" + name);
                                     var valueColumn = converter.createElement("text", "" + value);
-                                    var relColumn = converter.createElement("text", "(" + "" + relValue + "%)");
+                                    var relColumn = converter.createElement("text", relValue);
                                     valueColumn.width = "40%";
                                     indexColumn.width = "5%";
                                     valueColumn.width = "5%";

--- a/openslides/motions/static/templates/motions/motion-detail.html
+++ b/openslides/motions/static/templates/motions/motion-detail.html
@@ -151,7 +151,7 @@
                   <tr>
                     <td class="icon">
                       <i class="fa fa-thumbs-up fa-2x"></i>
-                    <td ng-init="voteYes = poll.getVote(poll.yes)">
+                    <td ng-init="voteYes = poll.getVote(poll.yes, 'yes')">
                       <span class="result_label"><translate>Yes</translate>:</span>
                       <span class="result_value">
                         {{ voteYes.value }} {{ voteYes.percentStr }}
@@ -163,7 +163,7 @@
                   <tr>
                     <td class="icon">
                       <i class="fa fa-thumbs-down fa-2x"></i>
-                    <td ng-init="voteNo = poll.getVote(poll.no)">
+                    <td ng-init="voteNo = poll.getVote(poll.no, 'no')">
                       <span class="result_label"><translate>No</translate>:</span>
                       <span class="result_value" >
                         {{ voteNo.value }} {{ voteNo.percentStr }}
@@ -175,7 +175,7 @@
                   <tr>
                     <td class="icon">
                       <strong style="font-size: 26px">&empty;</strong>
-                    <td ng-init="voteAbstain = poll.getVote(poll.abstain)">
+                    <td ng-init="voteAbstain = poll.getVote(poll.abstain, 'abstain')">
                       <span class="result_label"><translate>Abstain</translate>:</span>
                       <span class="result_value">
                         {{ voteAbstain.value }} {{ voteAbstain.percentStr }}
@@ -187,7 +187,7 @@
                   <tr>
                     <td class="icon">
                       <i class="fa fa-check fa-lg"></i>
-                    <td ng-init="votesValid = poll.getVote(poll.votesvalid)">
+                    <td ng-init="votesValid = poll.getVote(poll.votesvalid, 'votesvalid')">
                       <span class="result_label"><translate>Valid votes</translate>:</span>
                       <span class="result_value">
                         {{ votesValid.value }} {{ votesValid.percentStr }}
@@ -196,7 +196,7 @@
                   <tr>
                     <td class="icon">
                       <i class="fa fa-ban fa-lg"></i>
-                    <td ng-init="votesInvalid = poll.getVote(poll.votesinvalid)">
+                    <td ng-init="votesInvalid = poll.getVote(poll.votesinvalid, 'votesinvalid')">
                       <span class="result_label"><translate>Invalid votes</translate>:</span>
                       <span class="result_value">
                         {{ votesInvalid.value }}
@@ -208,7 +208,7 @@
                   <tr class="total">
                     <td class="icon">
                       <strong style="font-size: 16px">&sum;</strong>
-                    <td ng-init="votesCast = poll.getVote(poll.votescast)">
+                    <td ng-init="votesCast = poll.getVote(poll.votescast, 'votescast')">
                       <span class="result_label"><translate>Votes cast</translate>:</span>
                       <span class="result_value">
                         {{ votesCast.value }}

--- a/openslides/motions/static/templates/motions/slide_motion.html
+++ b/openslides/motions/static/templates/motions/slide_motion.html
@@ -23,36 +23,36 @@
             <tr>
               <td class="icon">
                 <i class="fa fa-thumbs-up fa-2x"></i>
-              <td ng-init="voteYes = poll.getVote(poll.yes)">
+              <td ng-init="voteYes = poll.getVote(poll.yes, 'yes')">
                 <span class="result_label"><translate>Yes</translate>:</span>
                 <span class="result_value">
                   {{ voteYes.value }} {{ voteYes.percentStr }}
                 </span>
-                <div ng-if="voteYes.percentNumber">
+                <div ng-if="voteYes.percentNumber >= 0">
                   <uib-progressbar value="voteYes.percentNumber" type="success"></uib-progressbar>
                 </div>
             <!-- no -->
             <tr>
               <td class="icon">
                 <i class="fa fa-thumbs-down fa-2x"></i>
-              <td ng-init="voteNo = poll.getVote(poll.no)">
+              <td ng-init="voteNo = poll.getVote(poll.no, 'no')">
                 <span class="result_label"><translate>No</translate>:</span>
                 <span class="result_value" >
                   {{ voteNo.value }} {{ voteNo.percentStr }}
                 </span>
-                <div ng-if="voteNo.percentNumber">
+                <div ng-if="voteNo.percentNumber >= 0">
                   <uib-progressbar value="voteNo.percentNumber" type="danger"></uib-progressbar>
                 </div>
             <!-- abstain -->
             <tr>
               <td class="icon">
                 <strong style="font-size: 26px">&empty;</strong>
-              <td ng-init="voteAbstain = poll.getVote(poll.abstain)">
+              <td ng-init="voteAbstain = poll.getVote(poll.abstain, 'abstain')">
                 <span class="result_label"><translate>Abstain</translate>:</span>
                 <span class="result_value">
                   {{ voteAbstain.value }} {{ voteAbstain.percentStr }}
                 </span>
-                <div ng-if="voteAbstain.percentNumber">
+                <div ng-if="voteAbstain.percentNumber >= 0">
                   <uib-progressbar value="voteAbstain.percentNumber" type="warning"></uib-progressbar>
                 </div>
           </table>

--- a/openslides/poll/models.py
+++ b/openslides/poll/models.py
@@ -66,9 +66,8 @@ class BaseVote(models.Model):
             percent_base = 0
         return print_value(self.weight, percent_base)
 
-
 PERCENT_BASE_CHOICES = (
-    {'value': 'WITHOUT_INVALID', 'display_name': ugettext_lazy('Only all valid votes')},
+    {'value': 'WITHOUT_INVALID', 'display_name': ugettext_lazy('All valid votes (Yes/No/Abstain)')},
     {'value': 'WITH_INVALID', 'display_name': ugettext_lazy('All votes cast (including invalid votes)')},
     {'value': 'DISABLED', 'display_name': ugettext_lazy('Disabled (no percents)')})
 
@@ -119,9 +118,11 @@ class CollectDefaultVotesMixin(models.Model):
         return value
 
     def get_percent_base(self):
-        if self.get_percent_base_choice() == "WITHOUT_INVALID" and self.votesvalid and self.votesvalid > 0:
+        if self.get_percent_base_choice() == "WITHOUT_INVALID" and\
+                self.votesvalid and self.votesvalid > 0:
             base = 100 / float(self.votesvalid)
-        elif self.get_percent_base_choice() == "WITH_INVALID" and self.votescast and self.votescast > 0:
+        elif self.get_percent_base_choice() == "WITH_INVALID" and\
+                self.votescast and self.votescast > 0:
             base = 100 / float(self.votescast)
         else:
             base = None


### PR DESCRIPTION
The 100% base in this option is calculated by (valid votes  - abstains), making it necessary to know the "abstains" beforehand (in case of assignments), or knowing which type of vote 'vote' is (in case of motions).