### PR TITLE
use pdfmake release 0.1.23

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -35,7 +35,7 @@
     "ng-file-upload": "~11.2.3",
     "ngstorage": "~0.3.11",
     "ngBootbox": "~0.1.3",
-    "pdfmake": "bpampuch/pdfmake#214ec161c11fadb8f02c08f2e3bea0576ac4c9fb",
+    "pdfmake": "~0.1.23",
     "roboto-fontface": "~0.6.0"
   },
   "overrides": {


### PR DESCRIPTION
change the version of pdfmake to the current release.
This allows us to:
- use QR codes
- (hopefully) use images via the local paths
and
- render hundreds of pages in no time

see: [https://github.com/bpampuch/pdfmake/releases/tag/0.1.23](https://github.com/bpampuch/pdfmake/releases/tag/0.1.23) and [https://github.com/bpampuch/pdfmake/releases/tag/0.1.22](https://github.com/bpampuch/pdfmake/releases/tag/0.1.22)
(since currently we are somewhere a little bit before 0.1.22)

I briefly tested the current functionality. Works as it was supposed to.
