### PR TITLE
Added the command getgeiss

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,6 @@ script:
   - coverage report --fail-under=44
 
   - DJANGO_SETTINGS_MODULE='tests.settings' coverage run ./manage.py test tests.integration
-  - coverage report --fail-under=70
+  - coverage report --fail-under=73
 
   - DJANGO_SETTINGS_MODULE='tests.old.settings' ./manage.py test tests.old

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,6 @@ script:
   - coverage report --fail-under=44
 
   - DJANGO_SETTINGS_MODULE='tests.settings' coverage run ./manage.py test tests.integration
-  - coverage report --fail-under=73
+  - coverage report --fail-under=70
 
   - DJANGO_SETTINGS_MODULE='tests.old.settings' ./manage.py test tests.old

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -115,7 +115,8 @@ Other:
 - Added function utils.auth.anonymous_is_enabled which returns true, if it is.
 - Changed has_perm to support an user id or None (for anyonmous) as first argument.
 - Removed our AnonymousUser. Make sure not to use user.has_perm() anymore.
-- Added Russia translation (Thanks to Andreas Engler).
+- Add the command getgeiss to download the latest version of Geiss.
+- Added Russian translation (Thanks to Andreas Engler).
 
 
 Version 2.0 (2016-04-18)

--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,7 @@ virtual environment::
     $ cd OpenSlides
     $ python3 -m venv .virtualenv
     $ source .virtualenv/bin/activate
+    $ pip install -U setuptools
 
 
 c. Install OpenSlides

--- a/openslides/core/management/commands/getgeiss.py
+++ b/openslides/core/management/commands/getgeiss.py
@@ -16,19 +16,19 @@ class Command(BaseCommand):
     help = 'Get the latest Geiss release from GitHub.'
 
     def handle(self, *args, **options):
-        geiss_name = get_geiss_name()
+        geiss_github_name = self.get_geiss_github_name()
         download_file = get_geiss_path()
 
         if os.path.isfile(download_file):
-            # Geiss does probably exist. Do Nothing.
+            # Geiss does probably exist. Do nothing.
             # TODO: Add an update flag, that downloads geiss anyway.
             return
 
-        response = urlopen(get_geiss_url()).read()
+        response = urlopen(self.get_geiss_url()).read()
         release = json.loads(response.decode())
         download_url = None
         for asset in release['assets']:
-            if asset['name'] == geiss_name:
+            if asset['name'] == geiss_github_name:
                 download_url = asset['browser_download_url']
                 break
         if download_url is None:
@@ -40,34 +40,36 @@ class Command(BaseCommand):
         st = os.stat(download_file)
         os.chmod(download_file, st.st_mode | stat.S_IEXEC)
 
+        self.stdout.write(self.style.SUCCESS('Geiss successfully downloaded.'))
 
-def get_geiss_url():
-    """
-    Returns the URL to the API which gives the information which geiss binary
-    has to be downloaded.
+    def get_geiss_url(self):
+        """
+        Returns the URL to the API which gives the information which Geiss
+        binary has to be downloaded.
 
-    Currently this is a static github-url to the repo where geiss is at the
-    moment. Could be changed to use a setting or a flag in the future.
-    """
-    return 'https://api.github.com/repos/ostcar/geiss/releases/latest'
+        Currently this is a static GitHub URL to the repository where geiss
+        is hosted at the moment.
+        """
+        # TODO: Use a settings variable or a command line flag in the future.
+        return 'https://api.github.com/repos/ostcar/geiss/releases/latest'
 
+    def get_geiss_github_name(self):
+        """
+        Returns the name of the Geiss executable for the current operating
+        system.
 
-def get_geiss_name():
-    """
-    Returns the name of the Geiss executable for the current operating system.
+        For example geiss_windows_64 on a windows64 platform.
+        """
+        # This will be 32 if the current python interpreter has only
+        # 32 bit, even if it is run on a 64 bit operating sysem.
+        bits = '64' if sys.maxsize > 2**32 else '32'
 
-    For example geiss_windows_64.exe on a windows64 platform.
-    """
-    # This will be 32 if the current python interpreter has only
-    # 32 bit, even if it is run on a 64 bit operating sysem.
-    bits = '64' if sys.maxsize > 2**32 else '32'
+        geiss_names = {
+            'linux': 'geiss_linux_{bits}',
+            'win32': 'geiss_windows_{bits}.exe',  # Yes, it is win32, even on a win64 system!
+            'darwin': 'geiss_mac_{bits}'}
 
-    geiss_names = {
-        'linux': 'geiss_linux_{bits}',
-        'win32': 'geiss_windows_{bits}.exe',  # Yes, it is win32, even on a win64 system!
-        'darwin': 'geiss_mac_{bits}'}
-
-    try:
-        return geiss_names[sys.platform].format(bits=bits)
-    except KeyError:
-        raise CommandError("Plattform {} is not supported by Geiss".format(sys.platform))
+        try:
+            return geiss_names[sys.platform].format(bits=bits)
+        except KeyError:
+            raise CommandError("Plattform {} is not supported by Geiss".format(sys.platform))

--- a/openslides/core/management/commands/getgeiss.py
+++ b/openslides/core/management/commands/getgeiss.py
@@ -1,0 +1,73 @@
+import json
+import os
+import stat
+import sys
+from urllib.request import urlopen, urlretrieve
+
+from django.core.management.base import BaseCommand, CommandError
+
+from openslides.utils.main import get_geiss_path
+
+
+class Command(BaseCommand):
+    """
+    Command to get the latest release of Geiss from GitHub.
+    """
+    help = 'Get the latest Geiss release from GitHub.'
+
+    def handle(self, *args, **options):
+        geiss_name = get_geiss_name()
+        download_file = get_geiss_path()
+
+        if os.path.isfile(download_file):
+            # Geiss does probably exist. Do Nothing.
+            # TODO: Add an update flag, that downloads geiss anyway.
+            return
+
+        response = urlopen(get_geiss_url()).read()
+        release = json.loads(response.decode())
+        download_url = None
+        for asset in release['assets']:
+            if asset['name'] == geiss_name:
+                download_url = asset['browser_download_url']
+                break
+        if download_url is None:
+            raise CommandError("Could not find download URL in release.")
+
+        urlretrieve(download_url, download_file)
+
+        # Set the executable bit on the file. This will do nothing on windows
+        st = os.stat(download_file)
+        os.chmod(download_file, st.st_mode | stat.S_IEXEC)
+
+
+def get_geiss_url():
+    """
+    Returns the URL to the API which gives the information which geiss binary
+    has to be downloaded.
+
+    Currently this is a static github-url to the repo where geiss is at the
+    moment. Could be changed to use a setting or a flag in the future.
+    """
+    return 'https://api.github.com/repos/ostcar/geiss/releases/latest'
+
+
+def get_geiss_name():
+    """
+    Returns the name of the Geiss executable for the current operating system.
+
+    For example geiss_windows_64.exe on a windows64 platform.
+    """
+    # This will be 32 if the current python interpreter has only
+    # 32 bit, even if it is run on a 64 bit operating sysem.
+    bits = '64' if sys.maxsize > 2**32 else '32'
+
+    geiss_names = {
+        'linux': 'geiss_linux_{bits}',
+        'win32': 'geiss_windows_{bits}.exe',  # Yes, it is win32, even on a win64 system!
+        'darwin': 'geiss_mac_{bits}'}
+
+    try:
+        return geiss_names[sys.platform].format(bits=bits)
+    except KeyError:
+        raise CommandError("Plattform {} is not supported by Geiss".format(sys.platform))

--- a/openslides/global_settings.py
+++ b/openslides/global_settings.py
@@ -81,8 +81,6 @@ LOCALE_PATHS = [
 
 STATIC_URL = '/static/'
 
-STATIC_ROOT = os.path.join(MODULE_DIR, '..', 'collected-static')
-
 STATICFILES_DIRS = [
     os.path.join(MODULE_DIR, 'static'),
 ]
@@ -134,6 +132,7 @@ CACHES = {
 
 # Django Channels
 # http://channels.readthedocs.io/en/latest/
+# https://github.com/ostcar/geiss
 
 CHANNEL_LAYERS = {
     'default': {

--- a/openslides/utils/main.py
+++ b/openslides/utils/main.py
@@ -281,6 +281,14 @@ def start_browser(browser_url):
         thread.start()
 
 
+def open_browser(host, port):
+    if host == '0.0.0.0':
+        # Windows does not support 0.0.0.0, so use 'localhost' instead
+        start_browser('http://localhost:%s' % port)
+    else:
+        start_browser('http://%s:%s' % (host, port))
+
+
 def get_database_path_from_settings():
     """
     Retrieves the database path out of the settings file. Returns None,
@@ -323,3 +331,20 @@ def is_local_installation():
     This is the case if manage.py is used, or when the --local-installation flag is set.
     """
     return True if '--local-installation' in sys.argv or 'manage.py' in sys.argv[0] else False
+
+
+def get_geiss_path():
+    """
+    Returns the path and file to the geis binary.
+    """
+    from django.conf import settings
+    download_path = getattr(settings, 'OPENSLIDES_USER_DATA_PATH', '')
+    bin_name = 'geiss.exe' if is_windows() else 'geiss'
+    return os.path.join(download_path, bin_name)
+
+
+def is_windows():
+    """
+    Returns True when the current system is windows. Returns False otherwise.
+    """
+    return sys.platform == 'win32'

--- a/openslides/utils/main.py
+++ b/openslides/utils/main.py
@@ -261,6 +261,18 @@ def write_settings(settings_path=None, template=None, **context):
     return os.path.realpath(settings_path)
 
 
+def open_browser(host, port):
+    """
+    Launches the default web browser at the given host and port and opens
+    the webinterface. Uses start_browser internally.
+    """
+    if host == '0.0.0.0':
+        # Windows does not support 0.0.0.0, so use 'localhost' instead
+        start_browser('http://localhost:%s' % port)
+    else:
+        start_browser('http://%s:%s' % (host, port))
+
+
 def start_browser(browser_url):
     """
     Launches the default web browser at the given url and opens the
@@ -279,14 +291,6 @@ def start_browser(browser_url):
 
         thread = threading.Thread(target=function)
         thread.start()
-
-
-def open_browser(host, port):
-    if host == '0.0.0.0':
-        # Windows does not support 0.0.0.0, so use 'localhost' instead
-        start_browser('http://localhost:%s' % port)
-    else:
-        start_browser('http://%s:%s' % (host, port))
 
 
 def get_database_path_from_settings():
@@ -335,7 +339,7 @@ def is_local_installation():
 
 def get_geiss_path():
     """
-    Returns the path and file to the geis binary.
+    Returns the path and file to the Geiss binary.
     """
     from django.conf import settings
     download_path = getattr(settings, 'OPENSLIDES_USER_DATA_PATH', '')
@@ -345,6 +349,6 @@ def get_geiss_path():
 
 def is_windows():
     """
-    Returns True when the current system is windows. Returns False otherwise.
+    Returns True if the current system is Windows. Returns False otherwise.
     """
     return sys.platform == 'win32'

--- a/openslides/utils/settings.py.tpl
+++ b/openslides/utils/settings.py.tpl
@@ -123,6 +123,8 @@ TIME_ZONE = 'Europe/Berlin'
 
 STATICFILES_DIRS = [os.path.join(OPENSLIDES_USER_DATA_PATH, 'static')] + STATICFILES_DIRS
 
+STATIC_ROOT = os.path.join(OPENSLIDES_USER_DATA_PATH, 'collected-static')
+
 
 # Files
 # https://docs.djangoproject.com/en/1.10/topics/files/

--- a/openslides/utils/utils.py
+++ b/openslides/utils/utils.py
@@ -1,6 +1,6 @@
 import re
-import roman
 
+import roman
 
 CAMEL_CASE_TO_PSEUDO_SNAKE_CASE_CONVERSION_REGEX_1 = re.compile('(.)([A-Z][a-z]+)')
 CAMEL_CASE_TO_PSEUDO_SNAKE_CASE_CONVERSION_REGEX_2 = re.compile('([a-z0-9])([A-Z])')

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [coverage:run]
 source = openslides
+omit = openslides/core/management/commands/getgeiss.py
 
 [coverage:html]
 directory = personal_data/tmp/htmlcov


### PR DESCRIPTION
@emanuelschuetze could you test this on windows and mac? Maybe even with 32bit and 64bit systems?

@normanjaeckel The current implementation saves the file into OPENSLIDES_USER_DATA_PATH. Do you think we should add a specific 'bin/' dir?

I will make sure, that there is a 1.0.0 release of geiss before the openslides 2.1 release.