### PR TITLE
Added settings value MOTION_IDENTIFIER_MIN_DIGITS. Solved #2696.

### DIFF
--- a/openslides/motions/views.py
+++ b/openslides/motions/views.py
@@ -431,7 +431,7 @@ class CategoryViewSet(ModelViewSet):
                         parent_identifier = motion.parent.identifier or ''
                         prefix = '%s %s ' % (parent_identifier, config['motions_amendments_prefix'])
                     number += 1
-                    identifier = '%s%d' % (prefix, number)
+                    identifier = '%s%s' % (prefix, motion.extend_identifier_number(number))
                     motion.identifier = identifier
                     motion.identifier_number = number
                     motion.save()

--- a/openslides/utils/settings.py.tpl
+++ b/openslides/utils/settings.py.tpl
@@ -115,3 +115,8 @@ MEDIA_ROOT = os.path.join(OPENSLIDES_USER_DATA_PATH, 'media', '')
 # https://whoosh.readthedocs.io/en/latest/
 
 SEARCH_INDEX = os.path.join(OPENSLIDES_USER_DATA_PATH, 'search_index')
+
+
+# Customization of OpenSlides apps
+
+MOTION_IDENTIFIER_MIN_DIGITS = 1

--- a/tests/old/settings.py
+++ b/tests/old/settings.py
@@ -66,6 +66,11 @@ MEDIA_ROOT = os.path.join(OPENSLIDES_USER_DATA_PATH, '')
 SEARCH_INDEX = 'ram'
 
 
+# Customization of OpenSlides apps
+
+MOTION_IDENTIFIER_MIN_DIGITS = 1
+
+
 # Special settings only for testing
 
 TEST_RUNNER = 'openslides.utils.test.OpenSlidesDiscoverRunner'

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -66,6 +66,11 @@ MEDIA_ROOT = os.path.join(OPENSLIDES_USER_DATA_PATH, '')
 SEARCH_INDEX = 'ram'
 
 
+# Customization of OpenSlides apps
+
+MOTION_IDENTIFIER_MIN_DIGITS = 1
+
+
 # Special settings only for testing
 
 TEST_RUNNER = 'openslides.utils.test.OpenSlidesDiscoverRunner'


### PR DESCRIPTION
Create new personal settings or just add MOTION_IDENTIFIER_MIN_DIGITS = 1 to your personal settings file. Then change the value to e. g. 3 to test leading zero digits.