### PR TITLE
Current list of speakers view (fixes #2212)

### DIFF
--- a/openslides/agenda/static/templates/agenda/current-list-of-speakers.html
+++ b/openslides/agenda/static/templates/agenda/current-list-of-speakers.html
@@ -1,0 +1,48 @@
+<div class="header">
+  <div class="title">
+    <div class="submenu">
+      <button ng-click="isFullScreen = !isFullScreen"
+        class="btn btn-sm btn-default">
+        <i class="fa fa-plus fa-lg"></i>
+        <translate>Fullscreen</translate>
+      </button>
+      <button os-perms="agenda.can_manage"
+        ng-click="goToListOfSpeakers()"
+        class="btn btn-sm btn-default">
+        <i class="fa fa-microphone"></i>
+        <translate>Manage list</translate>
+      </button>
+    </div>
+    <h1 translate>List of speakers</h1>
+    <h2> {{ AgendaItem.getTitle() }}
+      <span class="slimlabel label label-danger ng-scope" style="" ng-if="AgendaItem.speaker_list_closed" translate>
+        Closed
+      </span>
+    </h2>
+</div>
+
+<div class="content" ng-class="isFullScreen ? 'fullscreendiv' : 'details'"
+  ng-click="isFullScreen? (isFullScreen = !isFullScreen) : a">
+  <div ng-if="isFullScreen" class="fullscreendiv-title">
+    <h1 translate>List of speakers</h1>
+    <h2> {{ AgendaItem.getTitle() }}
+      <span class="slimlabel label label-danger ng-scope" style="" 
+        ng-if="AgendaItem.speaker_list_closed" translate>Closed</span>
+    </h2>
+  </div>
+  <div class="content">
+    <!-- Last speakers -->
+    <p ng-repeat="speaker in lastSpeakers = (AgendaItem.speakers | filter: {end_time: '!!', begin_time: '!!'}) |
+      limitTo: config('agenda_show_last_speakers') : (lastSpeakers.length - config('agenda_show_last_speakers'))" class="lastSpeakers">
+      {{ speaker.user.get_full_name() }}
+    <!-- Current speaker -->
+    <p ng-repeat="speaker in currentspeakers = (AgendaItem.speakers| filter: {end_time: null, begin_time: '!!'})"
+      class="currentSpeaker">
+      <i class="fa fa-microphone fa-lg"></i> {{ speaker.user.get_full_name() }}
+    <!-- Next speakers -->
+    <ol class="nextSpeakers">
+      <li ng-repeat="speaker in AgendaItem.speakers | filter: {begin_time: null} | orderBy:'weight'">
+     {{ speaker.user.get_full_name() }}
+    </ol>
+  </div>
+</div>

--- a/openslides/agenda/static/templates/agenda/item-list.html
+++ b/openslides/agenda/static/templates/agenda/item-list.html
@@ -66,6 +66,12 @@
             <i class="fa fa-sort-numeric-asc"></i>
             <translate>Numbering</translate>
           </a>
+          <!--current list of speakers button-->
+          <a os-perms="users.can_see_name" class="btn btn-default"
+            ui-sref="agenda.current-list-of-speakers">
+            <i class="fa fa-microphone"></i>
+            <translate>List of speakers</translate>
+          </a>
       </div>
     </div>
     <div class="col-sm-5">

--- a/openslides/core/static/css/app.css
+++ b/openslides/core/static/css/app.css
@@ -834,6 +834,49 @@ img {
     display: none;
 }
 
+/* List of speakers view */
+.fullscreendiv {
+    position: absolute;
+    font-size:120%;
+    top:0;
+    bottom:0;
+    right:0;
+    left:0;
+    padding: 50px;
+    background: #fff;
+    overflow: hidden;
+    width: 100vw;
+    height: 100vh;
+    z-index: 99;
+}
+
+.fullscreendiv-title {
+    border-bottom: 5px solid #d3d3d3;
+    margin-bottom: 40px;
+}
+
+.lastSpeakers {
+    color: #9a9898;
+    margin-left: 27px;
+}
+
+.currentSpeaker {
+    font-weight: bold;
+    margin-left: 0px;
+}
+
+.currentSpeaker i {
+    padding-right: 5px;
+}
+
+.nextSpeakers {
+    margin-left: 8px;
+}
+
+.nextSpeakers li {
+    line-height: 150%;
+}
+
 /* search results */
 .searchresults li {
     margin-bottom: 12px;


### PR DESCRIPTION
The idea is creating two views.
1) A view within the normal OpenSlides interface (/speakers), similar to /agenda or /motions. The content div of this page may be rescaled to fullscreen, but if not rescaled, it behaves as the normal interface does (navigation headers, sidebars, chat visible, etc.).
2) A view which is always reachable via a different URL (/listofspeakers), similar to /projector, being independent of whatever the user is doing on the normal interface. This view _only_ shows the last, current and next speakers or a message "no current speakers", and no header/footer/navigation tools.

However, I am stuck on the issue, with an error message I cannot decipher. What fails and keeps me from continuing with the issue seems to be something in the connection between the controller (agenda/site.js) and the template (/agenda/item-list-of-speakers.html) . The error message has about 40 lines pointing to obscure points in static/js/openslides-libs.js, beginning with: 
```
"Error: [ng:areq] Argument 'Itemundefined' is not a function, got undefined
http://errors.angularjs.org/1.4.11/ng/areq?p0=Itemundefined&p1=not%20aNaNunction%2C%20got%20undefinedminErr/
```
with no helpful hints on what is wrong; and changing anything in the template (including sending a blank template) doesn't help. (Also, searching for "Itemundefined" returned nothing)