### PR TITLE
Bugfix: Always open motions in original view

### DIFF
--- a/openslides/motions/static/js/motions/motion-services.js
+++ b/openslides/motions/static/js/motions/motion-services.js
@@ -452,7 +452,7 @@ angular.module('OpenSlidesApp.motions.motionservices', ['OpenSlidesApp.motions',
             }, 0, false);
         };
 
-        obj.init = function (_scope) {
+        obj.init = function (_scope, viewMode) {
             $scope = _scope;
             $scope.$evalAsync(function() {
                 obj.repositionOriginalAnnotations();
@@ -477,6 +477,8 @@ angular.module('OpenSlidesApp.motions.motionservices', ['OpenSlidesApp.motions',
             $scope.$on('$destroy', function() {
                 $interval.cancel(sizeChecker);
             });
+
+            obj.mode = viewMode;
         };
 
         return obj;

--- a/openslides/motions/static/js/motions/site.js
+++ b/openslides/motions/static/js/motions/site.js
@@ -1200,7 +1200,7 @@ angular.module('OpenSlidesApp.motions.site', [
 
         // Change recommendation viewing
         $scope.viewChangeRecommendations = ChangeRecommmendationView;
-        $scope.viewChangeRecommendations.init($scope);
+        $scope.viewChangeRecommendations.init($scope, 'original');
 
         // PDF creating functions
         $scope.pdfExport = MotionPDFExport;


### PR DESCRIPTION
Previously, a motion was opened in the view mode of the previously opened motion, even if this view mode is not officially available (like the diff-view when no change recommendation has been created)
