### PR TITLE
fix pdf style parsing issue (fixes #2811)

### DIFF
--- a/openslides/core/static/js/core/pdf.js
+++ b/openslides/core/static/js/core/pdf.js
@@ -499,6 +499,7 @@ angular.module('OpenSlidesApp.core.pdf', [])
                         ParseElement = function(alreadyConverted, element, currentParagraph, styles, diff_mode) {
                             styles = styles || [];
                             if (element.getAttribute) {
+                                styles = [];
                                 var nodeStyle = element.getAttribute("style");
                                 if (nodeStyle) {
                                     nodeStyle.split(";").forEach(function(nodeStyle) {


### PR DESCRIPTION
prevents nodes from parsing style attributes if they are not explicitly set.
That also means that the combination of styles using multiple notes will not work anymore.

That includes all combination of stylings

@emanuelschuetze 