### PR TITLE
print correct number of ballots (closes #2504)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -52,12 +52,14 @@ Motions:
 - Added DOCX export with docxtemplater.
 - Changed label of former state "commited a bill" to "refered to committee".
 - New csv import layout and using Papa Parse for parsing the csv.
+- Number of ballots printed can now be set in config.
 
 Elections:
 - Added options to calculate percentages on different bases.
 - Added calculation for required majority.
 - Candidates are now sortable.
 - Removed unused assignment config to publish winner election results only.
+- Number of ballots printed can now be set in config.
 
 Users:
 - Added new matrix-interface for managing groups and their permissions.

--- a/openslides/core/static/js/core/pdf.js
+++ b/openslides/core/static/js/core/pdf.js
@@ -102,13 +102,33 @@ angular.module('OpenSlidesApp.core.pdf', [])
         PDFLayout.getBallotLayoutLines = function() {
             return {
                 hLineWidth: function(i, node) {
-                    return (i === 0 || i === node.table.body.length) ? 0 : 0.5;
+                    if (i === 0){
+                        return 0;
+                    } else if (i === node.table.body.length) {
+                        if (node.rowsperpage && node.rowsperpage > i) {
+                            return 0.5;
+                        } else {
+                            return 0;
+                        }
+                    } else {
+                        return 0.5;
+                    }
                 },
                 vLineWidth: function(i, node) {
                     return (i === 0 || i === node.table.widths.length) ? 0 : 0.5;
                 },
                 hLineColor: function(i, node) {
-                    return (i === 0 || i === node.table.body.length) ? 'none' : 'gray';
+                    if (i === 0){
+                        return 'none';
+                    } else if (i === node.table.body.length) {
+                        if (node.rowsperpage && node.rowsperpage > i) {
+                            return 'gray';
+                        } else {
+                            return 'none';
+                        }
+                    } else {
+                        return 'gray';
+                    }
                 },
                 vLineColor: function(i, node) {
                     return (i === 0 || i === node.table.widths.length) ? 'none' : 'gray';


### PR DESCRIPTION
The pdf printing now respects the `..._pdf_ballot_papers_number` number; tested with up to 10000 ballots. 

It is not ready yet, as the config also gives the options:
- NUMBER_OF_DELEGATES
- NUMBER_OF_ALL_PARTICIPANTS

I am unsure how to get these numbers. Also, the printing of the last page is missing one horizontal line.