### PR TITLE
Line numbers + Karma-based JS-testing

### DIFF
--- a/DEVELOPMENT.rst
+++ b/DEVELOPMENT.rst
@@ -96,3 +96,13 @@ To setup and activate the virtual environment in step c. use::
     > .virtualenv\Scripts\activate.bat
 
 All other commands are the same as for GNU/Linux and Mac OS X.
+
+
+3. Running the test cases
+-------------------------
+
+a. Running Angular.js test cases
+''''''''''''''''''''''''''''''''
+
+    $ node_modules/.bin/karma start tests/karma/karma.conf.js
+

--- a/openslides/core/static/css/app.css
+++ b/openslides/core/static/css/app.css
@@ -304,6 +304,53 @@ img {
 }
 
 
+/*** Line numbers ***/
+.motion-text.line-numbers-outside {
+    padding-left: 50px;
+    position: relative;
+}
+
+.motion-text.line-numbers-outside .os-line-number {
+    display: inline-block;
+}
+.motion-text.line-numbers-outside .os-line-number:after {
+    content: attr(data-line-number);
+    position: absolute;
+    left: 0;
+    vertical-align: top;
+    margin-top: -14px;
+    color: gray;
+    font-family: Courier, serif;
+    font-size: 13px;
+}
+
+.motion-text.line-numbers-inside .os-line-break {
+    display: none;
+}
+.motion-text.line-numbers-inside .os-line-number {
+    display: inline-block;
+}
+.motion-text.line-numbers-inside .os-line-number:after {
+    display: inline-block;
+    content: attr(data-line-number);
+    vertical-align: top;
+    font-size: 11px;
+    color: gray;
+    font-family: Courier, serif;
+    margin-top: -3px;
+    margin-left: 0;
+    margin-right: 3px;
+}
+
+
+.motion-text.line-numbers-none .os-line-break {
+    display: none;
+}
+.motion-text.line-numbers-none .os-line-number {
+    display: none;
+}
+
+
 /** Projector sidebar column **/
 
 #content .col2 {

--- a/openslides/core/static/css/projector.css
+++ b/openslides/core/static/css/projector.css
@@ -335,3 +335,51 @@ tr.elected td {
 .nextSpeakers li {
     line-height: 150%;
 }
+
+
+
+/*** Line numbers ***/
+.motion-text.line-numbers-outside {
+    padding-left: 0;
+    position: relative;
+}
+
+.motion-text.line-numbers-outside .os-line-number {
+    display: inline-block;
+}
+.motion-text.line-numbers-outside .os-line-number:after {
+    content: attr(data-line-number);
+    position: absolute;
+    left: -40px;
+    vertical-align: top;
+    margin-top: -19px;
+    color: gray;
+    font-family: Courier, serif;
+    font-size: 13px;
+}
+
+.motion-text.line-numbers-inside .os-line-break {
+    display: none;
+}
+.motion-text.line-numbers-inside .os-line-number {
+    display: inline-block;
+}
+.motion-text.line-numbers-inside .os-line-number:after {
+    display: inline-block;
+    content: attr(data-line-number);
+    vertical-align: top;
+    font-size: 11px;
+    color: gray;
+    font-family: Courier, serif;
+    margin-top: -3px;
+    margin-left: 0;
+    margin-right: 3px;
+}
+
+
+.motion-text.line-numbers-none .os-line-break {
+    display: none;
+}
+.motion-text.line-numbers-none .os-line-number {
+    display: none;
+}

--- a/openslides/motions/apps.py
+++ b/openslides/motions/apps.py
@@ -7,7 +7,7 @@ class MotionsAppConfig(AppConfig):
     verbose_name = 'OpenSlides Motion'
     angular_site_module = True
     angular_projector_module = True
-    js_files = ['js/motions/base.js', 'js/motions/site.js', 'js/motions/projector.js']
+    js_files = ['js/motions/base.js', 'js/motions/site.js', 'js/motions/projector.js', 'js/motions/linenumbering.js']
 
     def ready(self):
         # Load projector elements.

--- a/openslides/motions/config_variables.py
+++ b/openslides/motions/config_variables.py
@@ -57,6 +57,19 @@ def get_config_variables():
         translatable=True)
 
     yield ConfigVariable(
+        name='motions_default_line_numbering',
+        default_value='none',
+        input_type='choice',
+        label='Default line numbering',
+        choices=(
+            {'value': 'outside', 'display_name': 'Outside'},
+            {'value': 'inside', 'display_name': 'Inside'},
+            {'value': 'none', 'display_name': 'None'}),
+        weight=322,
+        group='Motions',
+        subgroup='General')
+
+    yield ConfigVariable(
         name='motions_stop_submitting',
         default_value=False,
         input_type='boolean',

--- a/openslides/motions/static/js/motions/base.js
+++ b/openslides/motions/static/js/motions/base.js
@@ -2,7 +2,7 @@
 
 "use strict";
 
-angular.module('OpenSlidesApp.motions', ['OpenSlidesApp.users'])
+angular.module('OpenSlidesApp.motions', ['OpenSlidesApp.users', 'OpenSlidesApp.motions.lineNumbering'])
 
 .factory('WorkflowState', [
     'DS',
@@ -112,7 +112,8 @@ angular.module('OpenSlidesApp.motions', ['OpenSlidesApp.users'])
     'gettext',
     'operator',
     'Config',
-    function(DS, MotionPoll, jsDataModel, gettext, operator, Config) {
+    'lineNumberingService',
+    function(DS, MotionPoll, jsDataModel, gettext, operator, Config, lineNumberingService) {
         var name = 'motions/motion';
         return DS.defineResource({
             name: name,
@@ -139,6 +140,12 @@ angular.module('OpenSlidesApp.motions', ['OpenSlidesApp.users'])
                 },
                 getText: function (versionId) {
                     return this.getVersion(versionId).text;
+                },
+                getTextWithLineBreaks: function (versionId) {
+                    var html = this.getVersion(versionId).text,
+                        withBreaks = lineNumberingService.insertLineNumbers(html);
+
+                    return withBreaks;
                 },
                 getReason: function (versionId) {
                     return this.getVersion(versionId).reason;

--- a/openslides/motions/static/js/motions/linenumbering.js
+++ b/openslides/motions/static/js/motions/linenumbering.js
@@ -1,0 +1,311 @@
+(function () {
+
+"use strict";
+
+angular.module('OpenSlidesApp.motions.lineNumbering', [])
+
+/**
+ * Current limitations of this implementation:
+ *
+ * Only the following inline elements are supported:
+ * - 'SPAN', 'A', 'EM', 'S', 'B', 'I', 'STRONG', 'U', 'BIG', 'SMALL', 'SUB', 'SUP', 'TT'
+ *
+ * Only other inline elements are allowed within inline elements.
+ * No constructs like <a...><div></div></a> are allowed. CSS-attributes like 'display: block' are ignored.
+ */
+
+.service('lineNumberingService', function () {
+    var ELEMENT_NODE = 1,
+        TEXT_NODE = 3;
+
+    this.lineLength = 80;
+    this._currentInlineOffset = null;
+    this._currentLineNumber = null;
+    this._prependLineNumberToFirstText = false;
+
+    this.setLineLength = function (length) {
+        this.lineLength = length;
+    };
+
+    this._isInlineElement = function (node) {
+        var inlineElements = [
+            'SPAN', 'A', 'EM', 'S', 'B', 'I', 'STRONG', 'U', 'BIG', 'SMALL', 'SUB', 'SUP', 'TT'
+        ];
+        return (inlineElements.indexOf(node.nodeName) > -1);
+    };
+
+    this._isOsLineBreakNode = function (node) {
+        if (!node) {
+            return false;
+        }
+        if (node.nodeType !== ELEMENT_NODE || node.nodeName != 'BR') {
+            return false;
+        }
+        if (!node.hasAttribute('class')) {
+            return false;
+        }
+        var classes = node.getAttribute('class').split(' ');
+        return (classes.indexOf('os-line-break') > -1);
+    };
+    this._isOsLineNumberNode = function (node) {
+        if (!node) {
+            return false;
+        }
+        if (node.nodeType !== ELEMENT_NODE || node.nodeName != 'SPAN') {
+            return false;
+        }
+        if (!node.hasAttribute('class')) {
+            return false;
+        }
+        var classes = node.getAttribute('class').split(' ');
+        return (classes.indexOf('os-line-number') > -1);
+    };
+
+    /**
+     * Splits a TEXT_NODE into an array of TEXT_NODEs and BR-Elements separating them into lines.
+     * Each line has a maximum length of 'length', with one exception: spaces are accepted to exceed the length.
+     * Otherwise the string is split by the last space or dash in the line.
+     *
+     * @param node
+     * @param length
+     * @returns Array
+     * @private
+     */
+    this._textNodeToLines = function (node, length) {
+        var out = [],
+            currLineStart = 0,
+            i = 0,
+            firstTextNode = true,
+            lastBreakableIndex = null,
+            service = this;
+
+        var createLineBreak = function() {
+            var br = document.createElement('br');
+                br.setAttribute('class', 'os-line-break');
+                return br;
+            };
+        var createLineNumber = function() {
+            var node = document.createElement('span');
+            var lineNumber = service._currentLineNumber;
+            service._currentLineNumber++;
+            node.setAttribute('class', 'os-line-number line-number-' + lineNumber);
+            node.setAttribute('data-line-number', lineNumber + '');
+            return node;
+        };
+        var addLine = function (text) {
+            var newNode = document.createTextNode(text);
+            if (firstTextNode) {
+                firstTextNode = false;
+            } else {
+                out.push(createLineBreak());
+                out.push(createLineNumber());
+            }
+            out.push(newNode)
+        };
+
+        if (node.nodeValue == "\n") {
+            out.push(node);
+            return out;
+        }
+
+        // This happens if a previous inline element exactly stretches to the end of the line
+        if (this._currentInlineOffset >= length) {
+            out.push(createLineBreak());
+            out.push(createLineNumber());
+            this._currentInlineOffset = 0;
+        } else if (this._prependLineNumberToFirstText) {
+            out.push(createLineNumber());
+        }
+        this._prependLineNumberToFirstText = false;
+
+        while (i < node.nodeValue.length) {
+            var lineBreakAt = null;
+            if (this._currentInlineOffset >= length) {
+                if (lastBreakableIndex !== null) {
+                    lineBreakAt = lastBreakableIndex;
+                } else {
+                    lineBreakAt = i - 1;
+                }
+            }
+            if (lineBreakAt !== null && node.nodeValue[i] != ' ') {
+                var currLine = node.nodeValue.substring(currLineStart, lineBreakAt + 1);
+                addLine(currLine);
+
+                currLineStart = lineBreakAt + 1;
+                this._currentInlineOffset = i - lineBreakAt - 1;
+                lastBreakableIndex = null;
+            }
+
+            if (node.nodeValue[i] == ' ' || node.nodeValue[i] == '-') {
+                lastBreakableIndex = i;
+            }
+
+            this._currentInlineOffset++;
+            i++;
+
+        }
+        addLine(node.nodeValue.substring(currLineStart));
+
+        return out;
+    };
+
+
+    /**
+     * Moves line breaking and line numbering markup before inline elements
+     *
+     * @param innerNode
+     * @param outerNode
+     * @private
+     */
+    this._moveLeadingLineBreaksToOuterNode = function (innerNode, outerNode) {
+        if (!this._isInlineElement(innerNode)) {
+            return;
+        }
+        if (this._isOsLineBreakNode(innerNode.firstChild)) {
+            var br = innerNode.firstChild;
+            innerNode.removeChild(br);
+            outerNode.appendChild(br);
+        }
+        if (this._isOsLineNumberNode(innerNode.firstChild)) {
+            var span = innerNode.firstChild;
+            innerNode.removeChild(span);
+            outerNode.appendChild(span);
+        }
+    };
+
+
+    this._insertLineNumbersToInlineNode = function (node, length) {
+        var oldChildren = [], i;
+        for (i = 0; i < node.childNodes.length; i++) {
+            oldChildren.push(node.childNodes[i]);
+        }
+
+        while (node.firstChild) {
+            node.removeChild(node.firstChild);
+        }
+
+        for (i = 0; i < oldChildren.length; i++) {
+            if (oldChildren[i].nodeType == TEXT_NODE) {
+                var ret = this._textNodeToLines(oldChildren[i], length);
+                for (var j = 0; j < ret.length; j++) {
+                    node.appendChild(ret[j]);
+                }
+            } else if (oldChildren[i].nodeType == ELEMENT_NODE) {
+                var changedNode = this._insertLineNumbersToNode(oldChildren[i], length);
+                this._moveLeadingLineBreaksToOuterNode(changedNode, node);
+                node.appendChild(changedNode);
+            } else {
+                throw 'Unknown nodeType: ' + i + ': ' + oldChildren[i];
+            }
+        }
+
+        return node;
+    };
+
+    this._calcBlockNodeLength = function (node, oldLength) {
+        if (node.nodeName == 'LI') {
+            return oldLength - 5;
+        }
+        if (node.nodeName == 'BLOCKQUOTE') {
+            return oldLength - 20;
+        }
+        if (node.nodeName == 'DIV' || node.nodeName == 'P') {
+            var styles = node.getAttribute("style"),
+                padding = 0;
+            if (styles) {
+                var leftpad = styles.split("padding-left:");
+                if (leftpad.length > 1) {
+                    leftpad = parseInt(leftpad[1]);
+                    padding += leftpad;
+                }
+                var rightpad = styles.split("padding-right:");
+                if (rightpad.length > 1) {
+                    rightpad = parseInt(rightpad[1]);
+                    padding += rightpad;
+                }
+                return oldLength - Math.ceil(padding / 5);
+            }
+        }
+        if (node.nodeName == 'H1') {
+            return Math.ceil(oldLength * 0.5);
+        }
+        if (node.nodeName == 'H2') {
+            return Math.ceil(oldLength * 0.66);
+        }
+        if (node.nodeName == 'H3') {
+            return Math.ceil(oldLength * 0.66);
+        }
+        return oldLength;
+    };
+
+    this._insertLineNumbersToBlockNode = function (node, length) {
+        this._currentInlineOffset = 0;
+        this._prependLineNumberToFirstText = true;
+
+        var oldChildren = [], i;
+        for (i = 0; i < node.childNodes.length; i++) {
+            oldChildren.push(node.childNodes[i]);
+        }
+
+        while (node.firstChild) {
+            node.removeChild(node.firstChild);
+        }
+
+        for (i = 0; i < oldChildren.length; i++) {
+            if (oldChildren[i].nodeType == TEXT_NODE) {
+                var ret = this._textNodeToLines(oldChildren[i], length);
+                for (var j = 0; j < ret.length; j++) {
+                    node.appendChild(ret[j]);
+                }
+            } else if (oldChildren[i].nodeType == ELEMENT_NODE) {
+                var changedNode = this._insertLineNumbersToNode(oldChildren[i], length);
+                this._moveLeadingLineBreaksToOuterNode(changedNode, node);
+                node.appendChild(changedNode);
+            } else {
+                throw 'Unknown nodeType: ' + i + ': ' + oldChildren[i];
+            }
+        }
+
+        this._currentInlineOffset = 0;
+        this._prependLineNumberToFirstText = true;
+
+        return node;
+    };
+
+    this._insertLineNumbersToNode = function (node, length) {
+        if (node.nodeType !== ELEMENT_NODE) {
+            throw 'This method may only be called for ELEMENT-nodes: ' + node.nodeValue;
+        }
+        if (this._isInlineElement(node)) {
+            return this._insertLineNumbersToInlineNode(node, length);
+        } else {
+            var newLength = this._calcBlockNodeLength(node, length);
+            return this._insertLineNumbersToBlockNode(node, newLength);
+        }
+    };
+
+    this._nodesToHtml = function (nodes) {
+        var root = document.createElement('div');
+        for (var i in nodes) {
+            if (nodes.hasOwnProperty(i)) {
+                root.appendChild(nodes[i]);
+            }
+        }
+        return root.innerHTML;
+    };
+
+    this.insertLineNumbers = function (html) {
+        var root = document.createElement('div');
+        root.innerHTML = html;
+
+        this._currentInlineOffset = 0;
+        this._currentLineNumber = 1;
+        this._prependLineNumberToFirstText = true;
+        var newRoot = this._insertLineNumbersToNode(root, this.lineLength);
+
+        return newRoot.innerHTML;
+    }
+});
+
+
+}());

--- a/openslides/motions/static/js/motions/projector.js
+++ b/openslides/motions/static/js/motions/projector.js
@@ -17,7 +17,8 @@ angular.module('OpenSlidesApp.motions.projector', ['OpenSlidesApp.motions'])
     '$scope',
     'Motion',
     'User',
-    function($scope, Motion, User) {
+    'Config',
+    function($scope, Motion, User, Config) {
         // Attention! Each object that is used here has to be dealt on server side.
         // Add it to the coresponding get_requirements method of the ProjectorElement
         // class.
@@ -32,6 +33,8 @@ angular.module('OpenSlidesApp.motions.projector', ['OpenSlidesApp.motions'])
         // load all users
         User.findAll();
         User.bindAll({}, $scope, 'users');
+
+        Config.bindOne('motions_default_line_numbering', $scope, 'line_numbering');
     }
 ]);
 

--- a/openslides/motions/static/js/motions/site.js
+++ b/openslides/motions/static/js/motions/site.js
@@ -550,8 +550,9 @@ angular.module('OpenSlidesApp.motions.site', ['OpenSlidesApp.motions'])
     'Tag',
     'User',
     'Workflow',
+    'Config',
     'motion',
-    function($scope, $http, ngDialog, MotionForm, Motion, Category, Mediafile, Tag, User, Workflow, motion) {
+    function($scope, $http, ngDialog, MotionForm, Motion, Category, Mediafile, Tag, User, Workflow, Config, motion) {
         Motion.bindOne(motion.id, $scope, 'motion');
         Category.bindAll({}, $scope, 'categories');
         Mediafile.bindAll({}, $scope, 'mediafiles');
@@ -561,6 +562,7 @@ angular.module('OpenSlidesApp.motions.site', ['OpenSlidesApp.motions'])
         Motion.loadRelations(motion, 'agenda_item');
         $scope.version = motion.active_version;
         $scope.isCollapsed = true;
+        $scope.lineNumberMode = Config.get('motions_default_line_numbering').value;
 
         // open edit dialog
         $scope.openDialog = function (motion) {

--- a/openslides/motions/static/templates/motions/motion-detail.html
+++ b/openslides/motions/static/templates/motions/motion-detail.html
@@ -225,7 +225,7 @@
   <div class="row">
     <div class="col-sm-8">
       <h3 translate>Text</h3>
-      <div ng-bind-html="motion.getText(version) | trusted"></div>
+      <div ng-bind-html="motion.getTextWithLineBreaks(version) | trusted" class="motion-text line-numbers-{{ lineNumberMode }}"></div>
 
       <!-- reason -->
       <div ng-if="motion.getReason(version) != ''">
@@ -273,17 +273,42 @@
         </ul>
       </div>
 
-      <!-- log -->
-      <button type="button" class="btn btn-default spacer" ng-click="isCollapsed = !isCollapsed" translate>
-        Show history
-      </button>
-      <div uib-collapse="isCollapsed">
+      <div class="row spacer">
+        <div class="col-md-1">
+
+          <!-- switching line numbering mode -->
+          <div class="dropdown">
+            <button class="btn btn-default dropdown-toggle" type="button" id="lineNumberTypeBtn" data-toggle="dropdown"
+                    aria-haspopup="true" aria-expanded="true" title="{{ 'Switch line numbering' | translate }}">
+              <span class="glypicon glyphicon glyphicon-sort-by-order"></span>
+            </button>
+            <ul class="dropdown-menu" aria-labelledby="lineNumberTypeBtn">
+              <li class="dropdown-header"><translate>Line Numbering</translate></li>
+              <li><a href="#" ng-click="lineNumberMode = 'inside';"><translate>Inline</translate></a></li>
+              <li><a href="#" ng-click="lineNumberMode = 'outside';"><translate>Outside</translate></a></li>
+              <li><a href="#" ng-click="lineNumberMode = 'none';"><translate>None</translate></a></li>
+            </ul>
+          </div>
+
+        </div>
+        <div class="col-md-11">
+
+          <!-- log -->
+          <button type="button" class="btn btn-default" ng-click="isCollapsed = !isCollapsed" translate>
+            Show history
+          </button>
+        </div>
+      </div>
+      <div uib-collapse="isCollapsed" class="spacer">
         <div class="well well-sm">
           <ul class="list-unstyled">
             <li ng-repeat="message in motion.log_messages">
               <small>{{ message.message }}</small>
+            </li>
+          </ul>
         </div>
       </div>
+
     </div>
 
   </div>

--- a/openslides/motions/static/templates/motions/slide_motion.html
+++ b/openslides/motions/static/templates/motions/slide_motion.html
@@ -70,7 +70,7 @@
   </div>
 
   <!-- Text -->
-  <div ng-bind-html="motion.getText() | trusted"></div>
+  <div ng-bind-html="motion.getTextWithLineBreaks() | trusted" class="motion-text line-numbers-{{ line_numbering.value }}"></div>
 
   <!-- Reason -->
   <h3 ng-if="motion.getReason()" translate>Reason</h3>

--- a/package.json
+++ b/package.json
@@ -20,6 +20,12 @@
     "po2json": "~0.4.1",
     "sprintf-js": "~1.0.3",
     "through2": "~2.0.0",
-    "yargs": "~3.32.0"
+    "yargs": "~3.32.0",
+
+    "karma": "~1.0.0",
+    "karma-jasmine": "~1.0.2",
+    "karma-chrome-launcher": "~1.0.1",
+    "jasmine": "~2.4.1",
+    "angular-mocks": "~1.5.7"
   }
 }

--- a/tests/karma/karma.conf.js
+++ b/tests/karma/karma.conf.js
@@ -1,0 +1,72 @@
+// Karma configuration
+// Generated on Sun Jun 26 2016 14:46:31 GMT+0200 (CEST)
+
+module.exports = function(config) {
+  config.set({
+
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '../..',
+
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['jasmine'],
+
+
+    // list of files / patterns to load in the browser
+    files: [
+      'openslides/static/js/openslides-libs.js',
+      'node_modules/angular-mocks/angular-mocks.js',
+      'openslides/motions/static/js/motions/linenumbering.js',
+      'tests/karma/*/*.test.js'
+    ],
+
+
+    // list of files to exclude
+    exclude: [
+    ],
+
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+    },
+
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: ['progress'],
+
+
+    // web server port
+    port: 9876,
+
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: true,
+
+
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: ['Chrome'],
+
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: false,
+
+    // Concurrency level
+    // how many browser should be started simultaneous
+    concurrency: Infinity
+  })
+}

--- a/tests/karma/motions/linenumbering.service.test.js
+++ b/tests/karma/motions/linenumbering.service.test.js
@@ -1,0 +1,204 @@
+describe('linenumbering', function () {
+
+  beforeEach(module('OpenSlidesApp.motions.lineNumbering'));
+
+  var lineNumberingService,
+      brMarkup = function (no) {
+        return '<br class="os-line-break">' +
+            '<span class="os-line-number line-number-' + no + '" data-line-number="' + no + '"></span>';
+      },
+      noMarkup = function (no) {
+        return '<span class="os-line-number line-number-' + no + '" data-line-number="' + no + '"></span>';
+      },
+      longstr = function (length) {
+        var outstr = '';
+        for (var i = 0; i < length; i++) {
+          outstr += String.fromCharCode(65 + (i % 26));
+        }
+        return outstr;
+      };
+
+  beforeEach(inject(function (_lineNumberingService_) {
+    lineNumberingService = _lineNumberingService_;
+  }));
+
+  describe('line numbering: test nodes', function () {
+    it('breaks very short lines', function () {
+      var textNode = document.createTextNode("0123");
+      lineNumberingService._currentInlineOffset = 0;
+      var out = lineNumberingService._textNodeToLines(textNode, 5);
+      var outHtml = lineNumberingService._nodesToHtml(out);
+      expect(outHtml).toBe('0123');
+      expect(lineNumberingService._currentInlineOffset).toBe(4);
+    });
+
+    it('breaks simple lines', function () {
+      var textNode = document.createTextNode("012345678901234567");
+      lineNumberingService._currentInlineOffset = 0;
+      lineNumberingService._currentLineNumber = 1;
+      var out = lineNumberingService._textNodeToLines(textNode, 5);
+      var outHtml = lineNumberingService._nodesToHtml(out);
+      expect(outHtml).toBe('01234' + brMarkup(1) + '56789' + brMarkup(2) + '01234' + brMarkup(3) + '567');
+      expect(lineNumberingService._currentInlineOffset).toBe(3);
+    });
+
+    it('breaks simple lines with offset', function () {
+      var textNode = document.createTextNode("012345678901234567");
+      lineNumberingService._currentInlineOffset = 2;
+      lineNumberingService._currentLineNumber = 1;
+      var out = lineNumberingService._textNodeToLines(textNode, 5);
+      var outHtml = lineNumberingService._nodesToHtml(out);
+      expect(outHtml).toBe('012' + brMarkup(1) + '34567' + brMarkup(2) + '89012' + brMarkup(3) + '34567');
+      expect(lineNumberingService._currentInlineOffset).toBe(5);
+    });
+
+    it('breaks simple lines with offset equaling to length', function () {
+      var textNode = document.createTextNode("012345678901234567");
+      lineNumberingService._currentInlineOffset = 5;
+      lineNumberingService._currentLineNumber = 1;
+      var out = lineNumberingService._textNodeToLines(textNode, 5);
+      var outHtml = lineNumberingService._nodesToHtml(out);
+      expect(outHtml).toBe(brMarkup(1) + '01234' + brMarkup(2) + '56789' + brMarkup(3) + '01234' + brMarkup(4) + '567');
+      expect(lineNumberingService._currentInlineOffset).toBe(3);
+    });
+
+    it('breaks simple lines with spaces (1)', function () {
+      var textNode = document.createTextNode("0123 45 67 89012 34 567");
+      lineNumberingService._currentInlineOffset = 0;
+      lineNumberingService._currentLineNumber = 1;
+      var out = lineNumberingService._textNodeToLines(textNode, 5);
+      var outHtml = lineNumberingService._nodesToHtml(out);
+      expect(outHtml).toBe('0123 ' + brMarkup(1) + '45 67 ' + brMarkup(2) + '89012 ' + brMarkup(3) + '34 ' + brMarkup(4) + '567');
+      expect(lineNumberingService._currentInlineOffset).toBe(3);
+    });
+
+    it('breaks simple lines with spaces (2)', function () {
+      var textNode = document.createTextNode("0123 45 67 89012tes 344 ");
+      lineNumberingService._currentInlineOffset = 0;
+      lineNumberingService._currentLineNumber = 1;
+      var out = lineNumberingService._textNodeToLines(textNode, 5);
+      var outHtml = lineNumberingService._nodesToHtml(out);
+      expect(outHtml).toBe('0123 ' + brMarkup(1) + '45 67 ' + brMarkup(2) + '89012' + brMarkup(3) + 'tes ' + brMarkup(4) + '344 ');
+      expect(lineNumberingService._currentInlineOffset).toBe(4);
+    });
+
+    it('breaks simple lines with spaces (3)', function () {
+      var textNode = document.createTextNode("I'm a Demo-Text");
+      lineNumberingService._currentInlineOffset = 0;
+      lineNumberingService._currentLineNumber = 1;
+      var out = lineNumberingService._textNodeToLines(textNode, 5);
+      var outHtml = lineNumberingService._nodesToHtml(out);
+      expect(outHtml).toBe('I\'m a ' + brMarkup(1) + 'Demo-' + brMarkup(2) + 'Text');
+      expect(lineNumberingService._currentInlineOffset).toBe(4);
+    });
+
+    it('breaks simple lines with spaces (4)', function () {
+      var textNode = document.createTextNode("I'm a LongDemo-Text");
+      lineNumberingService._currentInlineOffset = 0;
+      lineNumberingService._currentLineNumber = 1;
+      var out = lineNumberingService._textNodeToLines(textNode, 5);
+      var outHtml = lineNumberingService._nodesToHtml(out);
+      expect(outHtml).toBe('I\'m a ' + brMarkup(1) + 'LongD' + brMarkup(2) + 'emo-' + brMarkup(3) + 'Text');
+      expect(lineNumberingService._currentInlineOffset).toBe(4);
+    });
+  });
+
+
+  describe('line numbering: inline nodes', function () {
+    it('leaves a simple SPAN untouched', function () {
+      lineNumberingService.setLineLength(5);
+      var outHtml = lineNumberingService.insertLineNumbers("<span>Test</span>");
+      expect(outHtml).toBe(noMarkup(1) + '<span>Test</span>');
+    });
+
+    it('breaks lines in a simple SPAN', function () {
+      lineNumberingService.setLineLength(5);
+      var outHtml = lineNumberingService.insertLineNumbers("<span>Lorem ipsum dolorsit amet</span>");
+      expect(outHtml).toBe(noMarkup(1) + '<span>Lorem ' + brMarkup(2) + 'ipsum ' + brMarkup(3) + 'dolor' + brMarkup(4) + 'sit ' + brMarkup(5) + 'amet</span>');
+    });
+
+    it('breaks lines in nested inline elements', function () {
+      lineNumberingService.setLineLength(5);
+      var outHtml = lineNumberingService.insertLineNumbers("<span>Lorem <strong>ipsum dolorsit</strong> amet</span>");
+      expect(outHtml).toBe(noMarkup(1) + '<span>Lorem ' + brMarkup(2) + '<strong>ipsum ' + brMarkup(3) + 'dolor' + brMarkup(4) + 'sit</strong> ' + brMarkup(5) + 'amet</span>');
+    });
+  });
+
+
+  describe('line numbering: block nodes', function () {
+    it('leaves a simple DIV untouched', function () {
+      lineNumberingService.setLineLength(5);
+      var outHtml = lineNumberingService.insertLineNumbers("<div>Test</div>");
+      expect(outHtml).toBe('<div>' + noMarkup(1) + 'Test</div>');
+    });
+
+    it('breaks a DIV containing only inline elements', function () {
+      lineNumberingService.setLineLength(5);
+      var outHtml = lineNumberingService.insertLineNumbers("<div>Test <span>Test1234</span>5678 Test</div>");
+      expect(outHtml).toBe('<div>' + noMarkup(1) + 'Test ' + brMarkup(2) + '<span>Test1' + brMarkup(3) + '234</span>56' + brMarkup(4) + '78 ' + brMarkup(5) + 'Test</div>');
+    });
+
+    it('handles a DIV within a DIV correctly', function () {
+      lineNumberingService.setLineLength(5);
+      var outHtml = lineNumberingService.insertLineNumbers("<div>Te<div>Te Test</div>Test");
+      expect(outHtml).toBe('<div>' + noMarkup(1) + 'Te<div>' + noMarkup(2) + 'Te ' + brMarkup(3) + 'Test</div>' + noMarkup(4) + 'Test</div>');
+    });
+
+    it('ignores white spaces between block element tags', function () {
+      var inHtml = "<ul>\n<li>Test</li>\n</ul>";
+      var outHtml = lineNumberingService.insertLineNumbers(inHtml);
+      expect(outHtml).toBe("<ul>\n<li>" + noMarkup(1) + 'Test</li>\n</ul>');
+    });
+  });
+
+
+  describe('indentation for block elements', function () {
+    it('indents LI-elements', function () {
+      var inHtml = '<div>' +longstr(100) + '<ul><li>' + longstr(100) + '</li></ul>' + longstr(100) + '</div>';
+      var expected = '<div>' + noMarkup(1) +
+          'ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZAB' + brMarkup(2) + 'CDEFGHIJKLMNOPQRSTUV' +
+          '<ul><li>' + noMarkup(3) +
+          'ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVW' + brMarkup(4) + 'XYZABCDEFGHIJKLMNOPQRSTUV' +
+          '</li></ul>' + noMarkup(5) +
+          'ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZAB' + brMarkup(6) + 'CDEFGHIJKLMNOPQRSTUV</div>';
+      var outHtml = lineNumberingService.insertLineNumbers(inHtml);
+      expect(outHtml).toBe(expected);
+    });
+
+    it('indents BLOCKQUOTE-elements', function () {
+      var inHtml = '<div>' +longstr(100) + '<blockquote>' + longstr(100) + '</blockquote>' + longstr(100) + '</div>';
+      var expected = '<div>' + noMarkup(1) +
+          'ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZAB' + brMarkup(2) + 'CDEFGHIJKLMNOPQRSTUV' +
+          '<blockquote>' + noMarkup(3) +
+          'ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGH' + brMarkup(4) + 'IJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUV' +
+          '</blockquote>' + noMarkup(5) +
+          'ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZAB' + brMarkup(6) + 'CDEFGHIJKLMNOPQRSTUV</div>';
+      var outHtml = lineNumberingService.insertLineNumbers(inHtml);
+      expect(outHtml).toBe(expected);
+    });
+
+    it('shortens the line for H1-elements by 1/2', function () {
+      var inHtml = '<h1>' + longstr(80) + '</h1>';
+      var expected = '<h1>' + noMarkup(1) + 'ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMN' +
+          brMarkup(2) + 'OPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZAB</h1>';
+      var outHtml = lineNumberingService.insertLineNumbers(inHtml);
+      expect(outHtml).toBe(expected);
+    });
+
+    it('shortens the line for H2-elements by 2/3', function () {
+      var inHtml = '<h2>' + longstr(80) + '</h2>';
+      var expected = '<h2>' + noMarkup(1) + 'ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZA' +
+          brMarkup(2) + 'BCDEFGHIJKLMNOPQRSTUVWXYZAB</h2>';
+      var outHtml = lineNumberingService.insertLineNumbers(inHtml);
+      expect(outHtml).toBe(expected);
+    });
+
+    it('indents Ps with 30px-padding by 6 characters', function () {
+      var inHtml = '<div style="padding-left: 30px;">' + longstr(80) + '</div>';
+      var expected = '<div style="padding-left: 30px;">' + noMarkup(1) + 'ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUV' +
+          brMarkup(2) + 'WXYZAB</div>';
+      var outHtml = lineNumberingService.insertLineNumbers(inHtml);
+      expect(outHtml).toBe(expected);
+    });
+  });
+});


### PR DESCRIPTION
Line numbers are disabled by default. You can activate them in the configuration in the "Motions"-section.

In the Motion-Detail-View, you can switch the line numbering on the bottom left.
The projector-view always uses the default line numbering as set in the configuration.

What's still missing: internationalization of the strings, configurable line length & more