### PR TITLE
sets language to en if no browser language is set

### DIFF
--- a/openslides/core/static/js/core/base.js
+++ b/openslides/core/static/js/core/base.js
@@ -106,10 +106,14 @@ angular.module('OpenSlidesApp.core', [
             // get detected browser language code
             getBrowserLanguage: function () {
                 var lang = navigator.language || navigator.userLanguage;
-                if (lang.indexOf('-') !== -1)
-                    lang = lang.split('-')[0];
-                if (lang.indexOf('_') !== -1)
-                    lang = lang.split('_')[0];
+                if (!navigator.language && !navigator.userLanguage) {
+                    lang = 'en';
+                } else {
+                    if (lang.indexOf('-') !== -1)
+                        lang = lang.split('-')[0];
+                    if (lang.indexOf('_') !== -1)
+                        lang = lang.split('_')[0];
+                }
                 return lang;
             },
             // set current language and return updated languages object array


### PR DESCRIPTION
When no language is set in the browser's setting, OpenSlides fails to start with a type error (at least in firefox). This PR fixes it by setting it to 'en'