### PR TITLE
Updated pdfmake to 0.1.27.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -34,7 +34,7 @@
     "ngstorage": "~0.3.11",
     "ngBootbox": "~0.1.3",
     "papaparse": "~4.1.2",
-    "pdfmake": "0.1.25",
+    "pdfmake": "0.1.27",
     "roboto-fontface": "~0.6.0"
   },
   "overrides": {


### PR DESCRIPTION
This pdfmake version improved performance (partly):

Tested with v0.1.27 (vs. 0.1.15) for generating 112 pages:
Firefox: 0:31min (1:32min)
Chromium: 0:24min (0:36min)

Good enough to integrate it in 2.1.