### PR TITLE
Motion comment permission fixes on server and client.

### DIFF
--- a/openslides/motions/static/js/motions/base.js
+++ b/openslides/motions/static/js/motions/base.js
@@ -315,7 +315,8 @@ angular.module('OpenSlidesApp.motions', [
 // Service for generic comment fields
 .factory('MotionComment', [
     'Config',
-    function (Config) {
+    'operator',
+    function (Config, operator) {
         return {
             getFields: function () {
                 // Take input from config field and parse it. It can be some
@@ -396,7 +397,7 @@ angular.module('OpenSlidesApp.motions', [
                             templateOptions: {
                                 label: field.name,
                             },
-                            hideExpression: '!model.more'
+                            hide: !operator.hasPerms("motions.can_see_and_manage_comments")
                         };
                     }
                 );

--- a/openslides/motions/static/js/motions/site.js
+++ b/openslides/motions/static/js/motions/site.js
@@ -648,7 +648,9 @@ angular.module('OpenSlidesApp.motions.site', ['OpenSlidesApp.motions', 'OpenSlid
                         placeholder: gettextCatalog.getString('Select a parent item ...')
                     },
                     hide: !operator.hasPerms('agenda.can_manage')
-                },
+                }]
+                .concat(MotionComment.getFormFields())
+                .concat([
                 {
                     key: 'more',
                     type: 'checkbox',
@@ -708,9 +710,8 @@ angular.module('OpenSlidesApp.motions.site', ['OpenSlidesApp.motions', 'OpenSlid
                         placeholder: gettextCatalog.getString('Select or search a supporter ...')
                     },
                     hideExpression: '!model.more'
-                }]
-                .concat(MotionComment.getFormFields())
-                .concat([{
+                },
+                {
                     key: 'workflow_id',
                     type: 'select-single',
                     templateOptions: {

--- a/openslides/motions/views.py
+++ b/openslides/motions/views.py
@@ -106,10 +106,13 @@ class MotionViewSet(ModelViewSet):
             self.permission_denied(request)
 
         # Check permission to send comment data.
-        if (not request.user.has_perm('motions.can_see_and_manage_comments') and
-                request.data.get('comments')):
-            # Some users are not allowed to send comments data.
-            self.permission_denied(request)
+        if not request.user.has_perm('motions.can_see_and_manage_comments'):
+            try:
+                # Ignore comments data if user is not allowed to send comments.
+                del request.data['comments']
+            except KeyError:
+                # No comments here. Just do nothing.
+                pass
 
         # Validate data and create motion.
         serializer = self.get_serializer(data=request.data)


### PR DESCRIPTION
- Show motion comment fields in form also for users without can_manage but with
  can_see_and_manage_comments permission.
- Ignore comments data if user is not allowed to send comments (in create view).