### PR TITLE
Increase the allowed characters for event name config to 100.

### DIFF
--- a/openslides/core/config_variables.py
+++ b/openslides/core/config_variables.py
@@ -17,7 +17,7 @@ def get_config_variables():
         weight=110,
         group='General',
         subgroup='Event',
-        validators=(MaxLengthValidator(50),))
+        validators=(MaxLengthValidator(100),))
 
     yield ConfigVariable(
         name='general_event_description',


### PR DESCRIPTION
Same limit as event_description. (Requested by an user.)