### PR TITLE
Watch perms in client (closes #1855)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -40,6 +40,7 @@ Core:
 - New csv import layout.
 - Replaced angular-csv-import through Papa Parse for csv parsing.
 - Added smooth projector scroll.
+- Added watching permissions in client and change the view immediately on changes.
 
 Motions:
 - Added adjustable line numbering mode (outside, inside, none) for each

--- a/openslides/agenda/static/js/agenda/site.js
+++ b/openslides/agenda/static/js/agenda/site.js
@@ -34,6 +34,7 @@ angular.module('OpenSlidesApp.agenda.site', [
                 template: "<ui-view/>",
                 data: {
                     title: gettext('Agenda'),
+                    basePerm: 'agenda.can_see',
                 },
             })
             .state('agenda.item', {

--- a/openslides/assignments/static/js/assignments/site.js
+++ b/openslides/assignments/static/js/assignments/site.js
@@ -34,6 +34,7 @@ angular.module('OpenSlidesApp.assignments.site', [
                 template: "<ui-view/>",
                 data: {
                     title: gettext('Elections'),
+                    basePerm: 'assignments.can_see',
                 },
             })
             .state('assignments.assignment', {

--- a/openslides/core/static/js/core/base.js
+++ b/openslides/core/static/js/core/base.js
@@ -123,10 +123,8 @@ angular.module('OpenSlidesApp.core', [
             setUser: function(user_id, user_data) {
                 if (user_id && user_data) {
                     operator.user = User.inject(user_data);
-                    operator.perms = operator.user.getPerms();
                 } else {
                     operator.user = null;
-                    operator.perms = Group.get(1).permissions;
                 }
             },
             // Returns true if the operator has at least one perm of the perms-list.
@@ -135,6 +133,14 @@ angular.module('OpenSlidesApp.core', [
                     perms = perms.split(' ');
                 }
                 return _.intersection(perms, operator.perms).length > 0;
+            },
+            reloadPerms: function () {
+                if (operator.user) {
+                    operator.perms = operator.user.getPerms();
+                } else {
+                    var defaultGroup = Group.get(1);
+                    operator.perms = defaultGroup ? defaultGroup.permissions : [];
+                }
             },
             // Returns true if the operator is a member of group.
             isInGroup: function(group) {

--- a/openslides/core/static/js/core/site.js
+++ b/openslides/core/static/js/core/site.js
@@ -115,10 +115,18 @@ angular.module('OpenSlidesApp.core.site', [
 .run([
     '$rootScope',
     'gettextCatalog',
-    function ($rootScope, gettextCatalog) {
+    'operator',
+    function ($rootScope, gettextCatalog, operator) {
         $rootScope.activeAppTitle = '';
-        $rootScope.$on('$stateChangeSuccess', function(evt, toState) {
-            $rootScope.activeAppTitle = toState.data ? toState.data.title : '';
+        $rootScope.$on('$stateChangeSuccess', function(event, toState) {
+            if (toState.data) {
+                $rootScope.activeAppTitle = toState.data.title || '';
+                $rootScope.baseViewPermissionsGranted = toState.data.basePerm ?
+                    operator.hasPerms(toState.data.basePerm) : true;
+            } else {
+                $rootScope.activeAppTitle = '';
+                $rootScope.baseViewPermissionsGranted = true;
+            }
         });
     }
 ])
@@ -263,6 +271,7 @@ angular.module('OpenSlidesApp.core.site', [
                 templateUrl: 'static/templates/home.html',
                 data: {
                     title: gettext('Home'),
+                    basePerm: 'core.can_see_frontpage',
                 },
             })
             .state('projector', {
@@ -287,6 +296,7 @@ angular.module('OpenSlidesApp.core.site', [
                 controller: 'ManageProjectorsCtrl',
                 data: {
                     title: gettext('Manage projectors'),
+                    basePerm: 'core.can_manage_projector',
                 },
             })
             .state('core', {
@@ -315,6 +325,7 @@ angular.module('OpenSlidesApp.core.site', [
                 },
                 data: {
                     title: gettext('Settings'),
+                    basePerm: 'core.can_manage_config',
                 },
             })
 
@@ -335,6 +346,7 @@ angular.module('OpenSlidesApp.core.site', [
                 template: "<ui-view/>",
                 data: {
                     title: gettext('Tags'),
+                    basePerm: 'core.can_manage_tags',
                 },
             })
             .state('core.tag.list', {})

--- a/openslides/core/static/js/core/start.js
+++ b/openslides/core/static/js/core/start.js
@@ -30,6 +30,39 @@ angular.module('OpenSlidesApp.core.start', [])
             }
         });
     }
+])
+
+.run([
+    '$rootScope',
+    '$state',
+    'operator',
+    'User',
+    'Group',
+    'mainMenu',
+    function ($rootScope, $state, operator, User, Group, mainMenu) {
+        var permissionChangeCallback = function () {
+            operator.reloadPerms();
+            mainMenu.updateMainMenu();
+            var stateData = $state.current.data;
+            var basePerm = stateData ? stateData.basePerm : '';
+            $rootScope.baseViewPermissionsGranted = basePerm ?
+                operator.hasPerms(basePerm) : true;
+        };
+
+        $rootScope.$watch(function () {
+            return Group.lastModified();
+        }, function () {
+            if (Group.getAll().length) {
+                permissionChangeCallback();
+            }
+        });
+
+        $rootScope.$watch(function () {
+            return operator.user ? User.lastModified(operator.user.id) : true;
+        }, function () {
+            permissionChangeCallback();
+        });
+    }
 ]);
 
 }());

--- a/openslides/core/static/templates/core/manage-projectors.html
+++ b/openslides/core/static/templates/core/manage-projectors.html
@@ -36,8 +36,8 @@
   </div>
 </div>
 
-<div class="details">
-  <div class="projectorContainer" os-perms="core.can_manage_projector">
+<div class="details" os-perms="core.can_manage_projector">
+  <div class="projectorContainer">
 
     <div ng-repeat="projector in projectors | orderBy: 'id'">
       <div>

--- a/openslides/core/static/templates/index.html
+++ b/openslides/core/static/templates/index.html
@@ -174,9 +174,9 @@
 <!-- Content -->
 <div id="content" ng-controller="ProjectorSidebarCtrl">
   <div class="containerOS">
-    <div class="col1" ng-class="isProjectorSidebar ? 'min' : 'max'">
+    <div class="col1" ng-class="(isProjectorSidebar && operator.hasPerms('core.can_see_projector')) ? 'min' : 'max'">
         <!-- dynamic views -->
-        <div ui-view ng-if="openslidesBootstrapDone"></div>
+        <div ui-view ng-if="openslidesBootstrapDone && baseViewPermissionsGranted"></div>
         <!-- footer -->
         <div id="footer">
           &copy; Copyright by <a href="http://www.openslides.org" target="_blank">OpenSlides</a> |
@@ -184,7 +184,7 @@
         </div><!--end footer-->
     </div>
     <div id="sidebar" class="col2" os-perms="core.can_see_projector"
-        ng-class="isProjectorSidebar ? 'max' : 'min'"
+        ng-class="(isProjectorSidebar && operator.hasPerms('core.can_see_projector')) ? 'max' : 'min'"
         ng-init="initSidebar()">
       <!-- sidebar maximized -->
       <div class="projector_full" ng-if="isProjectorSidebar">

--- a/openslides/mediafiles/static/js/mediafiles/states.js
+++ b/openslides/mediafiles/static/js/mediafiles/states.js
@@ -33,6 +33,7 @@ angular.module('OpenSlidesApp.mediafiles.states', [
             template: "<ui-view/>",
             data: {
                 title: gettext('Files'),
+                basePerm: 'mediafiles.can_see',
             },
         })
         .state('mediafiles.mediafile', {

--- a/openslides/motions/static/js/motions/site.js
+++ b/openslides/motions/static/js/motions/site.js
@@ -37,6 +37,7 @@ angular.module('OpenSlidesApp.motions.site', [
                 template: "<ui-view/>",
                 data: {
                     title: gettext('Motions'),
+                    basePerm: 'motions.can_see',
                 },
             })
             .state('motions.motion', {

--- a/openslides/users/static/js/users/site.js
+++ b/openslides/users/static/js/users/site.js
@@ -34,6 +34,7 @@ angular.module('OpenSlidesApp.users.site', [
             template: "<ui-view/>",
             data: {
                 title: gettext('Participants'),
+                basePerm: 'users.can_see_name',
             },
         })
         .state('users.user', {


### PR DESCRIPTION
Every base view now has a base permission. Currently by entering for example `/users/` the users were shown also without the `can_see_name` permission.

Whats with the projector permissions? Now everyone can see the projector, also if the user has not the `can_see_projector` permission.