### PR TITLE
Bugfix disabling inline editing

### DIFF
--- a/openslides/motions/static/js/motions/motion-services.js
+++ b/openslides/motions/static/js/motions/motion-services.js
@@ -315,6 +315,17 @@ angular.module('OpenSlidesApp.motions.motionservices', ['OpenSlidesApp.motions',
             $content.on("mouseover", ".line-numbers-outside .os-line-number.selectable", obj.mouseOver);
             $content.on("mouseover", ".motion-text-original", obj.startCreating);
 
+            $scope.$watch(function () {
+                return $scope.change_recommendations.length;
+            }, function () {
+                if (obj.mode == MODE_INACTIVE || obj.mode == MODE_SELECTING_FROM) {
+                    // Recalculate the affected lines so we cannot select lines affected by a recommendation
+                    // that has just been created
+                    $(".motion-text-original .os-line-number").removeClass("selected selectable");
+                    obj.startCreating();
+                }
+            });
+
             $scope.$on("$destroy", function () {
                 obj.destroy();
             });

--- a/openslides/motions/static/js/motions/site.js
+++ b/openslides/motions/static/js/motions/site.js
@@ -1093,7 +1093,7 @@ angular.module('OpenSlidesApp.motions.site', [
         // open edit dialog
         $scope.openDialog = function (motion) {
             if ($scope.inlineEditing.active) {
-                $scope.disableInlineEditing();
+                $scope.inlineEditing.disable();
             }
             ngDialog.open(MotionForm.getDialog(motion));
         };


### PR DESCRIPTION
This fixes two bugs:
- The script to disable inline editing when calling the "regular" motion editing dialog was broken after moving it to a separate service
- After creating a change recommendation, the lines affected by this recommendation were still selectable, as the classes making the line selectable were not recalculated. The same thing would have happened if a change recommendation was created on another window.