### PR TITLE
add "delete all speakers" button (feature, issue #2210)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,9 @@ Version 2.1 (unreleased)
 ========================
 [https://github.com/OpenSlides/OpenSlides/milestones/2.1]
 
+Agenda: 
+- Added button to remove all speakers from a list of speakers.
+
 Core:
 - Used Django Channels instead of Tornado.
 - Added support for big assemblies with lots of users.

--- a/openslides/agenda/static/js/agenda/site.js
+++ b/openslides/agenda/static/js/agenda/site.js
@@ -290,6 +290,26 @@ angular.module('OpenSlidesApp.agenda.site', ['OpenSlidesApp.agenda'])
             $scope.speakers = item.speakers;
         };
 
+        //delete all speakers from list of speakers
+        $scope.removeAllSpeakers = function () {
+            var speakersOnList = [];
+            angular.forEach(item.speakers, function (speaker) {
+                speakersOnList.push(speaker.id);
+            });
+            $http.delete(
+                '/rest/agenda/item/' + item.id + '/manage_speaker/',
+                {headers: {'Content-Type': 'application/json'},
+                 data: JSON.stringify({speaker: speakersOnList})}
+            )
+            .success(function(data){
+                $scope.speakers = item.speakers;
+            })
+            .error(function(data){
+                $scope.alert = { type: 'danger', msg: data.detail, show: true };
+            });
+            $scope.speakers = item.speakers;
+        };
+
         // check if user is allowed to see 'add me' / 'remove me' button
         $scope.isAllowed = function (action) {
             var nextUsers = [];

--- a/openslides/agenda/static/templates/agenda/item-detail.html
+++ b/openslides/agenda/static/templates/agenda/item-detail.html
@@ -37,6 +37,12 @@
 <div ng-if="item" class="details listOfSpeakers">
   <div class="pull-right">
     <span os-perms="agenda.can_manage">
+      <button class="btn btn-danger"
+          ng-bootbox-confirm="{{ 'Are you sure you want to remove all speakers from this list?'| translate }}"
+          ng-bootbox-confirm-action="removeAllSpeakers()">
+          <i class="fa fa-trash fa-lg"></i>
+          <translate>Remove all speakers</translate>
+      </button>
       <button ng-if="item.speaker_list_closed" ng-click="closeList(false)"
           class="btn btn-sm btn-default">
         <i class="fa fa-toggle-off"></i>


### PR DESCRIPTION
Feature: Added a new option on the agenda's speaker list: A button that, when pressed, deletes all speakers (current, previous, queued). I am not sure if an additional "confirm" dialog should be included before actually deleting the list