### PR TITLE
Upgraded requirements.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "OpenSlides",
+  "name": "openslides",
   "private": true,
   "dependencies": {
     "jquery": "~3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "OpenSlides",
+  "name": "openslides",
   "private": true,
   "scripts": {
     "prepublish": "bower install && gulp"

--- a/requirements_production.txt
+++ b/requirements_production.txt
@@ -10,5 +10,6 @@ natsort>=3.2,<5.1
 PyPDF2>=1.25.0,<1.27
 reportlab>=3.0,<3.4
 roman>=2.0,<2.1
-setuptools>=18.5,<26.0
+setuptools>=18.5,<28.0
+twisted>=16.2,<16.4
 Whoosh>=2.7.0,<2.8


### PR DESCRIPTION
Use twisted<16.4 for easier install (without compiling).
Use lowercase name 'openslides' in bower.jspon and packages.json to
prevent warning.