### PR TITLE
Use custom redis prefix for asgi and cache entries.

### DIFF
--- a/openslides/utils/settings.py.tpl
+++ b/openslides/utils/settings.py.tpl
@@ -96,7 +96,7 @@ if use_redis:
            "OPTIONS": {
                "CLIENT_CLASS": "django_redis.client.DefaultClient",
            },
-           "KEY_PREFIX": "openslides-cache"
+           "KEY_PREFIX": "openslides-cache",
        }
     }
 

--- a/openslides/utils/settings.py.tpl
+++ b/openslides/utils/settings.py.tpl
@@ -80,6 +80,7 @@ if use_redis:
     # https://channels.readthedocs.io/en/latest/backends.html#redis
 
     CHANNEL_LAYERS['default']['BACKEND'] = 'asgi_redis.RedisChannelLayer'
+    CHANNEL_LAYERS['default']['CONFIG']['prefix'] = 'asgi:'
 
 
     # Caching
@@ -94,7 +95,8 @@ if use_redis:
            "LOCATION": "redis://127.0.0.1:6379/0",
            "OPTIONS": {
                "CLIENT_CLASS": "django_redis.client.DefaultClient",
-           }
+           },
+           "KEY_PREFIX": "openslides-cache"
        }
     }
 


### PR DESCRIPTION
Note: These prefix have to be unique for each OpenSlides instance!

@ostcar Do you accept the new defaults for geiss?