### PR TITLE
Cache system for OpenSlides instances

### DIFF
--- a/openslides/core/config_variables.py
+++ b/openslides/core/config_variables.py
@@ -1,4 +1,5 @@
 from django.core.validators import MaxLengthValidator
+
 from openslides.core.config import ConfigVariable
 
 

--- a/openslides/utils/collection.py
+++ b/openslides/utils/collection.py
@@ -1,0 +1,29 @@
+from django.apps import apps
+
+
+def get_model_from_collection_string(collection_string):
+    """
+    Returns a model class which belongs to the argument collection_string.
+    """
+    def model_generator():
+        """
+        Yields all models of all apps.
+        """
+        for app_config in apps.get_app_configs():
+            for model in app_config.get_models():
+                yield model
+
+    for model in model_generator():
+        try:
+            model_collection_string = model.get_collection_string()
+        except AttributeError:
+            # Skip models which do not have the method get_collection_string.
+            pass
+        else:
+            if model_collection_string == collection_string:
+                # The model was found.
+                break
+    else:
+        # No model was found in all apps.
+        raise ValueError('Invalid message. A valid collection_string is missing.')
+    return model

--- a/openslides/utils/instance_cache.py
+++ b/openslides/utils/instance_cache.py
@@ -1,0 +1,155 @@
+from django.core.cache import cache
+
+from ..users.auth import AnonymousUser
+from ..users.models import User
+from .collection import get_model_from_collection_string
+
+
+def get_instance(collection, id, user=None):
+    """
+    Gets one instance from a collection. If the instance is in the cache, the
+    cached version is returned, if not, the instance is received from the
+    database and afterwards saved at the cache.
+
+    The argument user can be a integer (user-id) or a user instance. Zero stands
+    for the anonymous user. If user is not None, the instance is returned as the
+    user has permissions to see it. None is returned if the user can not see it
+    at all. If user is None, then the master-instance is returned.
+    """
+    cache_key = get_instance_cache_key(collection, id)
+    cached_instance = cache.get(cache_key)
+    if cached_instance is None:
+        # The instance is not is the cache. Get if from the database.
+        cached_instance = get_instance_from_db(collection, id)
+
+    # Apply permission filter
+    cached_instance = permission_filter(collection, cached_instance, user)
+    return cached_instance
+
+
+def get_instance_list(collection, user=None):
+    """
+    Like get_instance but returns all of instances of an collection as a generator.
+
+    Therefore a set of all ids of the collection is saved at the cache.
+    """
+    # Get list of ids
+    cache_key = get_instance_list_cache_key(collection)
+    cached_ids = cache.get(cache_key)
+    if cached_ids is None:
+        Model = get_model_from_collection_string(collection)
+        cached_ids = set(Model.objects.values_list('pk', flat=True).order_by('pk'))
+        cache.set(cache_key, cached_ids)
+
+    # Get all instances out of the cache
+    cache_keys = [get_instance_cache_key(collection, id) for id in cached_ids]
+    for cache_key, cached_instance in cache.get_many(cache_keys):
+        # TODO: Test if cached_instance is None for instances, that do not exist in the cache
+        if cached_instance is None:
+            cached_instance = get_instance_from_db(
+                get_collection_id_from_cache_key(cache_key))
+        cached_instance = permission_filter(collection, cached_instance, user)
+        if cached_instance is not None:
+            # Only return instances where the user can see at least some data
+            yield cached_instance
+
+
+def del_instance(collection, id):
+    """
+    Delets an instance from the cache.
+
+    Does nothing if the instance is not in the cache.
+    """
+    # Delete the instance from the cache
+    cache.delete(get_instance_cache_key(collection, id))
+
+    # Delete the id of the instance of the instance list
+    cache_key = get_instance_list_cache_key(collection)
+    cached_ids = set(cache.get(cache_key))
+    if cached_ids is not None:
+        try:
+            cached_ids.remove(id)
+        except KeyError:
+            # The id is not part of id list
+            pass
+        else:
+            # TODO: This can be a problem if two different ids are removed from
+            #       cache at the same time by different threads. Therefore we
+            #       need some kind of blocking or an atomic operation.
+            if cached_ids:
+                cache.set(cache_key, cached_ids)
+            else:
+                # Delete the key, if there are not ids left
+                cache.delete(cache_key)
+
+
+def update_instance(collection, id):
+    """
+    Changes the instance inside the cache.
+
+    If the instance is not in the cache, then it is added.
+    """
+    # Update the instance in the cache
+    get_instance_from_db(collection, id)
+
+    # Add the id of the instance in the instance list
+    # Do nothing if the ids are currently not in the cache
+    cache_key = get_instance_list_cache_key(collection)
+    cached_ids = set(cache.get(cache_key))
+    if cached_ids is not None:
+        cached_ids.add(id)
+        cache.set(cache_key, cached_ids)
+
+
+def get_instance_from_db(collection, id):
+    """
+    Gets an instance from the db.
+
+    Also saves this instance into the cache.
+    """
+    cache_key = get_instance_cache_key(collection, id)
+    Model = get_model_from_collection_string(collection)
+    instance = Model.objects.get(pk=id)
+    # TODO: Get the access_permissions object
+    instance = access_permissions.get_full_data(instance)
+    cache.set(cache_key, instance)
+    return instance
+
+
+def permission_filter(collection, instance, user):
+    # Apply permission filter
+    if user is not None:
+        Model = get_model_from_collection_string(collection)
+        if user == 0:
+            user = AnonymousUser()
+
+        if isinstance(user, int):
+            # user is the id of an user instance.
+            user = User.objects.get(user)
+
+        # TODO: Get the access_permissions object
+        instance = access_permissions.get_restricted_data(instance, user)
+    return instance
+
+
+def get_instance_cache_key(collection, id):
+    """
+    Returns a string that is used as cache key for a single instance.
+    """
+    # If you change this function, you also have to change get_collection_id_from_cache_key
+    return "{collection}:{id}".format(collection=collection, id=id)
+
+
+def get_instance_list_cache_key(collection):
+    """
+    Returns a string that is used as cache key for a list of instances.
+    """
+    return "{collection}".format(collection=collection)
+
+
+def get_collection_id_from_cache_key(cache_key):
+    """
+    Returns a tuble of the collection string and the id from a cache_key
+    created with get_instance_cache_key.
+    """
+    return cache_key.rsplit(':', 1)

--- a/tests/integration/utils/instance_cache.py
+++ b/tests/integration/utils/instance_cache.py
@@ -1,0 +1,118 @@
+from openslides.utils.test import TestCase as _TestCase
+
+from openslides.core.models import CustomSlide
+from openslides.utils.instance_cache import get_instance, instances_generator
+
+from unittest.mock import patch
+from django.core.cache import caches
+from openslides.users.models import User
+
+class TestCase(_TestCase):
+    """
+    Testcase that uses the local mem cache and clears the cache after each test.
+    """
+    def setUp(self):
+        cache = caches['locmem']
+        cache.clear()
+        self.patch = patch('openslides.utils.instance_cache.cache', cache)
+        self.patch.start()
+
+    def tearDown(self):
+        self.patch.stop()
+
+
+class TestGetInstance(TestCase):
+    def test_clean_cache(self):
+        """
+        Tests that the instance is retrieved from the database.
+
+        Currently there are 3 queries needed. This can change in the future, but
+        it has to be more then zero.
+        """
+        CustomSlide.objects.create(title='test cs')
+
+        with self.assertNumQueries(3):
+            instance = get_instance('core/customslide', 1)
+        self.assertEqual(instance['title'], 'test cs')
+
+    def test_with_cache(self):
+        """
+        Tests that no db query is used when get_instance is called two times.
+        """
+        CustomSlide.objects.create(title='test cs')
+        get_instance('core/customslide', 1)
+
+        with self.assertNumQueries(0):
+            instance = get_instance('core/customslide', 1)
+        self.assertEqual(instance['title'], 'test cs')
+
+    def test_non_existing_instance(self):
+        with self.assertRaises(CustomSlide.DoesNotExist):
+            get_instance('core/customslide', 1)
+
+    def test_with_user_id(self):
+        CustomSlide.objects.create(title='test cs')
+        instance = get_instance('core/customslide', 1, user=1)
+        self.assertEqual(instance['title'], 'test cs')
+
+    def test_with_anonymous_user(self):
+        """
+        Test to get the instance with the permissions of the anonymous user.
+
+        The anonymous user has not the permission to see custom slide instances
+        """
+        CustomSlide.objects.create(title='test cs')
+        instance = get_instance('core/customslide', 1, user=0)
+        self.assertIsNone(instance)
+
+    def test_with_user_object(self):
+        """
+        There should not be any database query if the object is in the cache and
+        get_instance is called with an user object.
+        """
+        CustomSlide.objects.create(title='test cs')
+        get_instance('core/customslide', 1, user=1)
+        admin = User.objects.get(pk=1)
+
+        with self.assertNumQueries(0):
+            instance = get_instance('core/customslide', 1)
+
+
+class TestInstancesGenerator(TestCase):
+    def test_clean_cache(self):
+        """
+        Tests that the instances are retrieved from the database.
+
+        Currently there are 10 queries needed. This can change in the future,
+        but it has to be more then zero.
+        """
+        CustomSlide.objects.create(title='test cs1')
+        CustomSlide.objects.create(title='test cs2')
+        CustomSlide.objects.create(title='test cs3')
+
+        with self.assertNumQueries(10):
+            instance_list = list(instances_generator('core/customslide'))
+        self.assertEqual(len(instance_list), 3)
+
+    def test_with_cache(self):
+        """
+        Tests that no db query is used when get_instance is called two times.
+        """
+        CustomSlide.objects.create(title='test cs1')
+        CustomSlide.objects.create(title='test cs2')
+        CustomSlide.objects.create(title='test cs3')
+        list(instances_generator('core/customslide'))
+
+        with self.assertNumQueries(0):
+            instance_list = list(instances_generator('core/customslide'))
+        self.assertEqual(len(instance_list), 3)
+
+    def test_with_some_objects_in_the_cache(self):
+        CustomSlide.objects.create(title='test cs1')
+        CustomSlide.objects.create(title='test cs2')
+        list(instances_generator('core/customslide'))
+        CustomSlide.objects.create(title='test cs3')
+
+        with self.assertNumQueries(0):
+            instance_list = list(instances_generator('core/customslide'))
+        self.assertEqual(len(instance_list), 3)

--- a/tests/integration/utils/instance_cache.py
+++ b/tests/integration/utils/instance_cache.py
@@ -1,11 +1,12 @@
-from openslides.utils.test import TestCase as _TestCase
+from unittest.mock import patch
+
+from django.core.cache import caches
 
 from openslides.core.models import CustomSlide
-from openslides.utils.instance_cache import get_instance, instances_generator
-
-from unittest.mock import patch
-from django.core.cache import caches
 from openslides.users.models import User
+from openslides.utils.instance_cache import get_instance, instances_generator
+from openslides.utils.test import TestCase as _TestCase
+
 
 class TestCase(_TestCase):
     """
@@ -75,7 +76,7 @@ class TestGetInstance(TestCase):
         admin = User.objects.get(pk=1)
 
         with self.assertNumQueries(0):
-            instance = get_instance('core/customslide', 1)
+            get_instance('core/customslide', 1, user=admin)
 
 
 class TestInstancesGenerator(TestCase):

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -51,3 +51,13 @@ SEARCH_INDEX = 'ram'
 PASSWORD_HASHERS = (
     'django.contrib.auth.hashers.MD5PasswordHasher',
 )
+
+# Use the dummy cache that does not cache anything
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache'
+    },
+    'locmem': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'
+    }
+}


### PR DESCRIPTION
System that caches instances.

The cache is automaticly updated through the autoupdate system.

It uses the django cache system, so the django cache has to be
configured.

The rest API should only use this cache system when it gets GET
requests.

TODO:
- [x] find a way to get the access_permission in the cache system
- [ ] change the viewsets to use the cache
- [ ] Test this

@normanjaeckel could you have a look at the two first todos?