### PR TITLE
Send only data to client which user is allowed to see (Fixed #2956).

### DIFF
--- a/openslides/mediafiles/access_permissions.py
+++ b/openslides/mediafiles/access_permissions.py
@@ -25,8 +25,8 @@ class MediafileAccessPermissions(BaseAccessPermissions):
         Returns the restricted serialized data for the instance prepared
         for the user.
         """
-        if (not full_data['hidden'] or has_perm(user, 'mediafiles.can_see_hidden')):
-            data = full_data
-        else:
-            data = None
+        data = None
+        if has_perm(user, 'mediafiles.can_see'):
+            if (not full_data['hidden'] or has_perm(user, 'mediafiles.can_see_hidden')):
+                data = full_data
         return data

--- a/openslides/motions/access_permissions.py
+++ b/openslides/motions/access_permissions.py
@@ -47,23 +47,23 @@ class MotionAccessPermissions(BaseAccessPermissions):
             is_submitter = False
 
         required_permission_to_see = full_data['state_required_permission_to_see']
-        if (not required_permission_to_see or
-                has_perm(user, required_permission_to_see) or
-                has_perm(user, 'motions.can_manage') or
-                is_submitter):
-            if has_perm(user, 'motions.can_see_and_manage_comments') or not full_data.get('comments'):
-                data = full_data
-            else:
-                data = deepcopy(full_data)
-                for i, field in enumerate(config['motions_comments']):
-                    if not field.get('public'):
-                        try:
-                            data['comments'][i] = None
-                        except IndexError:
-                            # No data in range. Just do nothing.
-                            pass
-        else:
-            data = None
+        data = None
+        if has_perm(user, 'motions.can_see'):
+            if (not required_permission_to_see or
+                    has_perm(user, required_permission_to_see) or
+                    has_perm(user, 'motions.can_manage') or
+                    is_submitter):
+                if has_perm(user, 'motions.can_see_and_manage_comments') or not full_data.get('comments'):
+                    data = full_data
+                else:
+                    data = deepcopy(full_data)
+                    for i, field in enumerate(config['motions_comments']):
+                        if not field.get('public'):
+                            try:
+                                data['comments'][i] = None
+                            except IndexError:
+                                # No data in range. Just do nothing.
+                                pass
         return data
 
     def get_projector_data(self, full_data):


### PR DESCRIPTION
Fixed get_restricted_data functions for motion and mediafiles.