### PR TITLE
Freeze angular-csv-import version to 0.0.36.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "angular-bootstrap": "~2.1.3",
     "angular-bootstrap-colorpicker": "~3.0.25",
     "angular-chosen-localytics": "~1.5.0",
-    "angular-csv-import": "~0.0.36",
+    "angular-csv-import": "0.0.36",
     "angular-file-saver": "~1.1.2",
     "angular-formly": "~8.4.0",
     "angular-formly-templates-bootstrap": "~6.2.0",


### PR DESCRIPTION
Current 0.0.37 release breaks the import button in our templates. Needs more work later.