### PR TITLE
Generate agendas using pdfmake

### DIFF
--- a/openslides/agenda/static/js/agenda/pdf.js
+++ b/openslides/agenda/static/js/agenda/pdf.js
@@ -1,0 +1,80 @@
+(function () {
+
+'use strict';
+
+angular.module('OpenSlidesApp.agenda.pdf', ['OpenSlidesApp.core.pdf'])
+
+.factory('AgendaContentProvider', [
+    'gettextCatalog',
+    'PdfPredefinedFunctions',
+    function(gettextCatalog, PdfPredefinedFunctions) {
+
+    var createInstance = function(items) {
+
+        //use the Predefined Functions to create the title
+        var title = PdfPredefinedFunctions.createTitle(gettextCatalog.getString("Agenda"));
+
+        //function to generate the item list out of the given "items" object
+        var createItemList = function() {
+            var agenda_items = [];
+            angular.forEach(items, function (item) {
+                if (item.is_hidden === false) {
+
+                    var itemIndent = item.parentCount * 20;
+
+                    var itemStyle;
+                    if (item.parentCount === 0) {
+                        itemStyle = 'listParent';
+                    } else {
+                        itemStyle = 'listChild';
+                    }
+
+                    var itemNumberWidth;
+                    if (item.item_number === "") {
+                        itemNumberWidth = 0;
+                    } else {
+                        itemNumberWidth = 60;
+                    }
+
+                    var agendaJsonString = {
+                        style: itemStyle,
+                        columns: [
+                            {
+                                width: itemIndent,
+                                text: ''
+                            },
+                            {
+                                width: itemNumberWidth,
+                                text: item.item_number
+                            },
+                            {
+                                text: item.title
+                            }
+                        ]
+                    };
+
+                    agenda_items.push(agendaJsonString);
+                }
+            });
+            return agenda_items;
+        };
+
+        var getContent = function() {
+            return [
+                title,
+                createItemList()
+            ];
+        };
+
+        return {
+            getContent: getContent
+        };
+    };
+
+    return {
+        createInstance: createInstance
+    };
+
+}]);
+
+}());

--- a/openslides/agenda/static/js/agenda/site.js
+++ b/openslides/agenda/static/js/agenda/site.js
@@ -2,7 +2,11 @@
 
 'use strict';
 
-angular.module('OpenSlidesApp.agenda.site', ['OpenSlidesApp.agenda'])
+angular.module('OpenSlidesApp.agenda.site', [
+    'OpenSlidesApp.agenda',
+    'OpenSlidesApp.core.pdf',
+    'OpenSlidesApp.agenda.pdf'
+])
 
 .config([
     'mainMenuProvider',
@@ -100,7 +104,11 @@ angular.module('OpenSlidesApp.agenda.site', ['OpenSlidesApp.agenda'])
     'AgendaTree',
     'Projector',
     'ProjectionDefault',
-    function($scope, $filter, $http, $state, DS, operator, ngDialog, Agenda, TopicForm, AgendaTree, Projector, ProjectionDefault) {
+    'AgendaContentProvider',
+    'PdfMakeDocumentProvider',
+    'gettextCatalog',
+    function($scope, $filter, $http, $state, DS, operator, ngDialog, Agenda, TopicForm, AgendaTree, Projector,
+        ProjectionDefault, AgendaContentProvider, PdfMakeDocumentProvider, gettextCatalog) {
         // Bind agenda tree to the scope
         $scope.$watch(function () {
             return Agenda.lastModified();
@@ -306,6 +314,13 @@ angular.module('OpenSlidesApp.agenda.site', ['OpenSlidesApp.agenda'])
         // auto numbering of agenda items
         $scope.autoNumbering = function() {
             $http.post('/rest/agenda/item/numbering/', {});
+        };
+
+        $scope.makePDF = function() {
+            var filename = gettextCatalog.getString("Agenda")+".pdf";
+            var agendaContentProvider = AgendaContentProvider.createInstance($scope.items);
+            var documentProvider = PdfMakeDocumentProvider.createInstance(agendaContentProvider);
+            pdfMake.createPdf(documentProvider.getDocument()).download(filename);
         };
     }
 ])

--- a/openslides/agenda/static/templates/agenda/item-list.html
+++ b/openslides/agenda/static/templates/agenda/item-list.html
@@ -23,7 +23,7 @@
       <div class="btn-group button" uib-dropdown
         uib-tooltip="{{ 'Projector' | translate }} {{ isAgendaProjected(mainListTree) }}"
         tooltip-enable="isAgendaProjected(mainListTree) > 0"
-        os-perms="core.can_manage_projector"> 
+        os-perms="core.can_manage_projector">
         <button type="button" class="btn btn-default btn-sm"
             title="{{ 'Project agenda' | translate }}"
             ng-click="projectAgenda(defaultProjectorId_all_items, mainListTree)"
@@ -83,7 +83,7 @@
             <translate>Numbering</translate>
           </a>
           <!-- pdf -->
-          <a ui-sref="agenda_pdf" target="_blank" class="btn btn-default btn-sm">
+          <a ng-click="makePDF()" class="btn btn-default btn-sm">
             <i class="fa fa-file-pdf-o fa-lg"></i>
             <translate>PDF</translate>
           </a>

--- a/openslides/core/static/js/core/pdf.js
+++ b/openslides/core/static/js/core/pdf.js
@@ -4,6 +4,21 @@
 
 angular.module('OpenSlidesApp.core.pdf', [])
 
+.factory('PdfPredefinedFunctions', [
+    function() {
+        var PdfPredefinedFunctions = {};
+
+        PdfPredefinedFunctions.createTitle = function(titleString) {
+            return {
+                text: titleString,
+                style: "title"
+            };
+        };
+
+        return PdfPredefinedFunctions;
+    }
+])
+
 .factory('HTMLValidizer', function() {
     var HTMLValidizer = {};
 
@@ -106,6 +121,14 @@ angular.module('OpenSlidesApp.core.pdf', [])
                             tableofcontent: {
                                 fontSize: 12,
                                 margin: [0,3]
+                            },
+                            listParent: {
+                                fontSize: 14,
+                                margin: [0,5]
+                            },
+                            listChild: {
+                                fontSize: 11,
+                                margin: [0,5]
                             }
                         }
                     };

--- a/openslides/motions/static/js/motions/pdf.js
+++ b/openslides/motions/static/js/motions/pdf.js
@@ -2,15 +2,21 @@
 
 "use strict";
 
-angular.module('OpenSlidesApp.motions.pdf', [])
+angular.module('OpenSlidesApp.motions.pdf', ['OpenSlidesApp.core.pdf'])
 
-.factory('MotionContentProvider', ['gettextCatalog', function(gettextCatalog) {
+.factory('MotionContentProvider', [
+    'gettextCatalog',
+    'PdfPredefinedFunctions',
+    function(gettextCatalog, PdfPredefinedFunctions) {
     /**
      * Provides the content as JS objects for Motions in pdfMake context
      * @constructor
      */
 
     var createInstance = function(converter, motion, $scope, User) {
+
+        var header = PdfPredefinedFunctions.createTitle(gettextCatalog.getString("Motion") + " " +
+            motion.identifier + ": " + motion.getTitle($scope.version));
 
         // generates the text of the motion. Also septerates between line-numbers
         var textContent = function() {
@@ -30,14 +36,6 @@ angular.module('OpenSlidesApp.motions.pdf', [])
         // Generate text of reason
         var reasonContent = function() {
             return converter.convertHTML(motion.getReason($scope.version), $scope);
-        };
-
-        // Generate header text of motion
-        var motionHeader = function() {
-            var header = converter.createElement("text", gettextCatalog.getString("Motion") + " " + motion.identifier + ": " + motion.getTitle($scope.version));
-            header.bold = true;
-            header.fontSize = 26;
-            return header;
         };
 
         // Generate text of signment
@@ -119,7 +117,7 @@ angular.module('OpenSlidesApp.motions.pdf', [])
             return result;
         };
 
-        // Generates title section for motion
+        //Generates title section for motion
         var titleSection = function() {
             var title = converter.createElement("text", motion.getTitle($scope.version));
             title.bold = true;
@@ -154,7 +152,7 @@ angular.module('OpenSlidesApp.motions.pdf', [])
         var getContent = function() {
             if (reasonContent().length === 0 ) {
                 return [
-                    motionHeader(),
+                    header,
                     signment(),
                     polls(),
                     titleSection(),
@@ -162,7 +160,7 @@ angular.module('OpenSlidesApp.motions.pdf', [])
                 ];
             } else {
                 return [
-                    motionHeader(),
+                    header,
                     signment(),
                     polls(),
                     titleSection(),
@@ -315,7 +313,10 @@ angular.module('OpenSlidesApp.motions.pdf', [])
     };
 })
 
-.factory('MotionCatalogContentProvider', ['gettextCatalog', function(gettextCatalog) {
+.factory('MotionCatalogContentProvider', [
+    'gettextCatalog',
+    'PdfPredefinedFunctions',
+    function(gettextCatalog, PdfPredefinedFunctions) {
 
     /**
     * Constructor
@@ -326,14 +327,7 @@ angular.module('OpenSlidesApp.motions.pdf', [])
     */
     var createInstance = function(allMotions, $scope, User, Category) {
 
-        //function to create the Table of contents
-        var createTitle = function() {
-
-            return {
-                text: gettextCatalog.getString("Motions"),
-                style: "title"
-            };
-        };
+        var title = PdfPredefinedFunctions.createTitle("Motions");
 
         var createTOContent = function(motionTitles) {
 
@@ -420,7 +414,7 @@ angular.module('OpenSlidesApp.motions.pdf', [])
             });
 
             return [
-                createTitle(),
+                title,
                 createTOCatergories(),
                 createTOContent(motionTitles),
                 motionContent


### PR DESCRIPTION
Replaces the current agenda generation with makePDF.
Also Cleans up some PDF generations.

As usual, see the examples below:

(normal)
![bildschirmfoto von 2016-10-08 21-42-06](https://cloud.githubusercontent.com/assets/10233032/19215574/427bf336-8da2-11e6-99d6-375404afc3f5.png)
will result in
[Agenda_sample_1.pdf](https://github.com/OpenSlides/OpenSlides/files/517900/Agenda_sample_1.pdf)

(with "TOP:"-prefix)
![bildschirmfoto von 2016-10-08 21-44-21](https://cloud.githubusercontent.com/assets/10233032/19215583/5bd6e0ca-8da2-11e6-8a96-1d95c276e728.png)
will result in
[Agenda_sample_2.pdf](https://github.com/OpenSlides/OpenSlides/files/517901/Agenda_sample_2.pdf)

(mix of prefix and no prefix and large titles)
![bildschirmfoto von 2016-10-08 21-47-30](https://cloud.githubusercontent.com/assets/10233032/19215589/86408e42-8da2-11e6-9eb8-919a3eafe32f.png)
will result in
[Agenda_sample_3.pdf](https://github.com/OpenSlides/OpenSlides/files/517902/Agenda_sample_3.pdf)



@emanuelschuetze 
@normanjaeckel 