### PR TITLE
Added requirements for Redis and PostgreSQL support.

### DIFF
--- a/DEVELOPMENT.rst
+++ b/DEVELOPMENT.rst
@@ -110,7 +110,7 @@ a. Running Angular.js test cases
     $ node_modules/.bin/karma start tests/karma/karma.conf.js
 
 
-Installation Openslides in big mode
+Installation OpenSlides in big mode
 ===================================
 
 1. Install PostgreSQL und redis:

--- a/requirements_production.txt
+++ b/requirements_production.txt
@@ -7,3 +7,9 @@ PyPDF2>=1.26,<1.27
 roman>=2.0,<2.1
 setuptools>=29.0,<35.0
 bleach>=1.5.0,<1.6
+
+# Requirements for Redis and PostgreSQL support
+asgi-redis>=1.0.0,<1.1
+django-redis>=4.7.0,<4.8
+django-redis-sessions>=0.5.6,<0.6
+psycopg2>=2.6.2,<2.7


### PR DESCRIPTION
We should install all requirements for redis and postgres that an admin can switch easier from sqlite/inmemory to postgres/redis. Especially for windows portable we should allow a "easy upgrade" to postgres (just install postgres and change settings).

I tested it successfully with a setup of redis and postgres on Linux and Windows (portable).
