### PR TITLE
Fixed motion form to save form with default text (Fixes #2069).

### DIFF
--- a/openslides/motions/static/templates/motions/motion-form.html
+++ b/openslides/motions/static/templates/motions/motion-form.html
@@ -6,7 +6,7 @@
   {{ alert.msg }}
 </uib-alert>
 
-<form name="motionForm" ng-submit="save(model)">
+<form name="motionForm" ng-submit="save(model)" novalidate>
   <formly-form model="model" fields="formFields">
     <button type="submit" ng-disabled="motionForm.$invalid" class="btn btn-primary" translate>
       Save


### PR DESCRIPTION
Use workaround: Added 'novalidate' to motion form. Otherwise user
can't save form if text editor field contains default value.