### PR TITLE
Change pdfmake to a version with fix (fixes #2287)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,15 +29,15 @@
     "ng-dialog": "~0.5.6",
     "ng-file-upload": "~11.2.3",
     "ngBootbox": "~0.1.3",
-    "pdfmake": "~0.1.17",
+    "pdfmake-fix": "0.1.20.1",
     "open-sans-fontface": "https://github.com/OpenSlides/open-sans.git#1.4.2.post1",
     "roboto-condensed": "~0.3.0",
     "tinymce-dist": "4.3.12",
     "tinymce-i18n": "OpenSlides/tinymce-i18n#a186ad61e0aa30fdf657e88f405f966d790f0805"
   },
   "overrides": {
-    "pdfmake-dist": {
-      "main": "build/pdfmake.min.js"
+    "pdfmake-fix-dist": {
+      "main": "build/pdfmake.js"
     },
     "pdfjs-dist": {
       "main": "build/pdf.combined.js"


### PR DESCRIPTION
This is more of an temporary solution but should do the trick.

The first problem is, I cannot build pdfmake. The developer does not react to the issue someone has made who also hast the build problem.
see: [https://github.com/bpampuch/pdfmake/issues/598](url)

Therefore, I cannot fix the source code to make a decent patch for pdfmake.
However, I am able to fix the builded source with following the steps provided here:
[https://github.com/bpampuch/pdfmake/issues/577#issuecomment-241249420](url)

I also registered a new bower source for my forked and fixed version so we can use it in OpenSlides as long as this is not fixed in official pdfmake master.

see also #2288

@emanuelschuetze 