### PR TITLE
Add motion catalog over pdfmake (fixes #2299)

### DIFF
--- a/openslides/core/static/js/core/site.js
+++ b/openslides/core/static/js/core/site.js
@@ -89,6 +89,22 @@ angular.module('OpenSlidesApp.core.site', [
                         header: header,
                         footer: footer,
                         content: content,
+                        styles: {
+                            title: {
+                                fontSize: 30,
+                                margin: [0,0,0,20],
+                                bold: true
+                            },
+                            heading: {
+                                fontSize: 16,
+                                margin: [0,0,0,10],
+                                bold: true
+                            },
+                            tableofcontent: {
+                                fontSize: 12,
+                                margin: [0,3]
+                            }
+                        }
                     };
                 };
             return {

--- a/openslides/motions/static/templates/motions/motion-list.html
+++ b/openslides/motions/static/templates/motions/motion-list.html
@@ -47,7 +47,7 @@
         <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownExport">
           <!-- PDF export -->
           <li>
-            <a ui-sref="motions_pdf" target="_blank">
+            <a href="" ng-click="pdf_export()">
               <i class="fa fa-file-pdf-o fa-lg"></i>
               <translate>PDF</translate>
             </a>
@@ -180,7 +180,7 @@
                   <translate translate-comment="short form of agenda item">Item</translate>
                   <span class="spacer-right pull-right"></span>
                   <i class="pull-right fa"
-                    ng-style="{'visibility': sortColumn === 'agenda_item.getItemNumberWithAncestors()' && header.sortable != false ? 'visible' : 'hidden'}" 
+                    ng-style="{'visibility': sortColumn === 'agenda_item.getItemNumberWithAncestors()' && header.sortable != false ? 'visible' : 'hidden'}"
                     ng-class="reverse ? 'fa-sort-desc' : 'fa-sort-asc'">
                   </i>
                 </div>
@@ -191,7 +191,7 @@
                   <translate>Identifier</translate>
                 <span class="spacer-right pull-right"></span>
                   <i class="pull-right fa"
-                    ng-style="{'visibility': sortColumn === 'identifier' && header.sortable != false ? 'visible' : 'hidden'}" 
+                    ng-style="{'visibility': sortColumn === 'identifier' && header.sortable != false ? 'visible' : 'hidden'}"
                     ng-class="reverse ? 'fa-sort-desc' : 'fa-sort-asc'">
                   </i>
                 </div>
@@ -202,7 +202,7 @@
                   <translate>Title</translate>
                   <span class="spacer-right pull-right"></span>
                   <i class="pull-right fa"
-                    ng-style="{'visibility': sortColumn === 'getTitle()' && header.sortable != false ? 'visible' : 'hidden'}" 
+                    ng-style="{'visibility': sortColumn === 'getTitle()' && header.sortable != false ? 'visible' : 'hidden'}"
                     ng-class="reverse ? 'fa-sort-desc' : 'fa-sort-asc'">
                   </i>
                 </div>
@@ -213,7 +213,7 @@
                   <translate>Submitters</translate>
                   <span class="spacer-right pull-right"></span>
                   <i class="pull-right fa"
-                    ng-style="{'visibility': sortColumn === 'submitters' && header.sortable != false ? 'visible' : 'hidden'}" 
+                    ng-style="{'visibility': sortColumn === 'submitters' && header.sortable != false ? 'visible' : 'hidden'}"
                     ng-class="reverse ? 'fa-sort-desc' : 'fa-sort-asc'">
                   </i>
                 </div>
@@ -224,7 +224,7 @@
                   <translate>Category</translate>
                   <span class="spacer-right pull-right"></span>
                   <i class="pull-right fa"
-                    ng-style="{'visibility': sortColumn === 'category' && header.sortable != false ? 'visible' : 'hidden'}" 
+                    ng-style="{'visibility': sortColumn === 'category' && header.sortable != false ? 'visible' : 'hidden'}"
                     ng-class="reverse ? 'fa-sort-desc' : 'fa-sort-asc'">
                   </i>
                 </div>
@@ -235,7 +235,7 @@
                   <translate>State</translate>
                   <span class="spacer-right pull-right"></span>
                   <i class="pull-right fa"
-                    ng-style="{'visibility': sortColumn === 'state.name' && header.sortable != false ? 'visible' : 'hidden'}" 
+                    ng-style="{'visibility': sortColumn === 'state.name' && header.sortable != false ? 'visible' : 'hidden'}"
                     ng-class="reverse ? 'fa-sort-desc' : 'fa-sort-asc'">
                   </i>
                 </div>
@@ -295,7 +295,7 @@
         | SelectMultipleFilter: multiselectFilter.category : getItemId.category
         | SelectMultipleFilter: multiselectFilter.tag : getItemId.tag
         | orderBy: sortColumn : reverse)">
-        
+
       <!-- select column -->
       <div ng-show="isDeleteMode" os-perms="motions.can_manage"
         class="col-xs-1 centered" ng-class="{'deleteColumn' : motion.selected}">
@@ -362,7 +362,7 @@
           <!-- Submitters -->
           <div>
             <small>
-              <span class="optional" translate>by</span> 
+              <span class="optional" translate>by</span>
               <span class="optional" ng-repeat="submitter in motion.submitters | limitTo:3">
                 {{ submitter.get_full_name() }}<span ng-if="!$last">,</span></span><span ng-if="motion.submitters.length > 3">, ...</span>
               <!-- sorry for merging them together, but otherwise there would be a whitespace because of the new line -->


### PR DESCRIPTION
This needed more changes then I originally expected. I needed to change a lot of code in some factory-patterns since it was unnecessary or overly complicated in my opinion.
Also, some code was (still) misaligned.
Travis probably to refuse to check this one.
edit: After rebaseing, travis was okay with this pullrequest

@emanuelschuetze 
@normanjaeckel 

Examples:
an unfiltered catalog, just exported everyting, also had 2 categories
[sampleUnfiltered.pdf](https://github.com/OpenSlides/OpenSlides/files/490830/sampleUnfiltered.pdf)

![bildschirmfoto von 2016-09-24 01-36-05](https://cloud.githubusercontent.com/assets/10233032/18804126/550a9b12-81f7-11e6-8c3d-18339af41f6d.png)

And only filtered by "Vocaloid". I removed the categories manually.
[SampleFilteredNoCat.pdf](https://github.com/OpenSlides/OpenSlides/files/490832/SampleFilteredNoCat.pdf)
