### PR TITLE
Reduced user profile form

### DIFF
--- a/openslides/users/serializers.py
+++ b/openslides/users/serializers.py
@@ -41,6 +41,7 @@ class UserFullSerializer(ModelSerializer):
     """
     groups = IdPrimaryKeyRelatedField(
         many=True,
+        required=False,
         queryset=Group.objects.exclude(pk=1),
         help_text=ugettext_lazy('The groups this user belongs to. A user will '
                                 'get all permissions granted to each of '

--- a/openslides/users/static/js/users/site.js
+++ b/openslides/users/static/js/users/site.js
@@ -412,55 +412,6 @@ angular.module('OpenSlidesApp.users.site', [
                     },
                 },
                 {
-                    className: "row",
-                    fieldGroup: [
-                        {
-                            key: 'title',
-                            type: 'input',
-                            className: "col-xs-2 no-padding-left",
-                            templateOptions: {
-                                label: gettextCatalog.getString('Title')
-                            }
-                        },
-                        {
-                            key: 'first_name',
-                            type: 'input',
-                            className: "col-xs-5 no-padding",
-                            templateOptions: {
-                                label: gettextCatalog.getString('Given name')
-                            }
-                        },
-                        {
-                            key: 'last_name',
-                            type: 'input',
-                            className: "col-xs-5 no-padding-right",
-                            templateOptions: {
-                                label: gettextCatalog.getString('Surname')
-                            }
-                        }
-                    ]
-                },
-                {
-                    className: "row",
-                    fieldGroup: [
-                        {
-                            key: 'structure_level',
-                            type: 'input',
-                            className: "col-xs-9 no-padding-left",
-                            templateOptions: {
-                                label: gettextCatalog.getString('Structure level'),
-                            }
-                        },
-                        {   key: 'number',
-                            type: 'input',
-                            className: "col-xs-3 no-padding-left no-padding-right",
-                            templateOptions: {
-                                label:gettextCatalog.getString('Participant number')
-                            }
-                        }
-                    ]
-                },
-                {
                     key: 'about_me',
                     type: 'editor',
                     templateOptions: {
@@ -485,7 +436,7 @@ angular.module('OpenSlidesApp.users.site', [
                 return {
                     template: 'static/templates/users/profile-password-form.html',
                     controller: 'UserPasswordCtrl',
-                    className: 'ngdialog-theme-default wide-form',
+                    className: 'ngdialog-theme-default',
                     closeByEscape: false,
                     closeByDocument: false,
                 };

--- a/tests/integration/users/test_viewset.py
+++ b/tests/integration/users/test_viewset.py
@@ -207,6 +207,31 @@ class UserUpdate(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    def test_update_yourself_non_manager(self):
+        """
+        Tests that an user can update himself even if he is not a manager.
+        """
+        user = User.objects.create_user(
+            username='non-admin zeiyeGhaoXoh4awe3xai',
+            password='non-admin chah1hoshohN5Oh7zouj')
+        client = APIClient()
+        client.login(
+            username='non-admin zeiyeGhaoXoh4awe3xai',
+            password='non-admin chah1hoshohN5Oh7zouj')
+
+        response = client.put(
+            reverse('user-detail', args=[user.pk]),
+            {'username': 'New username IeWeipee5mahpi4quupo',
+             'last_name': 'New name fae1Bu1Eyeis9eRox4xu',
+             'about_me': 'New profile text Faemahphi3Hilokangei'})
+
+        self.assertEqual(response.status_code, 200)
+        user = User.objects.get(pk=user.pk)
+        self.assertEqual(user.username, 'New username IeWeipee5mahpi4quupo')
+        self.assertEqual(user.about_me, 'New profile text Faemahphi3Hilokangei')
+        # The user is not allowed to change some other fields (like last_name).
+        self.assertNotEqual(user.last_name, 'New name fae1Bu1Eyeis9eRox4xu')
+
 
 class UserDelete(TestCase):
     """


### PR DESCRIPTION
A normal user should no longer edit the fields 'title, first/last name, structure level and number'. 
Reason: A user can changed and misused his/her name and structure level (e.g. use fake name) - and these fields are published on list of speakers, submitter, candidate etc.

@normanjaeckel If you accept this we should discuss if we prevent to change these fields also on server side.