### PR TITLE
Motion PDF improvements

### DIFF
--- a/openslides/core/static/js/core/pdf.js
+++ b/openslides/core/static/js/core/pdf.js
@@ -180,7 +180,7 @@ angular.module('OpenSlidesApp.core.pdf', [])
                 var content = contentProvider.getContent();
                 return {
                     pageSize: 'A4',
-                    pageMargins: [75, 90, 75, 100],
+                    pageMargins: [75, 90, 75, 75],
                     defaultStyle: {
                         font: 'PdfFont',
                         fontSize: 10
@@ -645,6 +645,7 @@ angular.module('OpenSlidesApp.core.pdf', [])
                                 case "li":
                                 case "div":
                                     currentParagraph = create("text");
+                                    currentParagraph.lineHeight = 1.25;
                                     var stackDiv = create("stack");
                                     stackDiv.stack.push(currentParagraph);
                                     ComputeStyle(stackDiv, styles);
@@ -708,7 +709,8 @@ angular.module('OpenSlidesApp.core.pdf', [])
                                                     text: line,
                                                     color: "gray",
                                                     fontSize: 8,
-                                                    margin: [0, 2.35, 0, 0]
+                                                    lineHeight: 1.25,
+                                                    margin: [0, 2.85, 0, 0]
                                                 });
                                             });
                                             listCol.columns.push(list);

--- a/openslides/core/static/js/core/site.js
+++ b/openslides/core/static/js/core/site.js
@@ -1598,6 +1598,7 @@ angular.module('OpenSlidesApp.core.site', [
         gettext('[Space for your welcome text.]');
         gettext('Allow access for anonymous guest users');
         gettext('Show this text on the login page.');
+        gettext('The separator used for the csv export and examples.');
         gettext('Show logo on projector');
         gettext('You can replace the logo. Just copy a file to ' +
                 '"static/img/logo-projector.png" in your OpenSlides data ' +

--- a/openslides/motions/config_variables.py
+++ b/openslides/motions/config_variables.py
@@ -71,7 +71,7 @@ def get_config_variables():
 
     yield ConfigVariable(
         name='motions_line_length',
-        default_value=80,
+        default_value=90,
         input_type='integer',
         label='Line length',
         help_text='The maximum number of characters per line. Relevant when line numbering is enabled. Min: 40',

--- a/openslides/motions/static/js/motions/motion-services.js
+++ b/openslides/motions/static/js/motions/motion-services.js
@@ -34,7 +34,8 @@ angular.module('OpenSlidesApp.motions.motionservices', ['OpenSlidesApp.motions',
                 var converter = PdfMakeConverter.createInstance(data.images);
                 var motionContentProvider = MotionContentProvider.createInstance(converter, $scope.motion, $scope, User, $http);
                 var documentProvider = PdfMakeDocumentProvider.createInstance(motionContentProvider);
-                var filename = gettextCatalog.getString("Motion") + "-" + $scope.motion.identifier + ".pdf";
+                var identifier = $scope.motion.identifier ? '-' + $scope.motion.identifier : '';
+                var filename = gettextCatalog.getString("Motion") + identifier + ".pdf";
                 PdfCreate.download(documentProvider.getDocument(), filename);
             });
         };


### PR DESCRIPTION
* Use consistent lineheight (1.25) in PDF (also for lists).
* set default value of motions_line_length config to 90.
* Reduce footer height.
* Use identifier in filename only if available.

Added missing translation string.