### PR TITLE
Added static media handling (Fixes #2223)

### DIFF
--- a/openslides/urls.py
+++ b/openslides/urls.py
@@ -1,5 +1,7 @@
+from django.conf import settings
 from django.conf.urls import include, url
 from django.views.generic import RedirectView
+from django.views.static import serve
 
 from openslides.utils.plugins import get_all_plugin_urlpatterns
 from openslides.utils.rest_api import router
@@ -7,6 +9,7 @@ from openslides.utils.rest_api import router
 urlpatterns = get_all_plugin_urlpatterns()
 
 urlpatterns += [
+    url(r'^%s(?P<path>.*)$' % settings.MEDIA_URL.lstrip('/'), serve, {'document_root': settings.MEDIA_ROOT}),
     url(r'^(?P<url>.*[^/])$', RedirectView.as_view(url='/%(url)s/', permanent=True)),
     url(r'^rest/', include(router.urls)),
     url(r'^agenda/', include('openslides.agenda.urls')),


### PR DESCRIPTION
Commit fe64941aabd0228fc8090ca21f2f99df5204ee20
replaced former use of tornado as webserver with django channels.
During this, the additional routing path for /media/ was forgotten.
This is now fixed.

Due to the routing scheme, the static URLS were added beforehand.
Adding it afterwards does not work.