### PR TITLE
Add line numbers to pdf (fixes #2300)

### DIFF
--- a/openslides/core/static/js/core/site.js
+++ b/openslides/core/static/js/core/site.js
@@ -352,7 +352,9 @@ angular.module('OpenSlidesApp.core.site', [
                                             lineNumberObject = {
                                                 width: 20,
                                                 text: lineNumberOutline,
-                                                color: "gray"
+                                                color: "gray",
+                                                fontSize: 8,
+                                                margin: [0, 2, 0, 0]
                                         },
                                             col = {
                                                 columns: [


### PR DESCRIPTION
Adds "inline like" line numbers to PDF if line numberins was selected.
Currently I support inline-style only, adding a column for outside-style requires quite some changes I guess.

Example:
[Antrag 3-example.pdf](https://github.com/OpenSlides/OpenSlides/files/463895/Antrag.3-example.pdf)

@emanuelschuetze 