### PR TITLE
Switch back to original view after deleting last change recommendation (Closes #2617)

### DIFF
--- a/openslides/motions/static/js/motions/motion-services.js
+++ b/openslides/motions/static/js/motions/motion-services.js
@@ -461,6 +461,13 @@ angular.module('OpenSlidesApp.motions.motionservices', ['OpenSlidesApp.motions',
             $scope.$watch(function() {
                 return $('.change-recommendation-list').children().length;
             }, obj.repositionOriginalAnnotations);
+            $scope.$watch(function () {
+                return $scope.change_recommendations.length;
+            }, function () {
+                if ($scope.change_recommendations.length === 0) {
+                    obj.mode = 'original';
+                }
+            });
 
             var sizeCheckerLastSize = null,
                 sizeCheckerLastClass = null,


### PR DESCRIPTION
After deleting the last change recommendation, the view remained in the diff view, but the controls to switch back to original view are not shown anymore. This switches the view back to the original view.
This addresses the following issue: #2617 