### PR TITLE
changing csv import regex for motions

### DIFF
--- a/openslides/motions/static/js/motions/site.js
+++ b/openslides/motions/static/js/motions/site.js
@@ -1580,7 +1580,7 @@ angular.module('OpenSlidesApp.motions.site', [
         // detect if csv file is loaded
         $scope.$watch('csv.result', function () {
             $scope.motions = [];
-            var quotionRe = /^"(.*)"$/;
+            var quotionRe = /^"([\s\S]*)"$/m;
             angular.forEach($scope.csv.result, function (motion) {
                 if (motion.identifier) {
                     motion.identifier = motion.identifier.replace(quotionRe, '$1');


### PR DESCRIPTION
Should this be changed for all imports?

Difference: [\s\S] matches everything (includes line breaks; the dot does not match line breaks) and the `m` flag for multiline.