### PR TITLE
A small tooltip after selecting the first line when creating a change recommendation

### DIFF
--- a/openslides/core/static/css/app.css
+++ b/openslides/core/static/css/app.css
@@ -487,6 +487,16 @@ img {
     background-color: #337ab7;
 }
 
+.tt_change_recommendation_create_help {
+    display: none;
+    max-width: 150px;
+    left: -45px;
+    margin-top: -8px;
+}
+.tt_change_recommendation_create_help.opened {
+    display: inherit;
+    opacity: 0.8;
+}
 
 /** Styles for annotating the original motion text with change recommendations */
 

--- a/openslides/motions/static/js/motions/motion-services.js
+++ b/openslides/motions/static/js/motions/motion-services.js
@@ -204,6 +204,7 @@ angular.module('OpenSlidesApp.motions.motionservices', ['OpenSlidesApp.motions',
                 return;
             }
 
+            $(".tt_change_recommendation_create_help").removeClass("opened");
             var $lineNumbers = $(".motion-text-original .os-line-number");
             if ($lineNumbers.filter(".selectable").length === 0) {
                 obj.mode = MODE_SELECTING_FROM;
@@ -238,7 +239,6 @@ angular.module('OpenSlidesApp.motions.motionservices', ['OpenSlidesApp.motions',
                 foundCollission = false;
 
             $(".motion-text-original .os-line-number").each(function () {
-
                 var $this = $(this);
                 if ($this.data("line-number") >= line && !foundCollission) {
                     if (alreadyAffectedLines.indexOf($this.data("line-number")) == -1) {
@@ -251,6 +251,9 @@ angular.module('OpenSlidesApp.motions.motionservices', ['OpenSlidesApp.motions',
                     $(this).removeClass("selectable");
                 }
             });
+
+            var tt_pos = $(".motion-text-original .line-number-" + line).position().top - 45;
+            $(".tt_change_recommendation_create_help").css("top", tt_pos).addClass("opened");
         };
 
         obj.setToLine = function (line) {

--- a/openslides/motions/static/templates/motions/motion-detail/view-original.html
+++ b/openslides/motions/static/templates/motions/motion-detail/view-original.html
@@ -46,3 +46,8 @@
         </div>
     </li>
 </ul>
+
+<div class="tooltip top tt_change_recommendation_create_help" role="tooltip">
+    <div class="tooltip-arrow"></div>
+    <div class="tooltip-inner" translate>Now choose the last line to be changed</div>
+</div>


### PR DESCRIPTION
This shows a little tooltip left of the first selected line number when starting creating a change recommendation. Hopefully this prevents some confusion if you don't know you have to select another line for anything to happen. This is an attempt to solve #2615.