### PR TITLE
Fix travis: upgrade setuptools before install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
   - "3.4"
   - "3.5"
 install:
+  - "pip install --upgrade setuptools"
   - "pip install --upgrade --requirement requirements.txt"
   - "npm install"
   - "node_modules/.bin/gulp --production"

--- a/requirements_production.txt
+++ b/requirements_production.txt
@@ -1,6 +1,6 @@
 # Requirements for OpenSlides in production in alphabetical order
 Django>=1.8,<1.10
-beautifulsoup4>=4.4,<4.5
+beautifulsoup4>=4.5,<4.6
 channels>=0.15,<1.0
 djangorestframework>=3.2.0,<3.4.0
 html5lib>=0.9,<1.0
@@ -9,6 +9,6 @@ natsort>=3.2,<4.1
 PyPDF2>=1.25.0,<1.26
 reportlab>=3.0,<3.4
 roman>=2.0,<2.1
-setuptools>=2.2,<21.0
+setuptools>=18.5,<26.0
 sockjs-tornado>=1.0.1,<1.1
 Whoosh>=2.7.0,<2.8


### PR DESCRIPTION
Upgrade setuptools to 18.5+.
Upgrade beautifulsoup4 to 4.5+ to work with latest html5lib.