### PR TITLE
 Add QR code in user access list pdf (fixes #2665)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -66,6 +66,7 @@ Users:
 - Added new field 'is_committee' and new default group 'Committees'.
 - Improved users CSV import (use group names instead of id).
 - Added more multiselect actions.
+- Added QR code in users access pdf.
 
 Other:
 - Django 1.10 is now supported. Dropped support for Django 1.8 and 1.9.

--- a/openslides/core/static/js/core/pdf.js
+++ b/openslides/core/static/js/core/pdf.js
@@ -203,7 +203,7 @@ angular.module('OpenSlidesApp.core.pdf', [])
                 };
             };
             // Generates the document(definition) for pdfMake
-            var getDocument = function() {
+            var getDocument = function(noFooter) {
                 var content = contentProvider.getContent();
                 return {
                     pageSize: 'A4',
@@ -213,7 +213,7 @@ angular.module('OpenSlidesApp.core.pdf', [])
                         fontSize: 10
                     },
                     header: header,
-                    footer: footer,
+                    footer: noFooter ? '' : footer,
                     content: content,
                     styles: {
                         title: {
@@ -296,6 +296,9 @@ angular.module('OpenSlidesApp.core.pdf', [])
                         },
                         bold: {
                             bold: true,
+                        },
+                        small: {
+                            fontSize: 8,
                         }
                     }
                 };

--- a/openslides/users/static/js/users/pdf.js
+++ b/openslides/users/static/js/users/pdf.js
@@ -128,6 +128,9 @@ angular.module('OpenSlidesApp.users.pdf', ['OpenSlidesApp.core.pdf'])
             };
 
             var createAccessDataContent = function(user) {
+                var wifiQrCode = "WIFI:S:" + Config.get('users_pdf_wlan_ssid').value +
+                    ";T:" + Config.get('users_pdf_wlan_encryption').value +
+                    ";P:" + Config.get('users_pdf_wlan_password').value + ";;";
                 var accessDataColumns = {
                     columns: [
                         {
@@ -159,6 +162,15 @@ angular.module('OpenSlidesApp.users.pdf', ['OpenSlidesApp.core.pdf'])
                                 {
                                     text: Config.get('users_pdf_wlan_encryption').value || '-',
                                     style: 'userDataValue'
+                                },
+                                {
+                                    text: "\n"
+                                },
+                                {
+                                    qr: wifiQrCode
+                                },
+                                {
+                                    text: gettextCatalog.getString("scan QR code to connect to WLAN")
                                 },
                             ]
                         },
@@ -192,6 +204,15 @@ angular.module('OpenSlidesApp.users.pdf', ['OpenSlidesApp.core.pdf'])
                                     text: Config.get('users_pdf_url').value  || '-',
                                     link: Config.get('users_pdf_url').value,
                                     style: 'userDataValue'
+                                },
+                                {
+                                    text: "\n"
+                                },
+                                {
+                                    qr: Config.get('users_pdf_url').value
+                                },
+                                {
+                                    text: gettextCatalog.getString("scan QR code to open the URL")
                                 },
                             ]
                         }

--- a/openslides/users/static/js/users/pdf.js
+++ b/openslides/users/static/js/users/pdf.js
@@ -128,96 +128,114 @@ angular.module('OpenSlidesApp.users.pdf', ['OpenSlidesApp.core.pdf'])
             };
 
             var createAccessDataContent = function(user) {
-                var wifiQrCode = "WIFI:S:" + Config.get('users_pdf_wlan_ssid').value +
-                    ";T:" + Config.get('users_pdf_wlan_encryption').value +
-                    ";P:" + Config.get('users_pdf_wlan_password').value + ";;";
-                var accessDataColumns = {
-                    columns: [
+                // wlan access data
+                var columnWifi = [
+                    {
+                        text: gettextCatalog.getString("WLAN access data"),
+                        style: 'userDataHeading'
+                    },
+                    {
+                        text: gettextCatalog.getString("WLAN name (SSID)") + ":",
+                        style: 'userDataTopic'
+                    },
+                    {
+                        text: Config.get('users_pdf_wlan_ssid').value || '-',
+                        style: 'userDataValue'
+                    },
+                    {
+                        text: gettextCatalog.getString("WLAN password") + ":",
+                        style: 'userDataTopic'
+                    },
+                    {
+                        text: Config.get('users_pdf_wlan_password').value || '-',
+                        style: 'userDataValue'
+                    },
+                    {
+                        text: gettextCatalog.getString("WLAN encryption") + ":",
+                        style: 'userDataTopic'
+                    },
+                    {
+                        text: Config.get('users_pdf_wlan_encryption').value || '-',
+                        style: 'userDataValue'
+                    },
+                    {
+                        text: "\n"
+                    }
+                ];
+                // wifi qr code
+                if (Config.get('users_pdf_wlan_ssid').value && Config.get('users_pdf_wlan_encryption').value) {
+                    var wifiQrCode = "WIFI:S:" + Config.get('users_pdf_wlan_ssid').value +
+                        ";T:" + Config.get('users_pdf_wlan_encryption').value +
+                        ";P:" + Config.get('users_pdf_wlan_password').value + ";;";
+                    columnWifi.push(
                         {
-                            stack: [
-                                {
-                                    text: gettextCatalog.getString("WLAN access data"),
-                                    style: 'userDataHeading'
-                                },
-                                {
-                                    text: gettextCatalog.getString("WLAN name (SSID)") + ":",
-                                    style: 'userDataTopic'
-                                },
-                                {
-                                    text: Config.get('users_pdf_wlan_ssid').value || '-',
-                                    style: 'userDataValue'
-                                },
-                                {
-                                    text: gettextCatalog.getString("WLAN password") + ":",
-                                    style: 'userDataTopic'
-                                },
-                                {
-                                    text: Config.get('users_pdf_wlan_password').value || '-',
-                                    style: 'userDataValue'
-                                },
-                                {
-                                    text: gettextCatalog.getString("WLAN encryption") + ":",
-                                    style: 'userDataTopic'
-                                },
-                                {
-                                    text: Config.get('users_pdf_wlan_encryption').value || '-',
-                                    style: 'userDataValue'
-                                },
-                                {
-                                    text: "\n"
-                                },
-                                {
-                                    qr: wifiQrCode
-                                },
-                                {
-                                    text: gettextCatalog.getString("scan QR code to connect to WLAN")
-                                },
-                            ]
+                            qr: wifiQrCode,
+                            fit: 120,
+                            margin: [0, 0, 0, 8]
                         },
                         {
-                            stack: [
-                                {
-                                    text: gettextCatalog.getString("OpenSlides access data"),
-                                    style: 'userDataHeading'
-                                },
-                                {
-                                    text: gettextCatalog.getString("Username") + ":",
-                                    style: 'userDataTopic'
-                                },
-                                {
-                                    text: user.username,
-                                    style: 'userDataValue'
-                                },
-                                {
-                                    text: gettextCatalog.getString("Initial password") + ":",
-                                    style: 'userDataTopic'
-                                },
-                                {
-                                    text: user.default_password,
-                                    style: 'userDataValue'
-                                },
-                                {
-                                    text: "URL:",
-                                    style: 'userDataTopic'
-                                },
-                                {
-                                    text: Config.get('users_pdf_url').value  || '-',
-                                    link: Config.get('users_pdf_url').value,
-                                    style: 'userDataValue'
-                                },
-                                {
-                                    text: "\n"
-                                },
-                                {
-                                    qr: Config.get('users_pdf_url').value
-                                },
-                                {
-                                    text: gettextCatalog.getString("scan QR code to open the URL")
-                                },
-                            ]
+                            text: gettextCatalog.getString("Scan this QR code to connect to WLAN."),
+                            style: 'small'
                         }
+                    );
+                }
+
+                // openslides access data
+                var columnOpenSlides = [
+                    {
+                        text: gettextCatalog.getString("OpenSlides access data"),
+                        style: 'userDataHeading'
+                    },
+                    {
+                        text: gettextCatalog.getString("Username") + ":",
+                        style: 'userDataTopic'
+                    },
+                    {
+                        text: user.username,
+                        style: 'userDataValue'
+                    },
+                    {
+                        text: gettextCatalog.getString("Initial password") + ":",
+                        style: 'userDataTopic'
+                    },
+                    {
+                        text: user.default_password,
+                        style: 'userDataValue'
+                    },
+                    {
+                        text: "URL:",
+                        style: 'userDataTopic'
+                    },
+                    {
+                        text: Config.get('users_pdf_url').value  || '-',
+                        link: Config.get('users_pdf_url').value,
+                        style: 'userDataValue'
+                    },
+                    {
+                        text: "\n"
+                    }
+                ];
+                // url qr code
+                if (Config.get('users_pdf_url').value) {
+                    columnOpenSlides.push(
+                        {
+                            qr: Config.get('users_pdf_url').value,
+                            fit: 120,
+                            margin: [0, 0, 0, 8]
+                        },
+                        {
+                            text: gettextCatalog.getString("Scan this QR code to open URL."),
+                            style: 'small'
+                        }
+                    );
+                }
+
+                var accessDataColumns = {
+                    columns: [
+                        columnWifi,
+                        columnOpenSlides,
                     ],
-                    margin: [0,20]
+                    margin: [0, 20]
                 };
 
                 return accessDataColumns;

--- a/openslides/users/static/js/users/site.js
+++ b/openslides/users/static/js/users/site.js
@@ -681,7 +681,8 @@ angular.module('OpenSlidesApp.users.site', [
             var userAccessDataListContentProvider = UserAccessDataListContentProvider.createInstance(
                 $scope.usersFiltered, $scope.groups, Config);
             var documentProvider = PdfMakeDocumentProvider.createInstance(userAccessDataListContentProvider);
-            pdfMake.createPdf(documentProvider.getDocument()).download(filename);
+            var noFooter = true;
+            pdfMake.createPdf(documentProvider.getDocument(noFooter)).download(filename);
         };
         // Export as a csv file
         $scope.csvExport = function () {


### PR DESCRIPTION
Adds QR codes to the PDF access data list.
The example contains private data. I tested it using the guest network of our company using the app "QR Droid" App with the "QR-WiFi Plugin"

[https://play.google.com/store/apps/details?id=la.droid.qr&hl=de](https://play.google.com/store/apps/details?id=la.droid.qr&hl=de)
[https://play.google.com/store/apps/details?id=la.droid.wifi&hl=de](https://play.google.com/store/apps/details?id=la.droid.wifi&hl=de)

Note that smartphones are not able to just use QR codes to connect to WiFi out of the box

also: this depends on the new pdfmake release

we also need two new entries in the gettext for
"scan QR code to connect to WLAN"
and
"scan QR code to open the URL"

@emanuelschuetze 
@normanjaeckel 