### PR TITLE
PDF line numbers for new linenumbering.js (fixes #2441)

### DIFF
--- a/openslides/motions/static/js/motions/linenumbering.js
+++ b/openslides/motions/static/js/motions/linenumbering.js
@@ -88,6 +88,9 @@ angular.module('OpenSlidesApp.motions.lineNumbering', [])
             service = this;
         var addLine = function (text, highlight) {
             var node;
+            if (typeof highlight === 'undefined') {
+                highlight = 0;
+            }
             if (firstTextNode) {
                 if (highlight == service._currentLineNumber - 1) {
                     node = document.createElement('span');

--- a/openslides/motions/static/js/motions/site.js
+++ b/openslides/motions/static/js/motions/site.js
@@ -21,7 +21,7 @@ angular.module('OpenSlidesApp.motions.site', ['OpenSlidesApp.motions', 'OpenSlid
                 * other project that might want to use this HTML to PDF parser.
                 * https://github.com/OpenSlides/OpenSlides/issues/2361
                 */
-                return converter.convertHTML($scope.lineBrokenText, $scope);
+                return converter.convertHTML(motion.getTextWithLineBreaks($scope.version, 0), $scope);
             } else {
                 return converter.convertHTML(motion.getText($scope.version), $scope);
             }

--- a/openslides/motions/static/js/motions/site.js
+++ b/openslides/motions/static/js/motions/site.js
@@ -21,7 +21,7 @@ angular.module('OpenSlidesApp.motions.site', ['OpenSlidesApp.motions', 'OpenSlid
                 * other project that might want to use this HTML to PDF parser.
                 * https://github.com/OpenSlides/OpenSlides/issues/2361
                 */
-                return converter.convertHTML(motion.getTextWithLineBreaks($scope.version, 0), $scope);
+                return converter.convertHTML(motion.getTextWithLineBreaks($scope.version), $scope);
             } else {
                 return converter.convertHTML(motion.getText($scope.version), $scope);
             }


### PR DESCRIPTION
fixes the issue mentioned above.
No examples this time.

Thanks to @FinnStutzenstein for helping out with the required information!