### PR TITLE
Add new personal settings MOTION_IDENTIFIER_WITHOUT_BLANKS.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -53,6 +53,7 @@ Motions:
 - Changed label of former state "commited a bill" to "refered to committee".
 - New csv import layout and using Papa Parse for parsing the csv.
 - Number of ballots printed can now be set in config.
+- Add new personal settings to remove all whitespaces from motion identifier.
 
 Elections:
 - Added options to calculate percentages on different bases.

--- a/openslides/motions/models.py
+++ b/openslides/motions/models.py
@@ -336,6 +336,10 @@ class Motion(RESTModelMixin, models.Model):
             number += 1
             identifier = '%s%s' % (prefix, self.extend_identifier_number(number))
 
+        # remove all whitespaces from identifier if MOTION_IDENTIFIER_WITHOUT_BLANKS is set
+        if hasattr(settings, 'MOTION_IDENTIFIER_WITHOUT_BLANKS') and settings.MOTION_IDENTIFIER_WITHOUT_BLANKS:
+            identifier = identifier.replace(' ', '')
+
         self.identifier = identifier
         self.identifier_number = number
 

--- a/openslides/utils/settings.py.tpl
+++ b/openslides/utils/settings.py.tpl
@@ -120,3 +120,4 @@ SEARCH_INDEX = os.path.join(OPENSLIDES_USER_DATA_PATH, 'search_index')
 # Customization of OpenSlides apps
 
 MOTION_IDENTIFIER_MIN_DIGITS = 1
+MOTION_IDENTIFIER_WITHOUT_BLANKS = False


### PR DESCRIPTION
Allow to remove all whitespaces from motion identifier if settings
value is True. Default: False.
Example: "B 1 - Ä 1" -> "B1-Ä1"