### PR TITLE
return to original pdfmake (fixes #2769)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -184,7 +184,7 @@ OpenSlides uses the following projects or parts of them:
   * `angular-gettext <http://angular-gettext.rocketeer.be/>`_, License: MIT
   * `angular-loading-bar <https://chieffancypants.github.io/angular-loading-bar>`_, License: MIT
   * `angular-messages <http://angularjs.org>`_, License: MIT
-  * `pdfmake <https://github.com/pdfmake/pdfmake>`_, License: MIT
+  * `pdfmake <https://github.com/bpampuch/pdfmake>`_, License: MIT
   * `angular-pdf <http://github.com/sayanee/angularjs-pdf>`_, License: MIT
   * `angular-sanitize <http://angularjs.org>`_, License: MIT
   * `angular-scroll-glue <https://github.com/Luegg/angularjs-scroll-glue>`_, License: MIT

--- a/bower.json
+++ b/bower.json
@@ -34,13 +34,13 @@
     "ng-file-upload": "~11.2.3",
     "ngstorage": "~0.3.11",
     "ngBootbox": "~0.1.3",
-    "pdfmake-dist": "~0.1.27",
+    "pdfmake": "bpampuch/pdfmake#3b44129d599424cd0e306fc5014ba3a129220c64",
     "roboto-fontface": "~0.6.0",
     "tinymce": "~4.4.3",
     "tinymce-i18n": "OpenSlides/tinymce-i18n#a186ad61e0aa30fdf657e88f405f966d790f0805"
   },
   "overrides": {
-    "pdfmake-dist": {
+    "pdfmake": {
       "main": [
           "build/pdfmake.min.js",
           "build/vfs_fonts.js"


### PR DESCRIPTION
sets the source of pdfmake to the following:
https://github.com/bpampuch/pdfmake/commit/3b44129d599424cd0e306fc5014ba3a129220c64

* To test it, make sure to remove the old pdfmake
`rm -R bower_components/pdfmake*`

+ run again
`npm install`

* make sure everything looks fine

* and clear your browser cache

I tested some stuff rather briefly and everything seemed to work just fine.