### PR TITLE
no nav underline glitch

### DIFF
--- a/openslides/core/static/css/app.css
+++ b/openslides/core/static/css/app.css
@@ -191,6 +191,7 @@ img {
     display: block;
     color: #fff;
     padding: 22px 15px;
+    text-decoration: none;
 }
 
 #nav .navbar li a:hover {


### PR DESCRIPTION
![navglitch](https://cloud.githubusercontent.com/assets/8439581/21049722/d76bbcd4-be16-11e6-8612-6ec9af3812f0.jpg)

This PR prevents the glitch. The glitch appears when clicking on one link and move the mouse away, but the link has now an underline. On the next click the underline disappears.