### PR TITLE
Improve the diff when a paragraph is replaced by another one

### DIFF
--- a/openslides/motions/static/js/motions/diff.js
+++ b/openslides/motions/static/js/motions/diff.js
@@ -855,14 +855,49 @@ angular.module('OpenSlidesApp.motions.diff', ['OpenSlidesApp.motions.lineNumberi
         };
 
         /**
+         * Calculates the ratio of the text affected by inline diff
+         * From 0 (no changes at all) to 1 (everything has changed)
+         *
+         * @param html
+         * @returns {number}
+         * @private
+         */
+        this._calcChangeRatio = function(html) {
+            var lengthChanged = 0;
+
+            html = html.replace(/<del>(.*?)<\/del>/gi, function() { lengthChanged += arguments[1].length; return ""; });
+            html = html.replace(/<ins>(.*?)<\/ins>/gi, function() { lengthChanged += arguments[1].length; return ""; });
+            html = html.replace(/<.*?>/, "").trim();
+
+            var lengthRemaining = html.length;
+            if (lengthRemaining === 0 && lengthChanged === 0) {
+                return 0;
+            } else {
+                return (lengthChanged / (lengthChanged + lengthRemaining));
+            }
+        };
+
+        /**
          *
          * @param {string} html
          * @returns {boolean}
          * @private
          */
         this._diffDetectBrokenDiffHtml = function(html) {
+            // If a regular HTML tag is enclosed by INS/DEL, the HTML is broken
             var match = html.match(/<(ins|del)><[^>]*><\/(ins|del)>/gi);
-            return (match !== null && match.length > 0);
+            if (match !== null && match.length > 0) {
+                return true;
+            }
+
+            // If too much of the text is changed, it's better to separate the old from new new version,
+            // otherwise the result looks strange
+            if (this._calcChangeRatio(html) > 0.66) {
+                return true;
+            }
+
+            // If non of the conditions up to now is met, we consider the diff as being sane
+            return false;
         };
 
         this._diffParagraphs = function(oldText, newText, lineLength, firstLineNumber) {

--- a/tests/karma/motions/diff.service.test.js
+++ b/tests/karma/motions/diff.service.test.js
@@ -368,7 +368,14 @@ describe('linenumbering', function () {
         var before = "<P>Ihr könnt ohne Sorge fortgehen.'Da meckerte die Alte und machte sich getrost auf den Weg.</P>",
             after = "";
         var diff = diffService.diff(before, after);
-        expect(diff).toBe("<p><del>Ihr könnt ohne Sorge fortgehen.'Da meckerte die Alte und machte sich getrost auf den Weg.</del></p>");
+        expect(diff).toBe("<P class=\"delete\">Ihr könnt ohne Sorge fortgehen.'Da meckerte die Alte und machte sich getrost auf den Weg.</P>");
+    });
+
+    it('does not perform inline diff if there are too many changes', function () {
+        var before = "<P>Dann kam er zurück, klopfte an die Hausthür und rief 'macht auf, ihr lieben Kinder, eure Mutter ist da und hat jedem von Euch etwas mitgebarcht.' Aber der Wolf hatte seine schwarze Pfote in das Fenster gelegt, das sahen die Kinder und riefen</P>",
+            after = "<p>(hier: Missbrauch von bewusstseinsverändernde Mittel - daher Zensiert)</p>";
+        var diff = diffService.diff(before, after);
+        expect(diff).toBe('<P class="delete">Dann kam er zurück, klopfte an die Hausthür und rief \'macht auf, ihr lieben Kinder, eure Mutter ist da und hat jedem von Euch etwas mitgebarcht.\' Aber der Wolf hatte seine schwarze Pfote in das Fenster gelegt, das sahen die Kinder und riefen</P><P class="insert">(hier: Missbrauch von bewusstseinsverändernde Mittel - daher Zensiert)</P>');
     });
   });
 });


### PR DESCRIPTION
If more than 66% of the text in an inline diff part is changed, no inline diff is shown, but a classical "before" / "after" view. This prevents strange effects when a paragraph is replaced by a completely different one, like single words inside of the paragraphs being marked as unchanged (see attachment). 
![bildschirmfoto 2017-03-04 um 20 51 23](https://cloud.githubusercontent.com/assets/533440/23581801/59c29c1e-011c-11e7-95a9-5527d83f0acb.png)
