### PR TITLE
Fixing countdown default time

### DIFF
--- a/openslides/core/static/js/core/base.js
+++ b/openslides/core/static/js/core/base.js
@@ -1045,7 +1045,10 @@ angular.module('OpenSlidesApp.core', [
                 data = 0;
                 if (time.length >= minLength) {
                     for (var i = 0; i < minLength; i++) {
-                        data = data*60 + (+time[i]);
+                        data = data*60;
+                        if (!isNaN(+time[i])) {
+                            data += (+time[i]);
+                        }
                     }
                     if (!params.seconds) { // the last field was minutes (e.g. h:mm)
                         data *= 60;


### PR DESCRIPTION
Fixes this situation: entering 1:r in the default time edit field for countdowns, OS crashes in my browser.