### PR TITLE
Fixing MotionBlock autoupdate and added projector button (fixes #2958)

### DIFF
--- a/openslides/motions/projector.py
+++ b/openslides/motions/projector.py
@@ -74,10 +74,10 @@ class MotionBlockSlide(ProjectorElement):
 
     def get_collection_elements_required_for_this(self, collection_element, config_entry):
         output = super().get_collection_elements_required_for_this(collection_element, config_entry)
-        # Full update if a motion changes because then it may be appended to
+        # Send all changed motions to the projector, because it may be appended
         # or removed from the block.
         if collection_element.collection_string == Motion.get_collection_string():
-            output.extend(self.get_requirements_as_collection_elements(config_entry))
+            output.append(collection_element)
         return output
 
     def update_data(self):

--- a/openslides/motions/static/js/motions/motion-block.js
+++ b/openslides/motions/static/js/motions/motion-block.js
@@ -106,7 +106,17 @@ angular.module('OpenSlidesApp.motions.motionBlock', [])
     'ngDialog',
     'MotionBlock',
     'MotionBlockForm',
-    function ($scope, ngDialog, MotionBlock, MotionBlockForm) {
+    'Projector',
+    'ProjectionDefault',
+    function ($scope, ngDialog, MotionBlock, MotionBlockForm, Projector, ProjectionDefault) {
+        $scope.$watch(function () {
+            return Projector.lastModified();
+        }, function () {
+            var projectiondefault = ProjectionDefault.filter({name: 'motionBlocks'})[0];
+            if (projectiondefault) {
+                $scope.defaultProjectorId = projectiondefault.projector_id;
+            }
+        });
         // Two-way data binding for all MotionBlock instances.
         MotionBlock.bindAll({}, $scope, 'motionBlocks');
 

--- a/openslides/motions/static/templates/motions/motion-block-list.html
+++ b/openslides/motions/static/templates/motions/motion-block-list.html
@@ -25,10 +25,14 @@
   <table class="table table-striped table-bordered table-hover">
     <thead>
       <tr>
+        <th os-perms="core.can_manage_projector" class="minimum">
         <th><translate>Name</translate>
         <th><translate>Motions</translate>
     <tbody>
       <tr ng-repeat="motionBlock in motionBlocks | filter: filter.search | orderBy: 'title'">
+        <td os-perms="core.can_manage_projector">
+          <projector-button model="motionBlock" default-projector-id="defaultProjectorId">
+          </projector-button>
         <td ng-mouseover="motionBlock.hover=true" ng-mouseleave="motionBlock.hover=false">
           <strong>
             <a ui-sref="motions.motionBlock.detail({id: motionBlock.id})">{{ motionBlock.title }}</a>


### PR DESCRIPTION
The issue was that you could remove a motion from a motion block and this triggers a full update. But the removed motion is not send to the client, because it obviously does not belong to the motion block. In fact, the projector does not get notified, that the motion is removed from the motion block. So now on every motion change, it is send, because it could be added or removed.

Also added projector buttons for the motion block ist view.