### PR TITLE
Set channel requirement to lower 1.0. We have to use the newest development version

### DIFF
--- a/requirements_production.txt
+++ b/requirements_production.txt
@@ -1,7 +1,7 @@
 # Requirements for OpenSlides in production in alphabetical order
 Django>=1.8,<1.10
 beautifulsoup4>=4.4,<4.5
-channels>=0.14,<0.15
+channels>=0.15,<1.0
 djangorestframework>=3.2.0,<3.4.0
 html5lib>=0.9,<1.0
 jsonfield>=0.9.19,<1.1


### PR DESCRIPTION
Django channels installs other requirements that are developed in the same "project" but are different packages. But they are only compatible at the "same" version. Probably until 1.0 is ready and the api is frozen.
