### PR TITLE
Change the language selector to the languages' own names

### DIFF
--- a/openslides/core/static/js/core/base.js
+++ b/openslides/core/static/js/core/base.js
@@ -125,12 +125,12 @@ angular.module('OpenSlidesApp.core', [
                 var current = gettextCatalog.getCurrentLanguage();
                 // Define here new languages...
                 var languages = [
-                    { code: 'en', name: gettext('English') },
-                    { code: 'de', name: gettext('German') },
-                    { code: 'fr', name: gettext('French') },
-                    { code: 'es', name: gettext('Spanish') },
-                    { code: 'pt', name: gettext('Portuguese') },
-                    { code: 'cs', name: gettext('Czech') },
+                    { code: 'en', name: 'English' },
+                    { code: 'de', name: 'Deutsch' },
+                    { code: 'fr', name: 'Français' },
+                    { code: 'es', name: 'Español' },
+                    { code: 'pt', name: 'Português' },
+                    { code: 'cs', name: 'Čeština'},
                 ];
                 angular.forEach(languages, function (language) {
                     if (language.code == current)


### PR DESCRIPTION
A minor tweak: 

If I don't speak the currently displayed language, I may not even know how *my* language is called in this language. So strings with native names are much more useful, in my opinion.