### PR TITLE
Repairs invalid HTML during PDF generation (fixes #2433)

### DIFF
--- a/openslides/core/static/js/core/site.js
+++ b/openslides/core/static/js/core/site.js
@@ -23,6 +23,29 @@ angular.module('OpenSlidesApp.core.site', [
 // Can be used to find out if the projector or the side is used
 .constant('REALM', 'site')
 
+//for global usage
+.factory('HTMLValidizer', function() {
+    var HTMLValidizer = {};
+
+    //checks if str is valid HTML. Returns valid HTML if not,
+    //return emptystring if empty
+    HTMLValidizer.validize = function(str) {
+        if (str) {
+            var a = document.createElement('div');
+            a.innerHTML = str;
+            angular.forEach(a.childNodes, function (child) {
+                if (child.nodeType == 1) {
+                    return str;
+                }
+            });
+            return "<p>" + str + "</p>";
+        } else {
+            return ""; //needed for blank "reaons" field
+        }
+    };
+    return HTMLValidizer;
+})
+
 .factory('PdfMakeDocumentProvider', [
     'gettextCatalog',
     'Config',
@@ -116,7 +139,9 @@ angular.module('OpenSlidesApp.core.site', [
         };
     }
 ])
-.factory('PdfMakeConverter', function() {
+.factory('PdfMakeConverter', [
+    'HTMLValidizer',
+    function(HTMLValidizer) {
         /**
          * Converter component for HTML->JSON for pdfMake
          * @constructor
@@ -471,7 +496,8 @@ angular.module('OpenSlidesApp.core.site', [
                          * @param {object} htmlText   -
                          */
                         ParseHtml = function(converted, htmlText) {
-                            var html = $(htmlText.replace(/\t/g, "").replace(/\n/g, ""));
+                            var html = HTMLValidizer.validize(htmlText);
+                            html = $(html.replace(/\t/g, "").replace(/\n/g, ""));
                             var emptyParagraph = create("text");
                             slice(html).forEach(function(element) {
                                 ParseElement(converted, element);
@@ -509,7 +535,7 @@ angular.module('OpenSlidesApp.core.site', [
         return {
             createInstance: createInstance
         };
-})
+}])
 
 // Provider to register entries for the main menu.
 .provider('mainMenu', [

--- a/openslides/motions/static/js/motions/site.js
+++ b/openslides/motions/static/js/motions/site.js
@@ -916,9 +916,10 @@ angular.module('OpenSlidesApp.motions.site', ['OpenSlidesApp.motions', 'OpenSlid
     'PdfMakeConverter',
     'PdfMakeDocumentProvider',
     'gettextCatalog',
+    'HTMLValidizer',
     function($scope, $state, $http, ngDialog, MotionForm, Motion, Category, Tag, Workflow, User, Agenda, MotionDocxExport,
                 MotionContentProvider, MotionCatalogContentProvider, PdfMakeConverter,
-                PdfMakeDocumentProvider, gettextCatalog) {
+                PdfMakeDocumentProvider, gettextCatalog, HTMLValidizer) {
         Motion.bindAll({}, $scope, 'motions');
         Category.bindAll({}, $scope, 'categories');
         Tag.bindAll({}, $scope, 'tags');
@@ -1084,7 +1085,7 @@ angular.module('OpenSlidesApp.motions.site', ['OpenSlidesApp.motions', 'OpenSlid
 
             //save the arrays of the filtered motions to an array
             angular.forEach($scope.motionsFiltered, function (motion) {
-                var content = motion.getText() + motion.getReason();
+                var content = HTMLValidizer.validize(motion.getText($scope.version)) + HTMLValidizer.validize(motion.getReason($scope.version));
                 var map = Function.prototype.call.bind([].map);
                 var tmp_image_sources = map($(content).find("img"), function(element) {
                     return element.getAttribute("src");
@@ -1190,9 +1191,10 @@ angular.module('OpenSlidesApp.motions.site', ['OpenSlidesApp.motions', 'OpenSlid
     'MotionInlineEditing',
     'gettextCatalog',
     'Projector',
+    'HTMLValidizer',
     function($scope, $http, ngDialog, MotionForm, Motion, Category, Mediafile, Tag, User, Workflow, Config,
              motion, MotionContentProvider, PollContentProvider,
-             PdfMakeConverter, PdfMakeDocumentProvider, MotionInlineEditing, gettextCatalog, Projector) {
+             PdfMakeConverter, PdfMakeDocumentProvider, MotionInlineEditing, gettextCatalog, Projector, HTMLValidizer) {
         Motion.bindOne(motion.id, $scope, 'motion');
         Category.bindAll({}, $scope, 'categories');
         Mediafile.bindAll({}, $scope, 'mediafiles');
@@ -1242,7 +1244,7 @@ angular.module('OpenSlidesApp.motions.site', ['OpenSlidesApp.motions', 'OpenSlid
         };
 
         $scope.makePDF = function() {
-            var content = motion.getText() + motion.getReason();
+            var content = HTMLValidizer.validize(motion.getText($scope.version)) + HTMLValidizer.validize(motion.getReason($scope.version));
             var map = Function.prototype.call.bind([].map);
             var image_sources = map($(content).find("img"), function(element) {
                 return element.getAttribute("src");


### PR DESCRIPTION
Introduces a new global usable factory to repair invalid HTML strings.
since I use it three times in the program, I decided to use a factory for that.

Samples as usual:
[Anträge-sample.pdf](https://github.com/OpenSlides/OpenSlides/files/493659/Antrage-sample.pdf)

@emanuelschuetze 
@normanjaeckel 