### PR TITLE
Fixed dynamic pdf header and footer for worker (Fixed #2923).

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -34,7 +34,7 @@
     "ngstorage": "~0.3.11",
     "ngBootbox": "~0.1.3",
     "papaparse": "~4.1.2",
-    "pdfmake": "0.1.23",
+    "pdfmake": "0.1.25",
     "roboto-fontface": "~0.6.0"
   },
   "overrides": {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -228,9 +228,13 @@ gulp.task('default', [
  */
 
 // Watches changes in JavaScript and templates.
-gulp.task('watch', ['js', 'templates'], function () {
-    gulp.watch(path.join('openslides', '*', 'static', 'js', '**', '*.js'), ['js']);
+gulp.task('watch', ['js', 'templates', 'pdf-worker'], function () {
+    gulp.watch([
+        path.join('openslides', '*', 'static', 'js', '**', '*.js'),
+        '!' + path.join('openslides', 'core', 'static', 'js', 'core', 'pdf-worker.js')
+    ], ['js']);
     gulp.watch(path.join('openslides', '*', 'static', 'templates', '**', '*.html'), ['templates']);
+    gulp.watch(path.join('openslides', 'core', 'static', 'js', 'core', 'pdf-worker.js'), ['pdf-worker']);
 });
 
 // Extracts translatable strings using angular-gettext and saves them in file

--- a/openslides/core/static/js/core/pdf-worker.js
+++ b/openslides/core/static/js/core/pdf-worker.js
@@ -30,6 +30,72 @@ pdfMake.fonts = {
 // Create PDF on message and return the base64 decoded document
 self.addEventListener('message', function(e) {
     var data = JSON.parse(e.data);
+
+    // Workaround for using dynamic footer with page number.
+    // TODO: Needs improvement of pdfmake's web worker support.
+    // see https://github.com/bpampuch/pdfmake/issues/38
+    if (data.footerTpl) {
+        data.footer = function (currentPage, pageCount) {
+            var footerText = data.footerTpl.text
+                .replace('{{currentPage}}', currentPage)
+                .replace('{{pageCount}}', pageCount);
+            return {
+                text: footerText,
+                alignment: data.footerTpl.alignment,
+                fontSize: data.footerTpl.fontSize,
+                color: data.footerTpl.color
+            };
+        };
+    }
+
+    // Workaround for using table layout functions.
+    // TODO: Needs improvement of pdfmake's web worker support.
+    // Currently only functions are allowed for 'layout'.
+    // But functions cannot be passed to workers (via JSON).
+    //
+    // ballot paper crop marks
+    for (var i = 0; i < data.content.length; i++) {
+        if (data.content[i].layout === "{{ballot-placeholder-to-insert-functions-here}}") {
+            data.content[i].layout = {
+                hLineWidth: function(i, node) {
+                    if (i === 0){
+                        return 0;
+                    } else if (i === node.table.body.length) {
+                        if (node.rowsperpage && node.rowsperpage > i) {
+                            return 0.5;
+                        } else {
+                            return 0;
+                        }
+                    } else {
+                        return 0.5;
+                    }
+                },
+                vLineWidth: function(i, node) {
+                    return (i === 0 || i === node.table.widths.length) ? 0 : 0.5;
+                },
+                hLineColor: function() {
+                    return 'gray';
+                },
+                vLineColor: function() {
+                    return 'gray';
+                }
+            };
+        }
+        // motion meta table border lines
+        if (data.content[i].layout === "{{motion-placeholder-to-insert-functions-here}}") {
+            data.content[i].layout = {
+                hLineWidth: function(i, node) {
+                    return (i === 0 || i === node.table.body.length) ? 0 : 0.5;
+                },
+                vLineWidth: function() {
+                    return 0;
+                },
+                hLineColor: function() {
+                    return 'white';
+                }
+            };
+        }
+    }
     var pdf = pdfMake.createPdf(data);
     pdf.getBase64(function (base64) {
         self.postMessage(base64);

--- a/openslides/motions/static/js/motions/pdf.js
+++ b/openslides/motions/static/js/motions/pdf.js
@@ -40,7 +40,7 @@ angular.module('OpenSlidesApp.motions.pdf', ['OpenSlidesApp.core.pdf'])
             metaTableBody.push([
                 {
                     text: gettextCatalog.getString('Submitters') + ':',
-                    style: ['bold', 'grey']
+                    style: ['bold', 'grey'],
                 },
                 {
                     text: submitters,
@@ -79,8 +79,7 @@ angular.module('OpenSlidesApp.motions.pdf', ['OpenSlidesApp.core.pdf'])
                 metaTableBody.push([
                     {
                         text: gettextCatalog.getString('Category') + ':',
-                        style: ['bold', 'grey']
-                    },
+                        style: ['bold', 'grey'] },
                     {
                         text: motion.category.name,
                         style: 'grey'
@@ -216,26 +215,17 @@ angular.module('OpenSlidesApp.motions.pdf', ['OpenSlidesApp.core.pdf'])
             }
 
             // build table
+            // Used placeholder for 'layout' functions whiche are
+            // replaced by lineWitdh/lineColor function in pfd-worker.js.
+            // TODO: Remove placeholder and us static values for LineWidth and LineColor
+            // if pdfmake has fixed this.
             var metaTableJsonString = {
                 table: {
                     widths: ['30%','70%'],
                     body: metaTableBody,
                 },
                 margin: [0, 0, 0, 20],
-                layout: {
-                    hLineWidth: function(i, node) {
-                        return (i === 0 || i === node.table.body.length) ? 0 : 0.5;
-                    },
-                    vLineWidth: function(i, node) {
-                        return (i === 0 || i === node.table.widths.length) ? 0 : 0;
-                    },
-                    hLineColor: function(i, node) {
-                        return (i === 0 || i === node.table.body.length) ? '' : 'white';
-                    },
-                    vLineColor: function(i, node) {
-                        return (i === 0 || i === node.table.widths.length) ? '' : 'white';
-                    }
-                }
+                layout: '{{motion-placeholder-to-insert-functions-here}}'
             };
             return metaTableJsonString;
         };

--- a/openslides/utils/validate.py
+++ b/openslides/utils/validate.py
@@ -2,7 +2,7 @@ import bleach
 
 allowed_tags = [
     'a', 'img',  # links and images
-    'p', 'span', 'blockquote',  # text layout
+    'br', 'p', 'span', 'blockquote',  # text layout
     'strike', 'strong', 'u', 'em', 'sup', 'sub', 'pre',  # text formatting
     'h1', 'h2', 'h3', 'h4', 'h5', 'h6',  # headings
     'ol', 'ul', 'li',  # lists


### PR DESCRIPTION
This fixed header and footer in PDF.
Still open: border color and border line width of motion meta table (see TODO in motions/pdf.js)
@FinnStutzenstein Any idea for a good fix?