### PR TITLE
New csv import using PapaParse

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -51,6 +51,7 @@ Motions:
 - New PDF layout.
 - Added DOCX export with docxtemplater.
 - Changed label of former state "commited a bill" to "refered to committee".
+- New csv import layout and using Papa Parse for parsing the csv.
 
 Elections:
 - Added options to calculate percentages on different bases.

--- a/README.rst
+++ b/README.rst
@@ -222,6 +222,7 @@ OpenSlides uses the following projects or parts of them:
   * `ngStorage <https://github.com/gsklee/ngStorage>`_, License: MIT
   * `ngbootbox <https://github.com/eriktufvesson/ngBootbox>`_, License: MIT
   * `open-sans-fontface <https://github.com/FontFaceKit/open-sans>`_, License: Apache License version 2.0
+  * `Papa Parse <http://papaparse.com/>`_, License: MIT
   * `pdfjs-dist <http://mozilla.github.io/pdf.js/>`_, License: Apache-2.0
   * `roboto-condensed <https://github.com/davidcunningham/roboto-condensed>`_, License: Apache 2.0
 

--- a/bower.json
+++ b/bower.json
@@ -35,6 +35,7 @@
     "ng-file-upload": "~11.2.3",
     "ngstorage": "~0.3.11",
     "ngBootbox": "~0.1.3",
+    "papaparse": "~4.1.2",
     "pdfmake": "~0.1.23",
     "roboto-fontface": "~0.6.0"
   },

--- a/openslides/core/static/css/app.css
+++ b/openslides/core/static/css/app.css
@@ -1453,22 +1453,31 @@ img {
     margin-right: .2em;
 }
 
-/* for angular-csv-import form */
+/* for csv import form */
 .import {
     margin-left: 15px;
+    width: 35%;
 }
 
-.import .label {
-    color: #333 !important;
-    font-size: 100%;
+.import .file-select input {
+    display: none;
+}
+
+.import .file-select label {
     font-weight: normal;
-    width: 100px;
-    text-align: left;
-    display: inline-block;
+    cursor: pointer;
 }
 
-.import .label::after {
-    content: ': ';
+.import .clear-file {
+    color: #555;
+}
+
+.import .help-block {
+    padding-bottom: 0;
+}
+
+.import .help-block-big {
+    font-size: 100%;
 }
 
 /* voting results */

--- a/openslides/core/static/templates/csv-import.html
+++ b/openslides/core/static/templates/csv-import.html
@@ -1,0 +1,30 @@
+<form class="import">
+  <label for="fileInput" translate>CSV file</label>
+  <div id="fileInput" class="file-select">
+    <div class="form-control">
+      <label for="csvFileSelector">
+        <i class="fa fa-upload"></i>
+        {{ selectedFile || ('Select a file' | translate) }}
+      </label>
+      <a href class="pull-right clear-file" ng-if="selectedFile" ng-click="clearFile()">
+        <i class="fa fa-times" title="{{ 'Deselect file' | translate }}"></i>
+      </a>
+    </div>
+    <input id="csvFileSelector" type="file" value="" accept="{{ accept }}">
+    <p class="help-block">
+      <translate translate-context="special filetypes in a file open dialog">Accept</translate>: {{ accept }}
+    </p>
+  </div>
+
+  <div class="form-group">
+    <label for="selectEncoding" translate>Encoding</label>
+    <select class="form-control" ng-model="$parent.encoding" ng-if="encodingOptions.length > 1" ng-change="parse()"
+      id="selectEncoding" ng-options="enc for enc in encodingOptions"></select>
+  </div>
+  <div class="form-group">
+    <label for="inputDelimiter" translate>Separator</label>
+    <input type="text" class="form-control" ng-model="delimiter" ng-change="parse()" id="inputDelimiter">
+    <p class="help-block help-block-big" ng-if="autodelimiter"><translate>Autodetect</translate>:&nbsp;&nbsp;{{ autodelimiter }}</p>
+    <p class="help-block" ng-if="!autodelimiter" translate>Leave empty for autodetection of the separator.</p>
+  </div>
+</form>

--- a/openslides/motions/static/templates/motions/motion-import.html
+++ b/openslides/motions/static/templates/motions/motion-import.html
@@ -12,40 +12,27 @@
 
 <div class="details">
 
-  <div class="block row">
-    <div class="title">
-      <h3 translate>Select a CSV file
-    </div>
-    <div class="block right import">
-      <label class="label" for="inputSeparator" translate>Separator</label>
-      <input type="text" ng-model="separator" ng-change="setSeparator()" ng-init="separator=separator" id="inputSeparator">
-      <br>
-      <label class="label" for="selectEncoding" translate>Encoding</label>
-      <select ng-model="encoding" ng-options="enc as enc for enc in encodingOptions"
-          ng-selected="setEncoding()" ng-init="encoding=encoding" id="selectEncoding"></select>
-      <ng-csv-import
-          content="csv.content"
-          header="csv.header"
-          header-visible="csv.headerVisible"
-          separator="csv.separator"
-          separator-visible="csv.separatorVisible"
-          result="csv.result"
-          encoding="csv.encoding"
-          accept="csv.accept"
-          encoding-visible="csv.encodingVisible"></ng-csv-import>
-    </div>
-  </div>
+  <h3 translate>Select a CSV file</h3>
+  <csv-import change="onCsvChange(csv)" config="csvConfig"></csv-import>
 
   <h4 translate>Please note:</h4>
   <ul class="indentation">
       <li><translate>Required comma or semicolon separated values with these column header names in the first row</translate>:<br>
-          <code>identifier, title, text, reason, submitter, category, origin</code>
+        <code>
+          <translate>Identifier</translate>,
+          <translate>Title</translate>,
+          <translate>Text</translate>,
+          <translate>Reason</translate>,
+          <translate>Submitter</translate>,
+          <translate>Category</translate>,
+          <translate>Origin</translate>
+        </code>
       <li translate>Identifier, reason, submitter, category and origin are optional and may be empty.
       <li translate>Only double quotes are accepted as text delimiter (no single quotes).
       <li><a id="downloadLink" href="" ng-click="downloadCSVExample()" translate>Download CSV example file</a>
   </ul>
 
-  <div ng-if="csv.result">
+  <div ng-if="motions.length">
     <h3 translate>Preview</h3>
     <table class="table table-striped table-bordered table-condensed">
       <thead>


### PR DESCRIPTION
This is an example for motions. If this is approved, I will change all imports. ng-csv-import is removed and now there is a new directive using PapaParse for parsing the csv file.

Closes:
- #2780 
- #2741 
- #2740 (the regex change may be obsolete)
- #2645 
- #2515 
- #2184 

Todo:

- [x] Add PapaParse to README
- [x] Check regex (see #2740 ) **Update: No regex needed**