### PR TITLE
Use twisted<16.4 for easier install (without compiling).

### DIFF
--- a/requirements_production.txt
+++ b/requirements_production.txt
@@ -6,5 +6,5 @@ jsonfield>=1.0,<1.1
 PyPDF2>=1.26,<1.27
 roman>=2.0,<2.1
 setuptools>=18.5,<33.0
-Twisted>=16.6,<16.7
+Twisted>=16.2,<16.4
 Whoosh>=2.7,<2.8


### PR DESCRIPTION
see also #2398