### PR TITLE
limit image scale in pdf documents (fixes #2301)

### DIFF
--- a/openslides/core/static/css/app.css
+++ b/openslides/core/static/css/app.css
@@ -318,6 +318,10 @@ img {
     margin-right: 13px;
 }
 
+.col1 .details img {
+    max-width: 100%;
+    height: auto;
+}
 .col1 ul, .col1 ol {
     margin-left: 20px;
 }

--- a/openslides/core/static/css/projector.css
+++ b/openslides/core/static/css/projector.css
@@ -81,6 +81,10 @@ body{
     z-index: -1;
     line-height: 1.3em;
 }
+.content img {
+    max-width: 65%;
+    height: auto;
+}
 .scrollcontent {
     transition-property: margin, font-size;
     transition-duration: 1s;

--- a/openslides/core/static/js/core/site.js
+++ b/openslides/core/static/js/core/site.js
@@ -355,10 +355,32 @@ angular.module('OpenSlidesApp.core.site', [
                                     alreadyConverted.push(stack);
                                     break;
                                 case "img":
+                                    // TODO: need a proper way to calculate the space
+                                    // left on the page.
+                                    // This requires further information
+                                    // A4 in 72dpi: 595px x 842px
+                                    var maxResolution = {
+                                        width: 590,
+                                        height: 840
+                                    },
+                                        width = parseInt(element.getAttribute("width")),
+                                        height = parseInt(element.getAttribute("height"));
+
+                                    if (width > maxResolution.width) {
+                                        var scaleByWidth = maxResolution.width/width;
+                                        width *= scaleByWidth;
+                                        height *= scaleByWidth;
+                                    }
+                                    if (height > maxResolution.height) {
+                                        var scaleByHeight = maxResolution.height/height;
+                                        width *= scaleByHeight;
+                                        height *= scaleByHeight;
+                                    }
+
                                     alreadyConverted.push({
                                         image: BaseMap[element.getAttribute("src")],
-                                        width: parseInt(element.getAttribute("width")),
-                                        height: parseInt(element.getAttribute("height"))
+                                        width: width,
+                                        height: height
                                     });
                                     break;
                                 case "ul":

--- a/openslides/core/static/js/core/site.js
+++ b/openslides/core/static/js/core/site.js
@@ -360,8 +360,8 @@ angular.module('OpenSlidesApp.core.site', [
                                     // This requires further information
                                     // A4 in 72dpi: 595px x 842px
                                     var maxResolution = {
-                                        width: 590,
-                                        height: 840
+                                        width: 435,
+                                        height: 830
                                     },
                                         width = parseInt(element.getAttribute("width")),
                                         height = parseInt(element.getAttribute("height"));


### PR DESCRIPTION
This solves the scale problem using a simple calculation.
Once there are proper ways to calculate the actual space (in pixel) on a page this can be enhanced.

@emanuelschuetze 