### PR TITLE
Cookie handling on login

### DIFF
--- a/openslides/core/static/templates/core/login-form.html
+++ b/openslides/core/static/templates/core/login-form.html
@@ -1,4 +1,4 @@
-<form ng-submit="login(username, password)">
+<form ng-submit="login()">
   <div class="modal-header">
     <img src="/static/img/openslides-logo.png" alt="OpenSlides" class="login-logo center-block">
   </div>

--- a/openslides/users/static/js/users/site.js
+++ b/openslides/users/static/js/users/site.js
@@ -1486,10 +1486,11 @@ angular.module('OpenSlidesApp.users.site', [
         // login
         $scope.login = function () {
             $scope.alerts = [];
-            $http.post(
-                '/users/login/',
-                {'username': $scope.username, 'password': $scope.password}
-            ).then(
+            var data = { 'username': $scope.username, 'password': $scope.password };
+            if (!navigator.cookieEnabled) {
+                data.cookies = false;
+            }
+            $http.post('/users/login/', data).then(
                 function (response) {
                     // Success: User logged in.
                     operator.setUser(response.data.user_id);

--- a/openslides/users/views.py
+++ b/openslides/users/views.py
@@ -164,6 +164,9 @@ class UserLoginView(APIView):
     http_method_names = ['get', 'post']
 
     def post(self, *args, **kwargs):
+        # If the client tells that cookies are disabled, do not continue as guest (if enabled)
+        if not self.request.data.get('cookies', True):
+            raise ValidationError({'detail': _('Cookies have to be enabled to use OpenSlides.')})
         form = AuthenticationForm(self.request, data=self.request.data)
         if not form.is_valid():
             raise ValidationError({'detail': _('Username or password is not correct.')})


### PR DESCRIPTION
Just a suggestion: The client sends `cookies: false` in login request, if cookies are disabled. So the server could just give an error and the user stays at the login form (if guests are enabled). This prevents the user of thinking he is logged in (See issue #2654 ).

@normanjaeckel (and others): Whats you opinion?