### PR TITLE
Fixed autoupdate for motion and assigment polls.

### DIFF
--- a/openslides/assignments/serializers.py
+++ b/openslides/assignments/serializers.py
@@ -144,7 +144,7 @@ class AssignmentAllPollSerializer(ModelSerializer):
                     if vote_value not in instance.get_vote_values():
                         raise ValidationError({
                             'detail': _('Vote value %s is invalid.') % vote_value})
-                instance.set_vote_objects_with_values(option, votes[index])
+                instance.set_vote_objects_with_values(option, votes[index], skip_autoupdate=True)
 
         # Update remaining writeable fields.
         instance.description = validated_data.get('description', instance.description)

--- a/openslides/motions/serializers.py
+++ b/openslides/motions/serializers.py
@@ -203,7 +203,7 @@ class MotionPollSerializer(ModelSerializer):
                 if vote_value not in instance.get_vote_values():
                     raise ValidationError({
                         'detail': _('Vote value %s is invalid.') % vote_value})
-            instance.set_vote_objects_with_values(instance.get_options().get(), votes)
+            instance.set_vote_objects_with_values(instance.get_options().get(), votes, skip_autoupdate=True)
 
         # Update remaining writeable fields.
         instance.votesvalid = validated_data.get('votesvalid', instance.votesvalid)

--- a/openslides/poll/models.py
+++ b/openslides/poll/models.py
@@ -163,7 +163,7 @@ class BasePoll(models.Model):
         """
         return self.get_vote_class().objects.filter(option__poll__id=self.id)
 
-    def set_vote_objects_with_values(self, option, data):
+    def set_vote_objects_with_values(self, option, data, skip_autoupdate=False):
         """
         Creates or updates the vote objects for the poll.
         """
@@ -173,7 +173,7 @@ class BasePoll(models.Model):
             except ObjectDoesNotExist:
                 vote = self.get_vote_class()(option=option, value=value)
             vote.weight = data[value]
-            vote.save()
+            vote.save(skip_autoupdate=skip_autoupdate)
 
     def get_vote_objects_with_values(self, option_id):
         """


### PR DESCRIPTION
Send autoupdate once only after all votes are saved. Disable
autoupdate for saving incompleted vote results.

@normanjaeckel as discussed...