### PR TITLE
use build pdfmake (fixes #2287)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,7 @@
     "ng-dialog": "~0.5.6",
     "ng-file-upload": "~11.2.3",
     "ngBootbox": "~0.1.3",
-    "pdfmake-dist": "~0.1.27",
+    "pdfmake-dist": "https://github.com/tsiegleauq/pdfmake.git#v0.1.30.1",
     "open-sans-fontface": "https://github.com/OpenSlides/open-sans.git#1.4.2.post1",
     "roboto-condensed": "~0.3.0",
     "tinymce-dist": "4.3.12",


### PR DESCRIPTION
The Current Build of pdfmake/pdfmake still uses the old version of grunt-browserify. Therefore,
the Firefox-PNG-problem still exists.
I made a [pull request](https://github.com/pdfmake/pdfmake/pull/14) for this, but since the new version has to be done tomorrow, I made a release with the fix myself just for the safety.

This can be changed later once the upstream version offers the fixed grunt-browserify.