### PR TITLE
Update requirements

### DIFF
--- a/make/commands.py
+++ b/make/commands.py
@@ -86,15 +86,24 @@ def min_requirements(args=None):
     requirement file.
 
     Uses requirements_production.txt by default.
-    """
 
+    The following line will install the version:
+
+    pip install $(python make min_requirements)
+    """
     import pip
 
     def get_lowest_versions(requirements_file):
         for line in pip.req.parse_requirements(requirements_file, session=pip.download.PipSession()):
-            yield '%s==%s' % (line.req.key, line.req.specs[0][1])
+            for specifier in line.req.specifier:
+                if specifier.operator == '>=':
+                    min_version = specifier.version
+                    break
+            else:
+                raise ValueError('Not supported line {}'.format(line))
+            yield '%s==%s' % (line.req.name, min_version)
 
-    print('pip install %s' % ' '.join(get_lowest_versions(args.requirements)))
+    print(' '.join(get_lowest_versions(args.requirements)))
 
 
 @command('clear',

--- a/requirements_production.txt
+++ b/requirements_production.txt
@@ -1,14 +1,13 @@
 # Requirements for OpenSlides in production in alphabetical order
-Django>=1.8,<1.10
+Django>=1.8,<1.11,!=1.10.0
 beautifulsoup4>=4.5,<4.6
 channels>=0.15,<1.0
-djangorestframework>=3.2.0,<3.4.0
-html5lib>=0.9,<1.0
+djangorestframework>=3.2.0,<3.5
+html5lib>=0.99,<1.0
 jsonfield>=0.9.19,<1.1
-natsort>=3.2,<4.1
-PyPDF2>=1.25.0,<1.26
+natsort>=3.2,<5.1
+PyPDF2>=1.25.0,<1.27
 reportlab>=3.0,<3.4
 roman>=2.0,<2.1
 setuptools>=18.5,<26.0
-sockjs-tornado>=1.0.1,<1.1
 Whoosh>=2.7.0,<2.8


### PR DESCRIPTION
Also fix min_requirements script

We do not support Django 1.10.0 because of this bug: https://code.djangoproject.com/ticket/26997
This will be fixt with Django 1.10.1: https://docs.djangoproject.com/en/1.10/releases/1.10.1/
Until the release of django 1.10.1 we have to stay with django 1.9