### PR TITLE
Remove erroneous margin around inline diff paragraphs in PDF

### DIFF
--- a/openslides/core/static/js/core/pdf.js
+++ b/openslides/core/static/js/core/pdf.js
@@ -498,6 +498,7 @@ angular.module('OpenSlidesApp.core.pdf', [])
                          */
                         ParseElement = function(alreadyConverted, element, currentParagraph, styles, diff_mode) {
                             styles = styles || [];
+                            var classes = [];
                             if (element.getAttribute) {
                                 styles = [];
                                 var nodeStyle = element.getAttribute("style");
@@ -509,7 +510,8 @@ angular.module('OpenSlidesApp.core.pdf', [])
                                 }
                                 var nodeClass = element.getAttribute("class");
                                 if (nodeClass) {
-                                    nodeClass.split(" ").forEach(function(nodeClass) {
+                                    classes = nodeClass.toLowerCase().split(" ");
+                                    classes.forEach(function(nodeClass) {
                                         if (typeof(classStyles[nodeClass]) != 'undefined') {
                                             classStyles[nodeClass].forEach(function(style) {
                                                 styles.push(style);
@@ -678,7 +680,11 @@ angular.module('OpenSlidesApp.core.pdf', [])
                                     break;
                                 case "p":
                                     currentParagraph = create("text");
-                                    currentParagraph.marginTop = 8;
+                                    if (classes.indexOf("merge-before") > -1) {
+                                        currentParagraph.marginTop = 0;
+                                    } else {
+                                        currentParagraph.marginTop = 8;
+                                    }
                                     currentParagraph.lineHeight = 1.25;
                                     var stackP = create("stack");
                                     stackP.stack.push(currentParagraph);

--- a/openslides/motions/static/js/motions/base.js
+++ b/openslides/motions/static/js/motions/base.js
@@ -260,8 +260,9 @@ angular.module('OpenSlidesApp.motions', [
 
                     var data = diffService.extractRangeByLineNumbers(html, line_from, line_to);
 
-                    html = data.outerContextStart + data.innerContextStart + data.html +
-                        data.innerContextEnd + data.outerContextEnd;
+                    // Add "merge-before"-css-class if the first line begins in the middle of a paragraph. Used for PDF.
+                    html = diffService.addCSSClassToFirstTag(data.outerContextStart + data.innerContextStart, "merge-before") +
+                        data.html + data.innerContextEnd + data.outerContextEnd;
                     html = lineNumberingService.insertLineNumbers(html, lineLength, highlight, null, line_from);
 
                     return html;
@@ -280,9 +281,9 @@ angular.module('OpenSlidesApp.motions', [
                     var data = diffService.extractRangeByLineNumbers(html, maxLine, null);
 
                     if (data.html !== '') {
-                        html = data.outerContextStart + data.innerContextStart +
-                            data.html +
-                            data.innerContextEnd + data.outerContextEnd;
+                        // Add "merge-before"-css-class if the first line begins in the middle of a paragraph. Used for PDF.
+                        html = diffService.addCSSClassToFirstTag(data.outerContextStart + data.innerContextStart, "merge-before") +
+                            data.html + data.innerContextEnd + data.outerContextEnd;
                         html = lineNumberingService.insertLineNumbers(html, lineLength, highlight, null, maxLine);
                     } else {
                         // Prevents empty lines at the end of the motion
@@ -761,6 +762,12 @@ angular.module('OpenSlidesApp.motions', [
 
                     if (highlight > 0) {
                         diff = lineNumberingService.highlightLine(diff, highlight);
+                    }
+
+                    var origBeginning = data.outerContextStart + data.innerContextStart;
+                    if (diff.toLowerCase().indexOf(origBeginning.toLowerCase()) === 0) {
+                        // Add "merge-before"-css-class if the first line begins in the middle of a paragraph. Used for PDF.
+                        diff = diffService.addCSSClassToFirstTag(origBeginning, "merge-before") + diff.substring(origBeginning.length);
                     }
 
                     return diff;

--- a/openslides/motions/static/js/motions/diff.js
+++ b/openslides/motions/static/js/motions/diff.js
@@ -983,6 +983,18 @@ angular.module('OpenSlidesApp.motions.diff', ['OpenSlidesApp.motions.lineNumberi
             return this._serializeDom(mergedFragment);
         };
 
+        this.addCSSClassToFirstTag = function (html, className) {
+            return html.replace(/<[a-z][^>]*>/i, function (match) {
+                if (match.match(/class=["'][a-z0-9 _-]*["']/i)) {
+                    return match.replace(/class=["']([a-z0-9 _-]*)["']/i, function (match2, previousClasses) {
+                        return "class=\"" + previousClasses + " " + className + "\"";
+                    });
+                } else {
+                    return match.substring(0, match.length - 1) + " class=\"" + className + "\">";
+                }
+            });
+        };
+
         /**
          * This function calculates the diff between two strings and tries to fix problems with the resulting HTML.
          * If lineLength and firstLineNumber is given, line numbers will be returned es well

--- a/tests/karma/motions/diff.service.test.js
+++ b/tests/karma/motions/diff.service.test.js
@@ -482,4 +482,18 @@ describe('linenumbering', function () {
       );
     });
   });
+
+  describe('addCSSClassToFirstTag function', function () {
+    it('works with plain tags', function () {
+        var strIn = "<ol start='2'><li>",
+            inserted = diffService.addCSSClassToFirstTag(strIn, "newClass");
+        expect(inserted).toBe("<ol start='2' class=\"newClass\"><li>")
+    });
+
+    it('works with tags already having classes', function () {
+        var strIn = "<ol start='2' class='my-old-class'><li>",
+            inserted = diffService.addCSSClassToFirstTag(strIn, "newClass");
+        expect(inserted).toBe("<ol start='2' class=\"my-old-class newClass\"><li>")
+    });
+  })
 });


### PR DESCRIPTION
This removes the extra margin around inline-diff-paragraphs in PDF-export. It does so by adding the "merge-before"-css-class to the outermost element (`<p>`, in the most regular case), IF this `<p>` was inserted during the line extraction. Therefore, natural spaces should be kept intact, if the Inline-Diff is the first line of a paragraph, in which case the extra margin before it is intended.

It does not work for the paragraph-based diff-fallback.