### PR TITLE
Configure config default value with ugettext_lazy.

### DIFF
--- a/openslides/assignments/config_variables.py
+++ b/openslides/assignments/config_variables.py
@@ -1,5 +1,4 @@
 from django.core.validators import MinValueValidator
-from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
 
 from openslides.core.config import ConfigVariable
@@ -74,7 +73,7 @@ def get_config_variables():
 
     yield ConfigVariable(
         name='assignments_pdf_title',
-        default_value=_('Elections'),
+        default_value=ugettext_lazy('Elections'),
         label=ugettext_lazy('Title for PDF document (all elections)'),
         weight=460,
         group=ugettext_lazy('Elections'),

--- a/openslides/core/config_variables.py
+++ b/openslides/core/config_variables.py
@@ -1,5 +1,4 @@
 from django.core.validators import MaxLengthValidator
-from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
 
 from openslides.core.config import ConfigVariable
@@ -24,7 +23,7 @@ def get_config_variables():
 
     yield ConfigVariable(
         name='general_event_description',
-        default_value=_('Presentation and assembly system'),
+        default_value=ugettext_lazy('Presentation and assembly system'),
         label=ugettext_lazy('Short description of event'),
         weight=115,
         group=ugettext_lazy('General'),
@@ -58,7 +57,7 @@ def get_config_variables():
 
     yield ConfigVariable(
         name='general_event_legal_notice',
-        default_value=_(
+        default_value=ugettext_lazy(
             '<a href="http://www.openslides.org">OpenSlides</a> is a free web based '
             'presentation and assembly system for visualizing and controlling agenda, '
             'motions and elections of an assembly.'),
@@ -71,7 +70,7 @@ def get_config_variables():
 
     yield ConfigVariable(
         name='general_event_welcome_title',
-        default_value=_('Welcome to OpenSlides'),
+        default_value=ugettext_lazy('Welcome to OpenSlides'),
         label=ugettext_lazy('Front page title'),
         weight=134,
         group=ugettext_lazy('General'),
@@ -80,7 +79,7 @@ def get_config_variables():
 
     yield ConfigVariable(
         name='general_event_welcome_text',
-        default_value=_('[Space for your welcome text.]'),
+        default_value=ugettext_lazy('[Space for your welcome text.]'),
         input_type='text',
         label=ugettext_lazy('Front page text'),
         weight=136,

--- a/openslides/motions/config_variables.py
+++ b/openslides/motions/config_variables.py
@@ -1,6 +1,5 @@
 from django.core.validators import MinValueValidator
-from django.utils.translation import ugettext as _
-from django.utils.translation import pgettext, ugettext_lazy
+from django.utils.translation import pgettext_lazy, ugettext_lazy
 
 from openslides.core.config import ConfigVariable
 from openslides.poll.models import PERCENT_BASE_CHOICES
@@ -51,7 +50,7 @@ def get_config_variables():
 
     yield ConfigVariable(
         name='motions_preamble',
-        default_value=_('The assembly may decide,'),
+        default_value=ugettext_lazy('The assembly may decide,'),
         label=ugettext_lazy('Motion preamble'),
         weight=320,
         group=ugettext_lazy('Motions'),
@@ -90,7 +89,7 @@ def get_config_variables():
 
     yield ConfigVariable(
         name='motions_amendments_prefix',
-        default_value=pgettext('Prefix for the identifier for amendments', 'A'),
+        default_value=pgettext_lazy('Prefix for the identifier for amendments', 'A'),
         label=ugettext_lazy('Prefix for the identifier for amendments'),
         hidden=True,
         weight=340,
@@ -158,7 +157,7 @@ def get_config_variables():
 
     yield ConfigVariable(
         name='motions_pdf_title',
-        default_value=_('Motions'),
+        default_value=ugettext_lazy('Motions'),
         label=ugettext_lazy('Title for PDF document (all motions)'),
         weight=370,
         group=ugettext_lazy('Motions'),

--- a/openslides/users/config_variables.py
+++ b/openslides/users/config_variables.py
@@ -1,4 +1,3 @@
-from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
 
 from openslides.core.config import ConfigVariable
@@ -26,7 +25,7 @@ def get_config_variables():
 
     yield ConfigVariable(
         name='users_pdf_welcometitle',
-        default_value=_('Welcome to OpenSlides!'),
+        default_value=ugettext_lazy('Welcome to OpenSlides!'),
         label=ugettext_lazy('Title for access data and welcome PDF'),
         weight=520,
         group=ugettext_lazy('Users'),
@@ -35,7 +34,7 @@ def get_config_variables():
 
     yield ConfigVariable(
         name='users_pdf_welcometext',
-        default_value=_('[Place for your welcome and help text.]'),
+        default_value=ugettext_lazy('[Place for your welcome and help text.]'),
         label=ugettext_lazy('Help text for access data and welcome PDF'),
         weight=530,
         group=ugettext_lazy('Users'),


### PR DESCRIPTION
In 2.0 the config value was initialized per request and therefore with
the browser language. Now the config value is initialized at startup.

Fixes: #2193