### PR TITLE
fix double PDF Head in Motions (fixes #3025)

### DIFF
--- a/openslides/core/static/js/core/pdf.js
+++ b/openslides/core/static/js/core/pdf.js
@@ -531,10 +531,35 @@ angular.module('OpenSlidesApp.core.pdf', [])
                                 case "h4":
                                 case "h5":
                                 case "h6":
-                                    currentParagraph = create("text");
-                                    currentParagraph.marginBottom = 4;
-                                    currentParagraph.marginTop = 10;
-                                    /* falls through */
+                                    // Special case quick fix to handle the dirty HTML format*/
+                                    // see following issue: https://github.com/OpenSlides/OpenSlides/issues/3025
+                                    if (lineNumberMode === "outside") {
+                                        var HeaderOutsideLineNumber = {
+                                            width: 20,
+                                            text: element.childNodes[0].getAttribute("data-line-number"),
+                                            color: "gray",
+                                            fontSize: 8,
+                                            margin: [0, 2, 0, 0]
+                                        };
+                                        var HeaderOutsideLineNumberText = {
+                                            text: element.childNodes[1].textContent,
+                                        };
+                                        ComputeStyle(HeaderOutsideLineNumberText, elementStyles[nodeName]);
+                                        var HeaderOutsideLineNumberColumns = {
+                                            columns: [
+                                                HeaderOutsideLineNumber,
+                                                HeaderOutsideLineNumberText
+                                            ]
+                                        };
+                                        alreadyConverted.push(HeaderOutsideLineNumberColumns);
+                                    } else {
+                                        currentParagraph = create("text");
+                                        currentParagraph.marginBottom = 4;
+                                        currentParagraph.marginTop = 10;
+                                        currentParagraph = parseChildren(alreadyConverted, element, currentParagraph, styles.concat(elementStyles[nodeName]), diff_mode);
+                                        alreadyConverted.push(currentParagraph);
+                                    }
+                                    break;
                                 case "a":
                                     currentParagraph = parseChildren(alreadyConverted, element, currentParagraph, styles.concat(elementStyles[nodeName]), diff_mode);
                                     alreadyConverted.push(currentParagraph);

--- a/openslides/core/static/js/core/pdf.js
+++ b/openslides/core/static/js/core/pdf.js
@@ -561,9 +561,6 @@ angular.module('OpenSlidesApp.core.pdf', [])
                                     }
                                     break;
                                 case "a":
-                                    currentParagraph = parseChildren(alreadyConverted, element, currentParagraph, styles.concat(elementStyles[nodeName]), diff_mode);
-                                    alreadyConverted.push(currentParagraph);
-                                    break;
                                 case "b":
                                 case "strong":
                                 case "u":


### PR DESCRIPTION
This is a hack. I do **not** plan to keep the code this way.
This hack is necessary due to the weird HTML Code structure introduced recently.
Currently: Outside Line Numbers and HTML Head-Tags do not get along well.
This hack helps to deal with that.

As explained before, the clean way is to ensure HTML headers in Motions keep the following structure:
```
<span>
<h1>
...
</h1>
</span>
```