### PR TITLE
Going back from tinymce to ckeditor

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,6 +24,8 @@ Core:
 - Added support for multiple projectors.
 - Added an overlay for the current list of speakers.
 - Added button to clear the chatbox.
+- Switched editor back from TinyMCE to CKEditor which provides a
+  better copy/paste support from MS Word.
 
 Motions:
 - Added origin field.

--- a/README.rst
+++ b/README.rst
@@ -178,6 +178,7 @@ OpenSlides uses the following projects or parts of them:
   * `angular-bootstrap <http://angular-ui.github.io/bootstrap>`_, License: MIT
   * `angular-bootstrap-colorpicker <https://github.com/buberdds/angular-bootstrap-colorpicker>`_, License: MIT
   * `angular-chosen-localytics <http://github.com/leocaseiro/angular-chosen>`_, License: MIT
+  * `angular-ckeditor <https://github.com/lemonde/angular-ckeditor/>`_, License: MIT
   * `angular-csv-import <https://github.com/bahaaldine/angular-csv-import>`_, License: MIT
   * `angular-formly <http://formly-js.github.io/angular-formly/>`_, License: MIT
   * `angular-formly-templates-bootstrap <https://github.com/formly-js/angular-formly-templates-bootstrap>`_, License: MIT
@@ -189,13 +190,13 @@ OpenSlides uses the following projects or parts of them:
   * `angular-sanitize <http://angularjs.org>`_, License: MIT
   * `angular-scroll-glue <https://github.com/Luegg/angularjs-scroll-glue>`_, License: MIT
   * `angular-ui-router <http://angular-ui.github.io/ui-router/>`_, License: MIT
-  * `angular-ui-tinymce <http://angular-ui.github.com>`_, License: MIT
   * `angular-ui-tree <https://github.com/angular-ui-tree/angular-ui-tree>`_, License: MIT
   * `angular-xeditable <https://github.com/vitalets/angular-xeditable>`_, License: MIT
   * `api-check <https://github.com/kentcdodds/api-check>`_, License: MIT
   * `bootstrap <http://getbootstrap.com>`_, License: MIT
   * `bootstrap-ui-datetime-picker <https://github.com/Gillardo/bootstrap-ui-datetime-picker>`_, License: MIT
   * `chosen <http://harvesthq.github.io/chosen/>`_, License: MIT
+  * `ckeditor <http://ckeditor.com>`_,  License: For licensing, see LICENSE.md or http://ckeditor.com/license.
   * `font-awesome-bower <https://github.com/tdg5/font-awesome-bower>`_, License: MIT
   * `jquery <https://jquery.com>`_, License: MIT
   * `jquery.cookie <https://plugins.jquery.com/cookie>`_, License: MIT

--- a/README.rst
+++ b/README.rst
@@ -196,7 +196,7 @@ OpenSlides uses the following projects or parts of them:
   * `bootstrap <http://getbootstrap.com>`_, License: MIT
   * `bootstrap-ui-datetime-picker <https://github.com/Gillardo/bootstrap-ui-datetime-picker>`_, License: MIT
   * `chosen <http://harvesthq.github.io/chosen/>`_, License: MIT
-  * `ckeditor <http://ckeditor.com>`_,  License: For licensing, see LICENSE.md or http://ckeditor.com/license.
+  * `ckeditor <http://ckeditor.com>`_,  License: GPL 2+, LGPL 2.1+ or MPL 1.1.
   * `font-awesome-bower <https://github.com/tdg5/font-awesome-bower>`_, License: MIT
   * `jquery <https://jquery.com>`_, License: MIT
   * `jquery.cookie <https://plugins.jquery.com/cookie>`_, License: MIT
@@ -211,8 +211,6 @@ OpenSlides uses the following projects or parts of them:
   * `open-sans-fontface <https://github.com/FontFaceKit/open-sans>`_, License: Apache License version 2.0
   * `pdfjs-dist <http://mozilla.github.io/pdf.js/>`_, License: Apache-2.0
   * `roboto-condensed <https://github.com/davidcunningham/roboto-condensed>`_, License: Apache 2.0
-  * `tinymce <http://www.tinymce.com>`_, License: LGPL-2.1
-  * `tinymce-i18n <https://github.com/OpenSlides/tinymce-i18n>`_, License: LGPL-2.1
 
 
 License and authors

--- a/bower.json
+++ b/bower.json
@@ -8,6 +8,7 @@
     "angular-bootstrap": "~2.1.3",
     "angular-bootstrap-colorpicker": "~3.0.25",
     "angular-chosen-localytics": "~1.5.0",
+    "angular-ckeditor": "~1.0.3",
     "angular-csv-import": "0.0.36",
     "angular-file-saver": "~1.1.2",
     "angular-formly": "~8.4.0",
@@ -19,11 +20,11 @@
     "angular-sanitize": "~1.5.8",
     "angular-scroll-glue": "~2.0.7",
     "angular-ui-router": "~0.3.1",
-    "angular-ui-tinymce": "~0.0.17",
     "angular-ui-tree": "~2.22.0",
     "angular-xeditable": "~0.5.0",
     "bootstrap-css-only": "~3.3.6",
     "bootstrap-ui-datetime-picker": "~2.4.0",
+    "ckeditor": "~4.6.1",
     "docxtemplater": "~2.1.5",
     "font-awesome-bower": "~4.5.0",
     "jquery.cookie": "~1.4.1",
@@ -35,9 +36,7 @@
     "ngstorage": "~0.3.11",
     "ngBootbox": "~0.1.3",
     "pdfmake": "bpampuch/pdfmake#214ec161c11fadb8f02c08f2e3bea0576ac4c9fb",
-    "roboto-fontface": "~0.6.0",
-    "tinymce": "~4.4.3",
-    "tinymce-i18n": "OpenSlides/tinymce-i18n#a186ad61e0aa30fdf657e88f405f966d790f0805"
+    "roboto-fontface": "~0.6.0"
   },
   "overrides": {
     "pdfmake": {
@@ -57,11 +56,28 @@
         "fonts/Roboto-Condensed/Roboto-Condensed-Light.woff"
       ]
     },
-    "tinymce": {
+    "ckeditor": {
       "main": [
-        "tinymce.js",
-        "themes/modern/theme.js",
-        "plugins/*/plugin.js"
+              "ckeditor.js",
+              "skins/moono-lisa/*",
+              "lang/en.js",
+              "lang/de.js",
+              "lang/pt.js",
+              "lang/es.js",
+              "lang/fr.js",
+              "lang/cs.js",
+              "plugins/about/*",
+              "plugins/clipboard/*",
+              "plugins/dialog/*",
+              "plugins/find/*",
+              "plugins/image/*",
+              "plugins/justify/*",
+              "plugins/liststyle/*",
+              "plugins/magicline/*",
+              "plugins/pastefromword/*",
+              "plugins/showblocks/*",
+              "plugins/table/*",
+              "plugins/tabletools/*"
       ]
     }
   },

--- a/bower.json
+++ b/bower.json
@@ -55,30 +55,6 @@
         "fonts/Roboto-Condensed/Roboto-Condensed-Regular.woff",
         "fonts/Roboto-Condensed/Roboto-Condensed-Light.woff"
       ]
-    },
-    "ckeditor": {
-      "main": [
-              "ckeditor.js",
-              "skins/moono-lisa/*",
-              "lang/en.js",
-              "lang/de.js",
-              "lang/pt.js",
-              "lang/es.js",
-              "lang/fr.js",
-              "lang/cs.js",
-              "plugins/about/*",
-              "plugins/clipboard/*",
-              "plugins/dialog/*",
-              "plugins/find/*",
-              "plugins/image/*",
-              "plugins/justify/*",
-              "plugins/liststyle/*",
-              "plugins/magicline/*",
-              "plugins/pastefromword/*",
-              "plugins/showblocks/*",
-              "plugins/table/*",
-              "plugins/tabletools/*"
-      ]
     }
   },
   "resolutions": {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -108,37 +108,12 @@ gulp.task('angular-chosen-img', function () {
         .pipe(gulp.dest(path.join(output_directory, 'css')));
 });
 
-// Catches all skins files for TinyMCE editor.
-gulp.task('tinymce-skins', function () {
-    return gulp.src(path.join('bower_components', 'tinymce', 'skins', '**'))
-        .pipe(gulp.dest(path.join(output_directory, 'tinymce', 'skins')));
+// Extra task only for CKEditor
+gulp.task('ckeditor', function () {
+    return gulp.src(path.join('bower_components', 'ckeditor', '**'))
+        .pipe(gulp.dest(path.join(output_directory, 'ckeditor')));
 });
 
-// Catches all required i18n files for TinyMCE editor.
-gulp.task('tinymce-i18n', function () {
-    return gulp.src([
-            'bower_components/tinymce-i18n/langs/en_GB.js',
-            'bower_components/tinymce-i18n/langs/cs.js',
-            'bower_components/tinymce-i18n/langs/de.js',
-            'bower_components/tinymce-i18n/langs/es.js',
-            'bower_components/tinymce-i18n/langs/fr_FR.js',
-            'bower_components/tinymce-i18n/langs/pt_PT.js',
-            ])
-        .pipe(rename(function (path) {
-            if (path.basename === 'en_GB') {
-                path.basename = 'en';
-            } else if (path.basename === 'fr_FR') {
-                path.basename = 'fr';
-            } else if (path.basename === 'pt_PT') {
-                path.basename = 'pt';
-            }
-        }))
-        .pipe(gulpif(argv.production, uglify()))
-        .pipe(gulp.dest(path.join(output_directory, 'tinymce', 'i18n')));
-});
-
-// Combines all TinyMCE related tasks.
-gulp.task('tinymce', ['tinymce-skins', 'tinymce-i18n'], function () {});
 
 // Compiles translation files (*.po) to *.json and saves them in the directory
 // openslides/static/i18n/.
@@ -151,7 +126,7 @@ gulp.task('translations', function () {
 });
 
 // Gulp default task. Runs all other tasks before.
-gulp.task('default', ['js', 'js-libs', 'templates', 'css-libs', 'fonts-libs', 'tinymce', 'angular-chosen-img', 'translations'], function () {});
+gulp.task('default', ['js', 'js-libs', 'templates', 'css-libs', 'fonts-libs',  'ckeditor', 'angular-chosen-img', 'translations'], function () {});
 
 
 /**

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -108,12 +108,59 @@ gulp.task('angular-chosen-img', function () {
         .pipe(gulp.dest(path.join(output_directory, 'css')));
 });
 
-// Extra task only for CKEditor
-gulp.task('ckeditor', function () {
-    return gulp.src(path.join('bower_components', 'ckeditor', '**'))
+// CKEditor defaults
+gulp.task('ckeditor-defaults', function () {
+    return gulp.src([
+            path.join('bower_components', 'ckeditor', 'styles.js'),
+            path.join('bower_components', 'ckeditor', 'contents.css'),
+        ])
         .pipe(gulp.dest(path.join(output_directory, 'ckeditor')));
 });
 
+// CKEditor skins
+gulp.task('ckeditor-skins', function () {
+    return gulp.src([
+            path.join('bower_components', 'ckeditor', 'skins', 'moono-lisa', '**', '*'),
+        ],{ base: path.join('bower_components', 'ckeditor', 'skins') })
+        .pipe(gulp.dest(path.join(output_directory, 'ckeditor', 'skins')));
+});
+
+// CKEditor plugins
+gulp.task('ckeditor-plugins', function () {
+    return gulp.src([
+            path.join('bower_components', 'ckeditor', 'plugins', 'clipboard', '**', '*'),
+            path.join('bower_components', 'ckeditor', 'plugins', 'colorbutton', '**', '*'),
+            path.join('bower_components', 'ckeditor', 'plugins', 'dialog', '**', '*'),
+            path.join('bower_components', 'ckeditor', 'plugins', 'find', '**', '*'),
+            path.join('bower_components', 'ckeditor', 'plugins', 'image', '**', '*'),
+            path.join('bower_components', 'ckeditor', 'plugins', 'justify', '**', '*'),
+            path.join('bower_components', 'ckeditor', 'plugins', 'liststyle', '**', '*'),
+            path.join('bower_components', 'ckeditor', 'plugins', 'magicline', '**', '*'),
+            path.join('bower_components', 'ckeditor', 'plugins', 'pastefromword', '**', '*'),
+            path.join('bower_components', 'ckeditor', 'plugins', 'panelbutton', '**', '*'),
+            path.join('bower_components', 'ckeditor', 'plugins', 'showblocks', '**', '*'),
+            path.join('bower_components', 'ckeditor', 'plugins', 'sourcedialog', '**', '*'),
+            path.join('bower_components', 'ckeditor', 'plugins', 'table', '**', '*'),
+            path.join('bower_components', 'ckeditor', 'plugins', 'tabeltools', '**', '*'),
+        ],{ base: path.join('bower_components', 'ckeditor', 'plugins') })
+        .pipe(gulp.dest(path.join(output_directory, 'ckeditor', 'plugins')));
+});
+
+// CKEditor languages
+gulp.task('ckeditor-lang', function () {
+    return gulp.src([
+            path.join('bower_components', 'ckeditor', 'lang', 'en.js'),
+            path.join('bower_components', 'ckeditor', 'lang', 'de.js'),
+            path.join('bower_components', 'ckeditor', 'lang', 'pt.js'),
+            path.join('bower_components', 'ckeditor', 'lang', 'es.js'),
+            path.join('bower_components', 'ckeditor', 'lang', 'fr.js'),
+            path.join('bower_components', 'ckeditor', 'lang', 'cs.js'),
+        ])
+        .pipe(gulp.dest(path.join(output_directory, 'ckeditor', 'lang')));
+});
+
+// Combines all CKEditor related tasks.
+gulp.task('ckeditor', ['ckeditor-defaults', 'ckeditor-skins', 'ckeditor-plugins', 'ckeditor-lang'], function () {});
 
 // Compiles translation files (*.po) to *.json and saves them in the directory
 // openslides/static/i18n/.
@@ -126,7 +173,16 @@ gulp.task('translations', function () {
 });
 
 // Gulp default task. Runs all other tasks before.
-gulp.task('default', ['js', 'js-libs', 'templates', 'css-libs', 'fonts-libs',  'ckeditor', 'angular-chosen-img', 'translations'], function () {});
+gulp.task('default', [
+        'js',
+        'js-libs',
+        'templates',
+        'css-libs',
+        'fonts-libs',
+        'ckeditor',
+        'angular-chosen-img',
+        'translations'
+    ], function () {});
 
 
 /**

--- a/openslides/core/static/js/core/site.js
+++ b/openslides/core/static/js/core/site.js
@@ -18,7 +18,7 @@ angular.module('OpenSlidesApp.core.site', [
     'ngMessages',
     'ngCsvImport',
     'ngStorage',
-    'ui.tinymce',
+    'ckeditor',
     'luegg.directives',
     'xeditable',
 ])

--- a/openslides/core/static/templates/core/editor.html
+++ b/openslides/core/static/templates/core/editor.html
@@ -1,2 +1,2 @@
-<!-- custom angular formly template for tinymce textarea field -->
-<textarea ui-tinymce="options.data.tinymceOption" ng-model="model[options.key]" class="form-control"></textarea>
+<!-- custom angular formly template for ckeditor textarea field -->
+<textarea ckeditor="options.data.ckeditorOptions" ng-model="model[options.key]" class="form-control"></textarea>

--- a/openslides/core/static/templates/index.html
+++ b/openslides/core/static/templates/index.html
@@ -10,19 +10,14 @@
 <link rel="stylesheet" href="static/css/openslides-libs.css">
 <link rel="stylesheet" href="static/css/app.css">
 <link rel="icon" href="/static/img/favicon.png">
-<!-- TODO: there is probably a better place for it:-->
+<!-- TODO (#2787): move into openslides-libs-->
 <script>
   window.CKEDITOR_BASEPATH = '/static/ckeditor/';
 </script>
-<!-- -->
 <script src="static/js/openslides-libs.js"></script>
 <script src="static/js/openslides.js"></script>
 <script src="static/js/openslides-templates.js"></script>
-<!-- TODO: move inside openslides-libs (?):-->
-    <script>
-      CKEDITOR.disableAutoInline = true;
-    </script>
-<!-- -->
+
 <div id="wrapper" ng-cloak>
 
 <!-- Header -->

--- a/openslides/core/static/templates/index.html
+++ b/openslides/core/static/templates/index.html
@@ -10,10 +10,19 @@
 <link rel="stylesheet" href="static/css/openslides-libs.css">
 <link rel="stylesheet" href="static/css/app.css">
 <link rel="icon" href="/static/img/favicon.png">
+<!-- TODO: there is probably a better place for it:-->
+<script>
+  window.CKEDITOR_BASEPATH = '/static/ckeditor/';
+</script>
+<!-- -->
 <script src="static/js/openslides-libs.js"></script>
 <script src="static/js/openslides.js"></script>
 <script src="static/js/openslides-templates.js"></script>
-
+<!-- TODO: move inside openslides-libs (?):-->
+    <script>
+      CKEDITOR.disableAutoInline = true;
+    </script>
+<!-- -->
 <div id="wrapper" ng-cloak>
 
 <!-- Header -->

--- a/openslides/motions/static/js/motions/base.js
+++ b/openslides/motions/static/js/motions/base.js
@@ -546,7 +546,7 @@ angular.module('OpenSlidesApp.motions', [
                                 label: field.name,
                             },
                             data: {
-                                tinymceOption: Editor.getOptions()
+                                ckeditorOptions: Editor.getOptions()
                             },
                             hide: !operator.hasPerms("motions.can_see_and_manage_comments")
                         };

--- a/openslides/motions/static/js/motions/linenumbering.js
+++ b/openslides/motions/static/js/motions/linenumbering.js
@@ -82,7 +82,7 @@ angular.module('OpenSlidesApp.motions.lineNumbering', [])
             node.setAttribute('class', 'os-line-number line-number-' + lineNumber);
             node.setAttribute('data-line-number', lineNumber + '');
             node.setAttribute('contenteditable', 'false');
-            node.innerHTML = '&nbsp;'; // Prevent tinymce from stripping out empty span's
+            node.innerHTML = '&nbsp;'; // Prevent ckeditor from stripping out empty span's
             return node;
         };
 

--- a/openslides/motions/static/js/motions/linenumbering.js
+++ b/openslides/motions/static/js/motions/linenumbering.js
@@ -302,6 +302,15 @@ angular.module('OpenSlidesApp.motions.lineNumbering', [])
 
             for (i = 0; i < oldChildren.length; i++) {
                 if (oldChildren[i].nodeType == TEXT_NODE) {
+                    if (!oldChildren[i].nodeValue.match(/\S/)) {
+                        // White space nodes between block elements should be ignored
+                        var prevIsBlock = (i > 0 && !this._isInlineElement(oldChildren[i - 1]));
+                        var nextIsBlock = (i < oldChildren.length - 1 && !this._isInlineElement(oldChildren[i + 1]));
+                        if ((prevIsBlock && nextIsBlock) || (i === 0 && nextIsBlock) || (i === oldChildren.length - 1 && prevIsBlock)) {
+                            node.appendChild(oldChildren[i]);
+                            continue;
+                        }
+                    }
                     var ret = this._textNodeToLines(oldChildren[i], length, highlight);
                     for (var j = 0; j < ret.length; j++) {
                         node.appendChild(ret[j]);

--- a/openslides/motions/static/js/motions/site.js
+++ b/openslides/motions/static/js/motions/site.js
@@ -397,7 +397,7 @@ angular.module('OpenSlidesApp.motions.site', [
                             required: false
                         },
                         data: {
-                            tinymceOption: Editor.getOptions()
+                            ckeditorOptions: Editor.getOptions()
                         }
                     }
                 ];
@@ -492,7 +492,7 @@ angular.module('OpenSlidesApp.motions.site', [
                         required: true
                     },
                     data: {
-                        tinymceOption: Editor.getOptions(images)
+                        ckeditorOptions: Editor.getOptions(images)
                     }
                 },
                 {
@@ -502,7 +502,7 @@ angular.module('OpenSlidesApp.motions.site', [
                         label: gettextCatalog.getString('Reason'),
                     },
                     data: {
-                        tinymceOption: Editor.getOptions(images)
+                        ckeditorOptions: Editor.getOptions(images)
                     }
                 },
                 {

--- a/openslides/motions/static/templates/motions/motion-detail/view-original.html
+++ b/openslides/motions/static/templates/motions/motion-detail/view-original.html
@@ -1,16 +1,16 @@
-<!-- Original view, Inline Editing is possible -->
-<div ng-if="viewChangeRecommendations.mode == 'original' && motion.isAllowed('update') && version == motion.getVersion(-1).id">
-    <div ng-show="inlineEditing.active">
-        <div ui-tinymce="inlineEditing.tinymceOptions" ng-model="inlineEditing.lineBrokenText"
-             class="motion-text line-numbers-{{ lineNumberMode }}"></div>
+<!-- Original view -->
+<div ng-if="viewChangeRecommendations.mode == 'original' && version == motion.getVersion(-1).id">
+    <div id="view-original-inline-editor" ng-bind-html="motion.getTextWithLineBreaks(version, highlight) | trusted"
+      class="motion-text motion-text-original line-numbers-{{ lineNumberMode }}"
+      contenteditable= "{{ inlineEditing.isEditable }}">
     </div>
-    <div ng-show="!inlineEditing.active" ng-bind-html="motion.getTextWithLineBreaks(version, highlight) | trusted"
-         class="motion-text motion-text-original line-numbers-{{ lineNumberMode }}"></div>
-
     <div class="motion-save-toolbar" ng-class="{ 'visible': (inlineEditing.changed && inlineEditing.active) }">
         <div class="changed-hint" translate>The text has been changed.</div>
         <button type="button" ng-click="inlineEditing.save()" class="btn btn-primary" translate>
             Save
+        </button>
+        <button type="button" ng-click="inlineEditing.revert()" class="btn btn-primary" translate>
+            Revert
         </button>
         <label ng-if="motion.state.versioning && config('motions_allow_disable_versioning')">
             <input type="checkbox" ng-model="inlineEditing.trivialChange" value="1">
@@ -18,13 +18,6 @@
         </label>
     </div>
 </div>
-
-<!-- Original view, Inline Editing is NOT possible -->
-<div ng-if="viewChangeRecommendations.mode == 'original' && !(motion.isAllowed('update') && version == motion.getVersion(-1).id)">
-    <div ng-bind-html="motion.getTextWithLineBreaks(version, highlight) | trusted"
-         class="motion-text motion-text-original line-numbers-{{ lineNumberMode }}"></div>
-</div>
-
 <!-- Original view, Change list -->
 <ul ng-if="viewChangeRecommendations.mode == 'original'" ng-show="lineNumberMode != 'none'"
     class="change-recommendation-list">

--- a/openslides/topics/static/js/topics/site.js
+++ b/openslides/topics/static/js/topics/site.js
@@ -118,7 +118,7 @@ angular.module('OpenSlidesApp.topics.site', ['OpenSlidesApp.topics'])
                         label: gettextCatalog.getString('Text')
                     },
                     data: {
-                        tinymceOption: Editor.getOptions(images)
+                        ckeditorOptions: Editor.getOptions(images)
                     }
                 }];
                 // attachments

--- a/openslides/users/static/js/users/site.js
+++ b/openslides/users/static/js/users/site.js
@@ -446,7 +446,7 @@ angular.module('OpenSlidesApp.users.site', [
                         label: gettextCatalog.getString('About me'),
                     },
                     data: {
-                        tinymceOption: Editor.getOptions(images)
+                        ckeditorOptions: Editor.getOptions(images)
                     },
                     hideExpression: '!model.more'
                 }
@@ -801,7 +801,7 @@ angular.module('OpenSlidesApp.users.site', [
     'user',
     function($scope, $state, Editor, User, user) {
         $scope.user = user;  // autoupdate is not activated
-        $scope.tinymceOption = Editor.getOptions();
+        $scope.ckeditorOptions = Editor.getOptions();
         $scope.save = function (user) {
             User.save(user).then(
                 function(success) {

--- a/openslides/users/static/templates/users/user-detail-profile.html
+++ b/openslides/users/static/templates/users/user-detail-profile.html
@@ -37,7 +37,7 @@
     </div>
     <div class="form-group">
       <label for="textAbout" translate>About me</label>
-      <textarea ng-model="user.about_me" ui-tinymce="tinymceOption" class="form-control" name="textAbout" />
+      <textarea ng-model="user.about_me" class="form-control" name="textAbout" />
     </div>
 
     <button type="submit" ng-click="save(user)" class="btn btn-primary" translate>

--- a/tests/karma/motions/linenumbering.service.test.js
+++ b/tests/karma/motions/linenumbering.service.test.js
@@ -251,4 +251,18 @@ describe('linenumbering', function () {
       expect(lineNumberingService.stripLineNumbers(outHtml)).toBe(inHtml);
     });
   });
+
+  describe('behavior regarding ckeditor', function() {
+    it('does not count empty lines, case 1', function () {
+      var inHtml = "<p>Line 1</p>\n\n<p>Line 2</p>";
+      var outHtml = lineNumberingService.insertLineNumbers(inHtml, 80);
+      expect(outHtml).toBe('<p>' + noMarkup(1) + 'Line 1</p>' + "\n\n" + '<p>' + noMarkup(2) + 'Line 2</p>');
+    });
+
+    it('does not count empty lines, case 2', function () {
+      var inHtml = "<ul>\n\n<li>Point 1</li>\n\n</ul>";
+      var outHtml = lineNumberingService.insertLineNumbers(inHtml, 80);
+      expect(outHtml).toBe("<ul>\n\n<li>" + noMarkup(1) + "Point 1</li>\n\n</ul>");
+    });
+  });
 });


### PR DESCRIPTION
This is an attempt to revert to CKEditor. The purpose is first evaluation, I'll keep working on the issues.

**Reason**: *copy+ pasting from Microsoft Word to OpenSlides is always difficult. Currently, after some research, I think CKEditor handles it better. The older issues we had with CKEditor (e.g. text disappearing) have been fixed in the latest release.*

What works better:
- better at keeping numbers of sections (tinyMCE messed up my test document numbering)
- better adherence to the original style
- tables

What does not (yet) work fine (in both editors):
- line spacing/ empty paragraphs
- more exotic numbered lists (e.g. latin letters, beginning with C)

TODO:
- [ ]  get bower/gulp to really only pull/concatenate the needed files to remove excess size.
- [x] fix inline editing
- [x] fix paragraph spacing/empty paragraphs
- [x] fix line numbering
- [x] numbered list other than standard `<li>`
- [x] <s>table handling (set visible borders, don't handle each cell as "line")</s> moved to #2784
- [x] beautification of UI, removal/adding of plugins according to needs.
- [ ] refactoring my ugly hacks (e.g. defining a path in index.html)
- [x] make the editor language dependant on openslides setting, not on browser setting