### PR TITLE
Added search filtering by category (fixes #2019, fixes #2239)

### DIFF
--- a/openslides/core/static/templates/index.html
+++ b/openslides/core/static/templates/index.html
@@ -139,9 +139,9 @@
       </ul>
       <!-- Search bar -->
       <div class="searchbar pull-right" ng-controller="SearchBarCtrl">
-        <form ng-submit="search(query); closeMenu()">
+        <form ng-submit="search(); closeMenu()">
           <div class="input-group">
-            <input ng-model="query" class="form-control" type="text" placeholder="{{ 'Search' | translate}}">
+            <input ng-model="querybar" class="form-control" type="text" placeholder="{{ 'Search' | translate}}">
             <span class="input-group-btn">
               <button type="submit" class="btn btn-default">
                 <i class="fa fa-search"></i>

--- a/openslides/core/static/templates/search.html
+++ b/openslides/core/static/templates/search.html
@@ -5,16 +5,43 @@
 </div>
 
 <div class="details">
-    <form class="input-group" ng-submit="search(query)">
+    <form class="input-group" ng-submit="search()">
       <input type="text" ng-model="query" class="form-control">
       <span class="input-group-btn">
         <button type="submit" class="btn btn-default" translate>Search</button>
       </span>
     </form>
-
+    <div class="searchfilter spacer-top">
+      <label class="checkbox-inline">
+        <input type="checkbox" ng-model="filterAgenda">
+        <translate>Agenda items</translate>
+      </label>
+      <label class="checkbox-inline">
+        <input type="checkbox" ng-model="filterMotion">
+        <translate>Motions</translate>
+      </label>
+      <label class="checkbox-inline">
+        <input type="checkbox" ng-model="filterAssignment">
+        <translate>Elections</translate>
+      </label>
+      <label class="checkbox-inline">
+        <input type="checkbox" ng-model="filterUser">
+        <translate>Participants</translate>
+      </label>
+      <label class="checkbox-inline">
+        <input type="checkbox" ng-model="filterMedia">
+        <translate>Files</translate>
+      </label>
+      <div>
+        <label class="checkbox-inline">
+          <input type="checkbox" ng-model="fullword" ng-change="search()">
+          <translate>Only whole words</translate>
+        </label>
+      </div>
+    </div>
   <div class="searchresults spacer-top-lg">
     <ol ng-show="results">
-      <li ng-repeat="result in results">
+      <li ng-repeat="result in results | filter:filterresult()">
         <a ng-if="!result.mediafileUrl" ui-sref="{{ result.urlState }}({{ result.urlParam }})">
           {{ result.getSearchResultName() }}
         </a>
@@ -24,6 +51,6 @@
         <br>
         <span class="grey">{{ result.getSearchResultSubtitle() | translate }}</span>
     </ol>
-    <p ng-show="!results" translate>No results.</p>
+    <p ng-show="!results || results.length == 0" translate>No results.</p>
   </div>
 </div>

--- a/openslides/mediafiles/static/templates/mediafiles/mediafile-form.html
+++ b/openslides/mediafiles/static/templates/mediafiles/mediafile-form.html
@@ -8,7 +8,7 @@
 <form name="mediafileForm" ng-submit="save(mediafile)">
   <!-- file -->
   <div class="form-group">
-    <label for="inputTitle" translate>File *</label>
+    <label for="inputTitle"><translate>File</translate>*</label>
     <!-- create view: show file select field -->
     <input ng-if="!mediafile.id" type="file" ngf-select ng-model="mediafile.newFile" required>
     <!-- update view: show filename only -->


### PR DESCRIPTION
*The search now uses "partial matches" as default; added "search for full words only" as option, added filtering per category on search results page*

1) Added a javascript search variable 'fullword'. If this variable is false or not defined, the `string` will be transformed to `*string*`, allowing for partial matches, before the request is sent to the server (#2019).
2) Added checkboxes on the search result page. If checked, the elements that match the search string *and* the checked categories will be shown (#2239).

**Future goals on search (not included)**
- Sub-options, like "participants: only those present"
- more advanced search options, like AND, OR, correction of misspelling, non-case-sensitive
- indicate somehow WHY the search results are listed.

(edit: new summary, TODOs are done)