### PR TITLE
Improved go to line number tooltip/popup. (#3028)

### DIFF
--- a/openslides/core/static/css/app.css
+++ b/openslides/core/static/css/app.css
@@ -1526,6 +1526,16 @@ img {
     display: inline !important;
 }
 
+.popover-wrapper .small-form input{
+    width: 100px;
+    height: 30px;
+}
+.popover-wrapper .small-form button{
+    padding: 5px 10px;
+    font-size: 12px;
+    line-height: 1.5;
+}
+
 @keyframes fade-out {
     0% { opacity: 1; background: none; }
     100% { opacity: 0; background: none; }

--- a/openslides/motions/static/templates/motions/motion-detail/toolbar.html
+++ b/openslides/motions/static/templates/motions/motion-detail/toolbar.html
@@ -49,13 +49,16 @@
 
         <!-- go to line number -->
         <div class="popover-wrapper">
-            <span editable-text="gotoLinenumber" e-form="lineNumberForm"
+            <span editable-number="gotoLinenumber" e-min="1" e-form="lineNumberForm"
+              e-placeholder="{{ 'Line' | translate }}"
+              e-formclass="small-form"
               onaftersave="scrollToAndHighlight(gotoLinenumber)">
             </span>
             <button type="button" class="btn btn-sm btn-default"
                 ng-click="lineNumberForm.$show()"
                 ng-if="lineNumberMode != 'none'"
-                uib-tooltip="{{ 'Jump to a given line' | translate }}"
+                uib-tooltip="{{ 'Jump to a given line number' | translate }}"
+                tooltip-placement="bottom"
                 tooltip-class="nobr">
                 <i class="fa fa-share"></i>
                 <translate>go</translate>


### PR DESCRIPTION
I added a placeholder text and reduced the popup size, see:
![linenumberpopup](https://cloud.githubusercontent.com/assets/2075427/23579725/ded9d79c-00f3-11e7-9363-cbc6fd8fdc66.png)

@donovaly Thanks for hint! Hope my improvement is ok for you.
