### PR TITLE
Parent items for Agenda items (fixes #2213)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ Version 2.1 (unreleased)
 
 Agenda:
 - Added button to remove all speakers from a list of speakers.
+- Added option to create or edit agenda items as subitems of others.
 
 Assignments:
 - Remove unused assignment config to publish winner election results only.

--- a/openslides/agenda/static/js/agenda/base.js
+++ b/openslides/agenda/static/js/agenda/base.js
@@ -21,6 +21,28 @@ angular.module('OpenSlidesApp.agenda', ['OpenSlidesApp.users'])
     }
 ])
 
+.factory('AgendaUpdate',[
+    'Agenda',
+    function(Agenda) {
+        return {
+            saveChanges: function (item_id, changes) {
+                Agenda.find(item_id).then(function(item) {
+                    var something = false;
+                    _.each(changes, function(change) {
+                        if (change.value !== item[change.key]) {
+                            item[change.key] = change.value;
+                            something = true;
+                        }
+                    });
+                    if (something === true) {
+                        Agenda.save(item);
+                    }
+                });
+            }
+        };
+    }
+])
+
 .factory('Agenda', [
     '$http',
     'DS',

--- a/openslides/agenda/static/js/agenda/site.js
+++ b/openslides/agenda/static/js/agenda/site.js
@@ -129,7 +129,7 @@ angular.module('OpenSlidesApp.agenda.site', ['OpenSlidesApp.agenda'])
         // open edit dialog
         $scope.editDialog = function (item) {
             $state.go(item.content_object.collection.replace('/','.')+'.detail.update',
-                        {id: item.content_object.id});
+                {id: item.content_object.id});
         };
         // detail view of related item (content object)
         $scope.open = function (item) {

--- a/openslides/core/static/js/core/base.js
+++ b/openslides/core/static/js/core/base.js
@@ -479,6 +479,26 @@ angular.module('OpenSlidesApp.core', [
     }
 ])
 
+// filters the requesting object (id=selfid) from a list of input objects
+.filter('notself', function() {
+    return function(input, selfid) {
+        var result;
+        if (selfid) {
+            result = [];
+            for (var key in input){
+                var obj = input[key];
+                if (selfid != obj.id) {
+                    result.push(obj);
+                }
+            }
+        } else {
+            result = input;
+        }
+        return result;
+    };
+})
+
+
 // Make sure that the DS factories are loaded by making them a dependency
 .run([
     'ChatMessage',

--- a/openslides/core/static/js/core/site.js
+++ b/openslides/core/static/js/core/site.js
@@ -647,6 +647,9 @@ angular.module('OpenSlidesApp.core.site', [
                 resolve: {
                     customslide: function(Customslide, $stateParams) {
                         return Customslide.find($stateParams.id);
+                    },
+                    items: function(Agenda) {
+                        return Agenda.findAll();
                     }
                 }
             })
@@ -655,21 +658,26 @@ angular.module('OpenSlidesApp.core.site', [
             // (from customslide controller use CustomSlideForm factory instead to open dialog in front
             // of current view without redirect)
             .state('core.customslide.detail.update', {
-                onEnter: ['$stateParams', '$state', 'ngDialog', 'Customslide',
-                    function($stateParams, $state, ngDialog, Customslide) {
+                onEnter: ['$stateParams', '$state', 'ngDialog', 'Customslide', 'Agenda',
+                    function($stateParams, $state, ngDialog, Customslide, Agenda) {
                         ngDialog.open({
                             template: 'static/templates/core/customslide-form.html',
                             controller: 'CustomslideUpdateCtrl',
                             className: 'ngdialog-theme-default wide-form',
                             resolve: {
-                                customslide: function() {return Customslide.find($stateParams.id);}
+                                customslide: function() {
+                                    return Customslide.find($stateParams.id);
+                                },
+                                items: function() {
+                                    return Agenda.findAll();
+                                }
                             },
                             preCloseCallback: function() {
                                 $state.go('core.customslide.detail', {customslide: $stateParams.id});
                                 return true;
                             }
                         });
-                }]
+                    }],
             })
             // tag
             .state('core.tag', {
@@ -979,7 +987,9 @@ angular.module('OpenSlidesApp.core.site', [
     'gettextCatalog',
     'Editor',
     'Mediafile',
-    function (gettextCatalog, Editor, Mediafile) {
+    'Agenda',
+    'AgendaTree',
+    function (gettextCatalog, Editor, Mediafile, Agenda, AgendaTree) {
         return {
             // ngDialog for customslide form
             getDialog: function (customslide) {
@@ -1038,7 +1048,16 @@ angular.module('OpenSlidesApp.core.site', [
                         description: gettextCatalog.getString('If deactivated it appears as internal item on agenda.')
                     }
                 },
-                ];
+                {
+                    key: 'agenda_parent_item_id',
+                    type: 'select-single',
+                    templateOptions: {
+                        label: gettextCatalog.getString('Parent item'),
+                        options: AgendaTree.getFlatTree(Agenda.getAll()),
+                        ngOptions: 'item.id as item.getListViewTitle() for item in to.options | notself : model.agenda_item_id',
+                        placeholder: gettextCatalog.getString('Select a parent item ...')
+                    }
+                }];
             }
         };
     }
@@ -1251,7 +1270,6 @@ angular.module('OpenSlidesApp.core.site', [
     function($scope, ngDialog, CustomslideForm, Customslide, customslide) {
         Customslide.bindOne(customslide.id, $scope, 'customslide');
         Customslide.loadRelations(customslide, 'agenda_item');
-
         // open edit dialog
         $scope.openDialog = function (customslide) {
             ngDialog.open(CustomslideForm.getDialog(customslide));
@@ -1265,30 +1283,24 @@ angular.module('OpenSlidesApp.core.site', [
     'Customslide',
     'CustomslideForm',
     'Agenda',
-    function($scope, $state, Customslide, CustomslideForm, Agenda) {
+    'AgendaUpdate',
+    function($scope, $state, Customslide, CustomslideForm, Agenda, AgendaUpdate) {
         $scope.customslide = {};
         $scope.model = {};
         $scope.model.showAsAgendaItem = true;
         // get all form fields
         $scope.formFields = CustomslideForm.getFormFields();
-
         // save form
         $scope.save = function (customslide) {
             Customslide.create(customslide).then(
                 function(success) {
-                    // find related agenda item
-                    Agenda.find(success.agenda_item_id).then(function(item) {
-                        // check form element and set item type (AGENDA_ITEM = 1, HIDDEN_ITEM = 2)
-                        var type = customslide.showAsAgendaItem ? 1 : 2;
-                        // save only if agenda item type is modified
-                        if (item.type != type) {
-                            item.type = type;
-                            Agenda.save(item);
-                        }
-                    });
-                    $scope.closeThisDialog();
-                }
-            );
+                    // type: Value 1 means a non hidden agenda item, value 2 means a hidden agenda item,
+                    // see openslides.agenda.models.Item.ITEM_TYPE.
+                    var changes = [{key: 'type', value: (customslide.showAsAgendaItem ? 1 : 2)},
+                                   {key: 'parent_id', value: customslide.agenda_parent_item_id}];
+                    AgendaUpdate.saveChanges(success.agenda_item_id,changes);
+                });
+            $scope.closeThisDialog();
         };
     }
 ])
@@ -1299,8 +1311,10 @@ angular.module('OpenSlidesApp.core.site', [
     'Customslide',
     'CustomslideForm',
     'Agenda',
+    'AgendaUpdate',
     'customslide',
-    function($scope, $state, Customslide, CustomslideForm, Agenda, customslide) {
+    function($scope, $state, Customslide, CustomslideForm, Agenda, AgendaUpdate, customslide) {
+        Customslide.loadRelations(customslide, 'agenda_item');
         $scope.alert = {};
         // set initial values for form model by create deep copy of customslide object
         // so list/detail view is not updated while editing
@@ -1311,25 +1325,22 @@ angular.module('OpenSlidesApp.core.site', [
             if ($scope.formFields[i].key == "showAsAgendaItem") {
                 // get state from agenda item (hidden/internal or agenda item)
                 $scope.formFields[i].defaultValue = !customslide.agenda_item.is_hidden;
+            } else if($scope.formFields[i].key == "agenda_parent_item_id") {
+                $scope.formFields[i].defaultValue = customslide.agenda_item.parent_id;
             }
         }
 
         // save form
         $scope.save = function (customslide) {
-            // inject the changed customslide (copy) object back into DS store
-            Customslide.inject(customslide);
-            // save change customslide object on server
-            Customslide.save(customslide).then(
+            Customslide.create(customslide).then(
                 function(success) {
-                    // save agenda specific stuff
-                    var type = customslide.showAsAgendaItem ? 1 : 2;
-                    if (customslide.agenda_item.type != type) {
-                        customslide.agenda_item.type = type;
-                        Agenda.save(customslide.agenda_item);
-                    }
+                    // type: Value 1 means a non hidden agenda item, value 2 means a hidden agenda item,
+                    // see openslides.agenda.models.Item.ITEM_TYPE.
+                    var changes = [{key: 'type', value: (customslide.showAsAgendaItem ? 1 : 2)},
+                                   {key: 'parent_id', value: customslide.agenda_parent_item_id}];
+                    AgendaUpdate.saveChanges(success.agenda_item_id,changes);
                     $scope.closeThisDialog();
-                },
-                function (error) {
+                }, function (error) {
                     // save error: revert all changes by restore
                     // (refresh) original customslide object from server
                     Customslide.refresh(customslide);


### PR DESCRIPTION
Whenever you create or edit an object that has an agenda entry (`agenda item`, `assignment`, `motion`) you can now chose to assign a "parent item" (or chose "no parent item"). The underlying agenda item's parent_id will be updated accordingly -- See #2213.

What remains up for discussion is the agenda *weight* of an item, as this decides where under the parent item the agenda item is listed. For now, it is not defined upon update, so probably random. I do not know how this weight is calculated.

In terms of code, I may have added a `resolve:` or two that are unnecessary, I did not fully understand when which resolve takes place, so it was a try-and-error.

(on a side note: `git rebase -i HEAD~7` failed, because the order of the commits is messed up/ reversed on my machine. Is there an easy way to recover from this, without losing the last state?)