### PR TITLE
some minor fixes

### DIFF
--- a/openslides/assignments/static/templates/assignments/assignment-detail.html
+++ b/openslides/assignments/static/templates/assignments/assignment-detail.html
@@ -78,8 +78,10 @@
 </div>
 
 <div class="details">
-  <h3 translate>Description</h3>
-  <div class="white-space-pre-line">{{ assignment.description }}</div>
+  <div ng-if="assignment.description">
+    <h3 translate>Description</h3>
+    <div class="white-space-pre-line">{{ assignment.description }}</div>
+  </div>
 
   <div ng-if="assignment.phase != 2">
     <h3 translate>Candidates</h3>

--- a/openslides/core/static/js/core/base.js
+++ b/openslides/core/static/js/core/base.js
@@ -215,7 +215,7 @@ angular.module('OpenSlidesApp.core', [
     '$rootScope',
     function ($http, $rootScope) {
         // Loads server time and calculates server offset
-        $rootScope.serverOffset = Math.floor(Date.now() / 1000);
+        $rootScope.serverOffset = 0;
         $http.get('/core/servertime/')
         .then(function(data) {
             $rootScope.serverOffset = Math.floor(Date.now() / 1000 - data.data);

--- a/openslides/mediafiles/static/templates/mediafiles/mediafile-list.html
+++ b/openslides/mediafiles/static/templates/mediafiles/mediafile-list.html
@@ -56,7 +56,7 @@
               </button>
               <button class="btn" ng-click="mediafileFit()" title="{{ 'Reset zoom' | translate }}"
                   ng-class="presentedMediafile.scale=='page-fit' ? 'btn-primary' : 'btn-default'">
-                100%
+                <i class="fa fa-arrows-alt"></i>
               </button>
               <button class="btn btn-default" ng-click="mediafileZoomIn()" title="{{ 'Zoom in' | translate }}">
                 <i class="fa fa-search-plus"></i>


### PR DESCRIPTION
1. Do not show the description header if there is no description of an election
2. The serverOffset has to be initialized with 0 assuming that the servers time is equal with the clients time. This fixes the projector clock bug, that when the projector is loaded the clock shows 01:00 until the first autoupdate comes in.
3. Many users of OpenSlides find the caption '100%' in the pdf control irritating. Most users don't get, that this is a button but an indicator for the zoom. If one zooms in, it stays at 100% and he thinks that this is a bug. For that reason I changed the '100%' to the full screen icon also used by images.