### PR TITLE
Send full_data through the channel.

### DIFF
--- a/openslides/utils/collection.py
+++ b/openslides/utils/collection.py
@@ -80,8 +80,12 @@ class CollectionElement:
             'collection_string': self.collection_string,
             'id': self.id,
             'deleted': self.is_deleted()}
-        if self.information is not None:
+        if self.information:
             channel_message['information'] = self.information
+        if self.full_data:
+            # Do not use the method get_full_data but the attribute, so the
+            # full_data is not generated.
+            channel_message['full_data'] = self.full_data
         return channel_message
 
     def as_autoupdate(self, method, *args):

--- a/tests/unit/utils/test_collection.py
+++ b/tests/unit/utils/test_collection.py
@@ -90,8 +90,7 @@ class TestCollectionElement(TestCase):
             collection_element.as_channels_message(),
             {'collection_string': 'testmodule/model',
              'id': 42,
-             'deleted': False,
-             'information': {}})
+             'deleted': False})
 
     def test_as_autoupdate_for_user(self):
         collection_element = collection.CollectionElement.from_values('testmodule/model', 42)


### PR DESCRIPTION
Saves db queries.

The ```is not None``` check is not needed because self.information is never None. It can be an empty dict.