### PR TITLE
Solving two bugs in the diff - for #2961

### DIFF
--- a/openslides/core/static/css/app.css
+++ b/openslides/core/static/css/app.css
@@ -609,11 +609,11 @@ img {
     padding-top: 5px;
 }
 .change-recommendation-overview {
-    margin-bottom: 50px;
-    padding: 10px;
+    margin-bottom: 30px;
+    padding: 10px 15px 0 10px;
 }
-.change-recommendation-overview h2 {
-    margin-top: 0;
+.change-recommendation-overview h3 {
+    margin-top: 10px;
 }
 .change-recommendation-overview ul {
     list-style: none;
@@ -628,7 +628,7 @@ img {
 }
 .change-recommendation-overview li > * {
     display: table-cell;
-    padding: 4px;
+    padding: 1px;
 }
 .change-recommendation-overview .status {
     color: gray;

--- a/openslides/core/static/css/projector.css
+++ b/openslides/core/static/css/projector.css
@@ -537,8 +537,7 @@ tr.elected td {
     background-color: #f9f9f9;
     border: solid 1px #eee;
     border-radius: 3px;
-    margin-bottom: 0;
-    margin-top: -25px;
+    margin-bottom: 10px;
     padding-top: 0;
     padding-right: 155px;
 }

--- a/openslides/core/static/css/projector.css
+++ b/openslides/core/static/css/projector.css
@@ -534,12 +534,9 @@ tr.elected td {
 }
 
 .diff-box {
-    background-color: #f9f9f9;
-    border: solid 1px #eee;
-    border-radius: 3px;
-    margin-bottom: 10px;
+    margin-left: 25px;
     padding-top: 0;
-    padding-right: 155px;
+    margin-top: -10px;
 }
 .motion-text-with-diffs .original-text {
     min-height: 30px; // Spacer between .diff-box, in case .original-text is empty
@@ -553,34 +550,6 @@ tr.elected td {
 .diff-box:hover {
     background-color: #f0f0f0;
 }
-.diff-box .action-row {
-    font-size: 0.8em;
-    padding-top: 5px;
-    padding-bottom: 5px;
-    float: right;
-    width: 150px;
-    text-align: right;
-    margin-right: -150px;
-    opacity: 0.5;
-}
-.diff-box:hover .action-row {
-    opacity: 1;
-}
-.diff-box .action-row .btn-delete {
-    margin-left: 5px;
-    color: red;
-}
-.diff-box .action-row .btn-edit {
-    margin-left: 5px;
-}
-.diff-box .status-row {
-    font-style: italic;
-    color: gray;
-}
-.diff-box .status-row > *:after {
-    content: ':';
-}
-
 .motion-text-diff .delete {
     color: red;
     text-decoration: line-through;

--- a/openslides/motions/static/js/motions/base.js
+++ b/openslides/motions/static/js/motions/base.js
@@ -736,8 +736,7 @@ angular.module('OpenSlidesApp.motions', [
                         oldText = data.outerContextStart + data.innerContextStart +
                             data.html + data.innerContextEnd + data.outerContextEnd;
 
-                    var diff = diffService.diff(oldText, this.text, lineLength, this.line_from);
-                    return lineNumberingService.insertLineNumbers(diff, lineLength, highlight, null, this.line_from);
+                    return diffService.diff(oldText, this.text, lineLength, this.line_from);
                 },
                 getType: function(original_full_html) {
                     return this.type;

--- a/openslides/motions/static/js/motions/diff.js
+++ b/openslides/motions/static/js/motions/diff.js
@@ -963,6 +963,17 @@ angular.module('OpenSlidesApp.motions.diff', ['OpenSlidesApp.motions.lineNumberi
             if (this._diffDetectBrokenDiffHtml(diffUnnormalized)) {
                 diff = this._diffParagraphs(htmlOld, htmlNew, lineLength, firstLineNumber);
             } else {
+                diffUnnormalized = diffUnnormalized.replace(/<ins>.*?(\n.*?)*<\/ins>/gi, function (found) {
+                    found = found.replace(/<(div|p|li)[^>]*>/gi, function(match) { return match + '<ins>'; });
+                    found = found.replace(/<\/(div|p|li)[^>]*>/gi, function(match) { return '</ins>' + match; });
+                    return found;
+                });
+                diffUnnormalized = diffUnnormalized.replace(/<del>.*?(\n.*?)*<\/del>/gi, function (found) {
+                    found = found.replace(/<(div|p|li)[^>]*>/gi, function(match) { return match + '<del>'; });
+                    found = found.replace(/<\/(div|p|li)[^>]*>/gi, function(match) { return '</del>' + match; });
+                    return found;
+                });
+
                 var node = document.createElement('div');
                 node.innerHTML = diffUnnormalized;
                 diff = node.innerHTML;

--- a/openslides/motions/static/templates/motions/motion-detail.html
+++ b/openslides/motions/static/templates/motions/motion-detail.html
@@ -378,6 +378,9 @@
 
     <div ng-class="{'col-sm-8': (lineNumberMode != 'outside'), 'col-sm-12': (lineNumberMode == 'outside')}">
 
+      <ng-include ng-if="viewChangeRecommendations.mode == 'diff'"
+          src="'static/templates/motions/motion-detail/change-summary.html'"></ng-include>
+
       <div><p>{{ config('motions_preamble') | translate }}</p></div>
 
       <div class="motion-text-holder">

--- a/openslides/motions/static/templates/motions/motion-detail/change-summary.html
+++ b/openslides/motions/static/templates/motions/motion-detail/change-summary.html
@@ -1,11 +1,11 @@
 <!-- A summary of all changes -->
 <section class="change-recommendation-overview">
-    <h2>
-        <translate>Summary of change recommendations</translate>
-    </h2>
+    <strong>
+        <translate>Summary of change recommendations</translate>:
+    </strong>
     <ul ng-if="change_recommendations.length > 0">
-        <li ng-repeat="change in (changes = (change_recommendations | filter:{motion_version_id:version}:true | orderBy: 'line_from')) "
-            ng-click="viewChangeRecommendations.scrollToDiffBox(change.id)">
+        <li ng-repeat="change in (changes = (change_recommendations | filter:{motion_version_id:version}:true | orderBy: 'line_from')) ">
+          <a href='' ng-click="viewChangeRecommendations.scrollToDiffBox(change.id)">
             <span ng-if="change.line_from >= change.line_to - 1" class="line-number">
                 <translate>Line</translate> {{ change.line_from }}:
             </span>
@@ -20,6 +20,7 @@
             <span class="status">
                 <translate ng-if="change.rejected">Rejected</translate>
             </span>
+          </a>
         </li>
     </ul>
     <div ng-if="change_recommendations.length == 0" class="no-changes">

--- a/openslides/motions/static/templates/motions/motion-detail/view-diff.html
+++ b/openslides/motions/static/templates/motions/motion-detail/view-diff.html
@@ -1,5 +1,4 @@
 <div ng-if="viewChangeRecommendations.mode == 'diff'">
-    <ng-include src="'static/templates/motions/motion-detail/change-summary.html'"></ng-include>
 
     <!-- The actual diff view -->
     <div class="motion-text-with-diffs line-numbers-{{ lineNumberMode }}">

--- a/openslides/motions/static/templates/motions/slide_motion.html
+++ b/openslides/motions/static/templates/motions/slide_motion.html
@@ -103,11 +103,11 @@
             ng-bind-html="change.getDiff(motion, null, line) | trusted">
           </div>
         </div>
-        <div class="motion-text original-text line-numbers-{{ config('motions_default_line_numbering') }}"
-          ng-bind-html="motion.getTextRemainderAfterLastChangeRecommendation(null, changes, line) | trusted">
-        </div>
-
       </div>
+      <div class="motion-text original-text line-numbers-{{ config('motions_default_line_numbering') }}"
+        ng-bind-html="motion.getTextRemainderAfterLastChangeRecommendation(null, changes, line) | trusted">
+      </div>
+
     </div>
   </div>
 

--- a/tests/karma/motions/diff.service.test.js
+++ b/tests/karma/motions/diff.service.test.js
@@ -351,5 +351,17 @@ describe('linenumbering', function () {
 
       expect(diff).toBe("<P class=\"p1 delete\">Test1 Test2</P><P class=\"p2 insert\">Test1 Test2</P>");
     });
+
+    it('handles inserted paragraphs', function () {
+      var before = "<P>liebliche Stimme, aber deine Stimme ist rauh; du bist der Wolf.' Da gieng der </P>",
+          after = "<p>liebliche Stimme, aber deine Stimme ist rauh; du bist der Wolf.'</p>\
+\
+<p>Der Wolf hatte danach richtig schlechte laune, trank eine Flasche Rum,</p>\
+\
+<p>machte eine Weltreise und kam danach wieder um die Ziegen zu fressen. Da ging der</p>";
+      var diff = diffService.diff(before, after);
+
+      expect(diff).toBe("<p>liebliche Stimme, aber deine Stimme ist rauh; du bist der <del>Wolf.' </del><ins>Wolf.'</ins></p><p><ins>Der Wolf hatte danach richtig schlechte laune, trank eine Flasche Rum,</ins></p><p><ins>machte eine Weltreise und kam danach wieder um die Ziegen zu fressen. </ins>Da gi<del>e</del>ng der</p>");
+    });
   });
 });


### PR DESCRIPTION
This solves:
- Double Line-numbering in Diff View
- In Diff view, inserted paragraphs were not marked as such (only the first paragraph), as could be seen in the test database ("Der Wolf hatte danach richtig schlechte laune, trank eine Flasche Rum,
machte eine Weltreise und kam danach wieder um die Ziegen zu fressen." wasn't green before)