### PR TITLE
Bugfixes: line numbering

### DIFF
--- a/openslides/core/static/css/app.css
+++ b/openslides/core/static/css/app.css
@@ -397,6 +397,7 @@ img {
     color: gray;
     font-family: Courier, serif;
     font-size: 13px;
+    font-weight: normal;
 }
 
 .motion-text.line-numbers-inline .os-line-break {
@@ -410,6 +411,7 @@ img {
     content: attr(data-line-number);
     vertical-align: top;
     font-size: 11px;
+    font-weight: normal;
     color: gray;
     font-family: Courier, serif;
     margin-top: -3px;

--- a/openslides/core/static/css/projector.css
+++ b/openslides/core/static/css/projector.css
@@ -394,6 +394,7 @@ tr.elected td {
     color: gray;
     font-family: Courier, serif;
     font-size: 13px;
+    font-weight: normal;
 }
 
 .motion-text.line-numbers-inline .os-line-break {
@@ -407,6 +408,7 @@ tr.elected td {
     content: attr(data-line-number);
     vertical-align: top;
     font-size: 0.75em;
+    font-weight: normal;
     color: gray;
     font-family: Courier, serif;
     margin-top: -5px;

--- a/tests/karma/motions/linenumbering.service.test.js
+++ b/tests/karma/motions/linenumbering.service.test.js
@@ -212,5 +212,19 @@ describe('linenumbering', function () {
       expect(outHtml).toBe(expected);
       expect(lineNumberingService.stripLineNumbers(outHtml)).toBe(inHtml);
     });
+
+    it('breaks before an inline element, if the first word of the new inline element is longer than the remaining line (1)', function () {
+      var inHtml = "<p>Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie <strong>consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio</strong>.</p>";
+      var outHtml = lineNumberingService.insertLineNumbers(inHtml, 80);
+      expect(outHtml).toBe('<p>' + noMarkup(1) + 'Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie ' + brMarkup(2) + '<strong>consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan ' + brMarkup(3) + 'et iusto odio</strong>.</p>');
+      expect(lineNumberingService.stripLineNumbers(outHtml)).toBe(inHtml);
+    });
+
+    it('breaks before an inline element, if the first word of the new inline element is longer than the remaining line (2)', function () {
+      var inHtml = "<p><span>Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie <strong>consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio</strong>.</span></p>";
+      var outHtml = lineNumberingService.insertLineNumbers(inHtml, 80);
+      expect(outHtml).toBe('<p>' + noMarkup(1) + '<span>Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie ' + brMarkup(2) + '<strong>consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan ' + brMarkup(3) + 'et iusto odio</strong>.</span></p>');
+      expect(lineNumberingService.stripLineNumbers(outHtml)).toBe(inHtml);
+    });
   });
 });


### PR DESCRIPTION
Fixes two bugs:
- the line numbers where shown bold if they ocurred within bold text
- when a new inline element started near the end of a line and the length of the first word exceeds the remaining space of the line, the first word was broken into two parts. The better solution would be to break the line before the inline element starts.