### PR TITLE
Highlighting and jumping to lines

### DIFF
--- a/openslides/core/static/css/app.css
+++ b/openslides/core/static/css/app.css
@@ -308,6 +308,11 @@ img {
     margin-left: 15px;
 }
 
+.col1 .details .line-number-setter > span {
+    margin-right: 5px;
+    float: left;
+}
+
 .col1 .details .line-number-setter .btn.disabled {
     cursor: default;
     opacity: 1;
@@ -381,6 +386,10 @@ img {
 }
 
 /*** Line numbers ***/
+.motion-text .highlight {
+    background-color: #ff0;
+}
+
 .motion-text.line-numbers-outside {
     padding-left: 35px;
     position: relative;
@@ -808,6 +817,11 @@ img {
 .slimDropDown {
     padding-left: 4px !important;
     padding-right: 4px !important;
+}
+
+.btn-slim {
+    padding-left: 6px;
+    padding-right: 6px;
 }
 
 .spacer, .spacer-top {

--- a/openslides/core/static/css/projector.css
+++ b/openslides/core/static/css/projector.css
@@ -381,6 +381,10 @@ tr.elected td {
 
 
 /*** Line numbers ***/
+.motion-text .highlight {
+    background-color: #ff0;
+}
+
 .motion-text.line-numbers-outside {
     padding-left: 0;
     margin-left: 25px;
@@ -424,5 +428,5 @@ tr.elected td {
     display: none;
 }
 .motion-text.line-numbers-none .os-line-number {
-    display: none;
+    visibility: hidden;
 }

--- a/openslides/core/static/js/core/projector.js
+++ b/openslides/core/static/js/core/projector.js
@@ -144,7 +144,7 @@ angular.module('OpenSlidesApp.core.projector', ['OpenSlidesApp.core'])
                     }
                 });
                 // TODO: Use the current projector. At the moment there is only one
-                $scope.scroll = -5 * Projector.get(1).scroll;
+                $scope.scroll = -80 * Projector.get(1).scroll;
                 $scope.scale = 100 + 20 * Projector.get(1).scale;
             }
         });

--- a/openslides/core/static/templates/projector.html
+++ b/openslides/core/static/templates/projector.html
@@ -37,7 +37,7 @@
 <div ng-controller="ProjectorCtrl">
   <style type="text/css">
     .scrollcontent {
-      margin-top: {{scroll}}em !important;
+      margin-top: {{scroll}}px !important;
       font-size: {{scale}}%;
     }
   </style>

--- a/openslides/core/views.py
+++ b/openslides/core/views.py
@@ -192,7 +192,8 @@ class ProjectorViewSet(ReadOnlyModelViewSet):
         elif self.action == 'metadata':
             result = self.request.user.has_perm('core.can_see_projector')
         elif self.action in ('activate_elements', 'prune_elements', 'update_elements',
-                             'deactivate_elements', 'clear_elements', 'control_view', 'set_resolution'):
+                             'deactivate_elements', 'clear_elements', 'control_view',
+                             'set_resolution', 'set_scroll'):
             result = (self.request.user.has_perm('core.can_see_projector') and
                       self.request.user.has_perm('core.can_manage_projector'))
         else:
@@ -426,6 +427,25 @@ class ProjectorViewSet(ReadOnlyModelViewSet):
         message = '{action} {direction} was successful.'.format(
             action=request.data['action'].capitalize(),
             direction=request.data['direction'])
+        return Response({'detail': message})
+
+    @detail_route(methods=['post'])
+    def set_scroll(self, request, pk):
+        """
+        REST API operation to scroll the projector.
+
+        It expects a POST request to
+        /rest/core/projector/<pk>/set_scroll/ with a new value for scroll.
+        """
+        if not isinstance(request.data, int):
+            raise ValidationError({'detail': 'Data must be an int.'})
+
+        projector_instance = self.get_object()
+        projector_instance.scroll = request.data
+
+        projector_instance.save()
+        message = 'Setting scroll to {scroll} was successful.'.format(
+            scroll=request.data)
         return Response({'detail': message})
 
 

--- a/openslides/motions/static/js/motions/base.js
+++ b/openslides/motions/static/js/motions/base.js
@@ -162,11 +162,11 @@ angular.module('OpenSlidesApp.motions', [
                 getText: function (versionId) {
                     return this.getVersion(versionId).text;
                 },
-                getTextWithLineBreaks: function (versionId) {
+                getTextWithLineBreaks: function (versionId, highlight, callback) {
                     var lineLength = Config.get('motions_line_length').value,
                         html = this.getVersion(versionId).text;
 
-                    return lineNumberingService.insertLineNumbers(html, lineLength);
+                    return lineNumberingService.insertLineNumbers(html, lineLength, highlight, callback);
                 },
                 setTextStrippingLineBreaks: function (versionId, text) {
                     this.text = lineNumberingService.stripLineNumbers(text);

--- a/openslides/motions/static/js/motions/projector.js
+++ b/openslides/motions/static/js/motions/projector.js
@@ -15,14 +15,69 @@ angular.module('OpenSlidesApp.motions.projector', ['OpenSlidesApp.motions'])
 
 .controller('SlideMotionCtrl', [
     '$scope',
+    '$rootScope',
+    '$http',
     'Motion',
     'User',
     'Config',
-    function($scope, Motion, User, Config) {
+    'Projector',
+    function($scope, $rootScope, $http, Motion, User, Config, Projector) {
         // Attention! Each object that is used here has to be dealt on server side.
         // Add it to the coresponding get_requirements method of the ProjectorElement
         // class.
         var id = $scope.element.id;
+
+        $scope.line = $scope.element.highlightAndScroll;
+
+        // get cookie using jQuery
+        var getCookie = function (name) {
+            var cookieValue = null;
+            if (document.cookie && document.cookie !== '') {
+                var cookies = document.cookie.split(';');
+                for (var i = 0; i < cookies.length; i++) {
+                    var cookie = jQuery.trim(cookies[i]);
+                    // Does this cookie string begin with the name we want?
+                    if (cookie.substring(0, name.length + 1) == (name + '=')) {
+                        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                        break;
+                    }
+                }
+            }
+            return cookieValue;
+        };
+
+        var scrollRequest = function (position) {
+            // request with csrf token
+            // TODO: Why is the X-CSRFToken not included in the header by default?
+            var csrfToken = getCookie('csrftoken');
+            var request = {
+                method: 'POST',
+                url: '/rest/core/projector/1/set_scroll/',
+                data: position,
+                headers: {
+                    'X-CSRFToken': csrfToken
+                }
+            };
+            $http(request);
+        };
+        $scope.scroll = function () {
+            // Prevent getting in an infinite loop by updating only if the value has changed.
+            // (if this check is removed this happends: controller loads --> call of $scope.scroll
+            // --> same line but scrollRequest --> projector updates --> controller loads --> ... )
+            if ($scope.line !== $rootScope.motion_projector_line) {
+                // line value has changed
+                var lineElement = document.getElementsByName('L' + $scope.line);
+                if (lineElement[0]) {
+                    $rootScope.motion_projector_line = $scope.line;
+                    var pos = lineElement[0].getBoundingClientRect().top + Projector.get(1).scroll*80;
+                    scrollRequest(Math.floor(pos/80.0) - 1);
+                } else if ($scope.line === 0) {
+                    $rootScope.motion_projector_line = $scope.line;
+                    scrollRequest(0);
+                }
+            }
+        };
+
         Motion.bindOne(id, $scope, 'motion');
         User.bindAll({}, $scope, 'users');
     }

--- a/openslides/motions/static/js/motions/site.js
+++ b/openslides/motions/static/js/motions/site.js
@@ -1069,9 +1069,10 @@ angular.module('OpenSlidesApp.motions.site', ['OpenSlidesApp.motions', 'OpenSlid
     'PdfMakeDocumentProvider',
     'MotionInlineEditing',
     'gettextCatalog',
+    'Projector',
     function($scope, $http, ngDialog, MotionComment, MotionForm, Motion, Category, Mediafile, Tag,
              User, Workflow, Config, motion, SingleMotionContentProvider, MotionContentProvider,
-             PollContentProvider, PdfMakeConverter, PdfMakeDocumentProvider, MotionInlineEditing, gettextCatalog) {
+             PollContentProvider, PdfMakeConverter, PdfMakeDocumentProvider, MotionInlineEditing, gettextCatalog, Projector) {
         Motion.bindOne(motion.id, $scope, 'motion');
         Category.bindAll({}, $scope, 'categories');
         Mediafile.bindAll({}, $scope, 'mediafiles');
@@ -1087,6 +1088,38 @@ angular.module('OpenSlidesApp.motions.site', ['OpenSlidesApp.motions', 'OpenSlid
             Motion.bindOne(motion.parent_id, $scope, 'parent');
         }
         $scope.amendments = Motion.filter({parent_id: motion.id});
+
+        $scope.highlight = 0;
+        $scope.linesForProjector = false;
+        // Set 0 for disable highlighting on projector
+        var setHighlightOnProjector = function (line) {
+            var elements = _.map(Projector.get(1).elements, function(element) { return element; });
+            elements.forEach(function (element) {
+                if (element.name == 'motions/motion') {
+                    var data = {};
+                    data[element.uuid] = {
+                        highlightAndScroll: line,
+                    };
+                    $http.post('/rest/core/projector/1/update_elements/', data);
+                }
+            });
+        };
+        $scope.scrollToAndHighlight = function (line) {
+            $scope.highlight = line;
+            var lineElement = document.getElementsByName('L' + line);
+            if (lineElement[0]) {
+                // Scroll local
+                $('html, body').animate({
+                    scrollTop: lineElement[0].getBoundingClientRect().top
+                }, 1000);
+            }
+            // set highlight and scroll on Projector
+            setHighlightOnProjector($scope.linesForProjector ? line : 0);
+        };
+        $scope.toggleLinesForProjector = function () {
+            $scope.linesForProjector = !$scope.linesForProjector;
+            setHighlightOnProjector($scope.linesForProjector ? $scope.highlight : 0);
+        };
 
         $scope.makePDF = function() {
           var id = motion.identifier,

--- a/openslides/motions/static/templates/motions/motion-detail.html
+++ b/openslides/motions/static/templates/motions/motion-detail.html
@@ -287,7 +287,7 @@
     </div>
 
     <div class="line-number-setter {{ lineNumberMode }}">
-      <div class="btn-group" data-toggle="buttons">
+      <span class="btn-group" data-toggle="buttons">
         <div class="btn btn-default disabled" title="{{ 'Line Numbering' | translate }}">
           <i class="fa fa-list-ol" aria-hidden="true"></i>
         </div>
@@ -309,9 +309,29 @@
                  ng-checked="lineNumberMode == 'outside'">
           <translate>Outside</translate>
         </label>
-      </div>
+      </span>
+      <span>
+        <form class="input-group" style="max-width: 220px;" ng-if="lineNumberMode != 'none'" ng-submit="scrollToAndHighlight(gotoLinenumber)">
+          <input type="number" class="form-control" ng-model="gotoLinenumber" placeholder="{{ 'Line' | translate }}"></input>
+          <span class="input-group-btn">
+            <button type="button" class="btn btn-default btn-slim" ng-show="gotoLinenumber"
+              ng-click="gotoLinenumber = ''; scrollToAndHighlight(0);">
+              <i class="fa fa-times text-danger"></i>
+            </button>
+            <button type="submit" class="btn btn-default">
+              <i class="fa fa-share"></i>
+              <translate>go</translate>
+            </button>
+            <button type="button" class="btn btn-default" os-perms="core.can_manage_projector"
+              ng-show="lineNumberMode != 'none' && motion.isProjected()" ng-click="toggleLinesForProjector()"
+              uib-tooltip="{{ 'Show highlighted line also on projector.' | translate }}">
+              <i class="fa" ng-class="linesForProjector ? 'fa-check-square-o' : 'fa-square-o'"></i>
+              <i class="fa fa-video-camera"></i>
+            </button>
+          </span>
+        </form>
+      </span>
     </div>
-
     <div  ng-class="{'col-sm-8': (lineNumberMode != 'outside'), 'col-sm-12': (lineNumberMode == 'outside')}">
 
       <div ng-if="motion.isAllowed('update') && version == motion.getVersion(-1).id">
@@ -319,7 +339,7 @@
           <div ui-tinymce="inlineEditing.tinymceOptions" ng-model="inlineEditing.lineBrokenText"
             class="motion-text line-numbers-{{ lineNumberMode }}"></div>
         </div>
-        <div ng-show="!inlineEditing.active" ng-bind-html="motion.getTextWithLineBreaks(version) | trusted"
+        <div ng-show="!inlineEditing.active" ng-bind-html="motion.getTextWithLineBreaks(version, highlight) | trusted"
            class="motion-text line-numbers-{{ lineNumberMode }}"></div>
 
         <div class="motion-save-toolbar" ng-class="{ 'visible': (inlineEditing.changed && inlineEditing.active) }">
@@ -332,7 +352,7 @@
         </div>
       </div>
       <div ng-if="!(motion.isAllowed('update') && version == motion.getVersion(-1).id)">
-        <div ng-bind-html="motion.getTextWithLineBreaks(version) | trusted"
+        <div ng-bind-html="motion.getTextWithLineBreaks(version, highlight) | trusted"
            class="motion-text line-numbers-{{ lineNumberMode }}"></div>
       </div>
 

--- a/openslides/motions/static/templates/motions/slide_motion.html
+++ b/openslides/motions/static/templates/motions/slide_motion.html
@@ -70,7 +70,7 @@
   </div>
 
   <!-- Text -->
-  <div ng-bind-html="motion.getTextWithLineBreaks() | trusted"
+  <div ng-bind-html="motion.getTextWithLineBreaks(null, line, scroll) | trusted"
        class="motion-text line-numbers-{{ config('motions_default_line_numbering') }}"></div>
 
   <!-- Reason -->


### PR DESCRIPTION
~~One problem:
The motion text is rendered in the `linenumbers.js`. I've added span-tags around each line and provided an id `L + lineNumber`. So every line has an id like `L3` for line 3. But these id's are not available in javascript. Trying to click on scroll should scroll to line 1. Additionally the context from `L1` should be changed (see `$scope.scroll` in `site.js`).
For testing I've added some text above. Each line has an id `LC + lineNumber`. Jumping to them works. Even replacing the content inside works.
Does someone know how to make the id's of the motion text accessible and known in javascript?~~

@emanuelschuetze Please test, should be functional.