### PR TITLE
Fixed switching between motion versions (Fixed #2363)

### DIFF
--- a/openslides/motions/static/js/motions/motion-services.js
+++ b/openslides/motions/static/js/motions/motion-services.js
@@ -31,7 +31,7 @@ angular.module('OpenSlidesApp.motions.motionservices', ['OpenSlidesApp.motions',
             });
 
             $http.post('/core/encode_media/', JSON.stringify(image_sources)).then(function (success) {
-                var converter = PdfMakeConverter.createInstance(sucess.data.images);
+                var converter = PdfMakeConverter.createInstance(success.data.images);
                 var motionContentProvider = MotionContentProvider.createInstance(converter, $scope.motion, $scope, User, $http);
                 var documentProvider = PdfMakeDocumentProvider.createInstance(motionContentProvider);
                 var identifier = $scope.motion.identifier ? '-' + $scope.motion.identifier : '';
@@ -148,6 +148,7 @@ angular.module('OpenSlidesApp.motions.motionservices', ['OpenSlidesApp.motions',
                 }
 
                 saveData(obj);
+                obj.disable();
 
                 Motion.inject(motion);
                 // save change motion object on server

--- a/openslides/motions/static/templates/motions/motion-detail.html
+++ b/openslides/motions/static/templates/motions/motion-detail.html
@@ -477,7 +477,7 @@
       <!-- reason -->
       <div ng-if="motion.getReason(version) != ''">
         <h3 translate>Reason</h3>
-        <div ng-bind-html="motion.getReason() | trusted"></div>
+        <div ng-bind-html="motion.getReason(version) | trusted"></div>
       </div>
 
       <!-- attachments -->

--- a/openslides/motions/static/templates/motions/motion-detail/view-original.html
+++ b/openslides/motions/static/templates/motions/motion-detail/view-original.html
@@ -1,5 +1,5 @@
 <!-- Original view -->
-<div ng-if="viewChangeRecommendations.mode == 'original' && version == motion.getVersion(-1).id">
+<div ng-if="viewChangeRecommendations.mode == 'original'">
     <div id="view-original-text-inline-editor" ng-bind-html="motion.getTextWithLineBreaks(version, highlight) | trusted"
       class="motion-text motion-text-original line-numbers-{{ lineNumberMode }}"
       contenteditable="{{ inlineEditing.isEditable }}">


### PR DESCRIPTION
- Show correct text and reason for selected version.
- Disable inline editing after save (otherwise inline mode is still
  active when user change version)
- Fixed typo of #3018 