### PR TITLE
Disable projector auto reload after 5 minutes.

### DIFF
--- a/openslides/core/static/js/core/base.js
+++ b/openslides/core/static/js/core/base.js
@@ -18,9 +18,6 @@ angular.module('OpenSlidesApp.core', [
     'DSProvider',
     'DSHttpAdapterProvider',
     function(DSProvider, DSHttpAdapterProvider) {
-        // Reloads everything after 5 minutes.
-        // TODO: * find a way only to reload things that are still needed
-        DSProvider.defaults.maxAge = 5 * 60 * 1000;  // 5 minutes
         DSProvider.defaults.reapAction = 'none';
         DSProvider.defaults.basePath = '/rest';
         DSProvider.defaults.afterReap = function(model, items) {


### PR DESCRIPTION
Auto reload no longer used because client gets all required data
after reconnection via websocket.