### PR TITLE
Switch projector scroll direction

### DIFF
--- a/openslides/core/static/js/core/projector.js
+++ b/openslides/core/static/js/core/projector.js
@@ -171,7 +171,7 @@ angular.module('OpenSlidesApp.core.projector', ['OpenSlidesApp.core'])
         var STEPS = 5;
         $scope.scroll = 0;
         var setScroll = function (scroll) {
-            scroll = 250 * scroll;
+            scroll = -250 * scroll;
             if ($scope.scrollTimeout) {
                 $timeout.cancel($scope.scrollTimeout);
             }


### PR DESCRIPTION
- button 'arrow down': moves the visible part of the projector down
  (forward = text scrolls from bottom to top)
- button 'arrow up': moves the visible part of the projector up
  (backward = text scrolls from top to bottom)

Reverts change from #3094.