### PR TITLE
Bugfix: changing line length did not invalidate cache

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,7 @@ Motions:
 - Removed server side image to base64 transformation and
   added local transformation [#2705]
 - Added support for export motions in a zip archive [#3189].
+- Bugfix: changing motion line length did not invalidate cache [#3202]
 
 Core:
 - No reload on logoff. OpenSlides is now a full single page

--- a/openslides/motions/static/js/motions/linenumbering.js
+++ b/openslides/motions/static/js/motions/linenumbering.js
@@ -475,7 +475,7 @@ angular.module('OpenSlidesApp.motions.lineNumbering', [])
                 newRoot = this.insertLineNumbersNode(html, lineLength, highlight, firstLine);
                 newHtml = newRoot.innerHTML;
             } else {
-                var cacheKey = this.djb2hash(html);
+                var cacheKey = this.djb2hash(lineLength.toString() + html);
                 newHtml = lineNumberCache.get(cacheKey);
 
                 if (angular.isUndefined(newHtml)) {

--- a/tests/karma/motions/linenumbering.service.test.js
+++ b/tests/karma/motions/linenumbering.service.test.js
@@ -389,4 +389,13 @@ describe('linenumbering', function () {
         expect(highlighted).toBe(noMarkup(1) + '<span>Lorem ' + brMarkup(2) + 'ipsum ' + brMarkup(3) + 'dolor' + brMarkup(4) + 'sit ' + brMarkup(5) + 'amet</span>');
     });
   });
+
+  describe('caching', function() {
+    it('caches based on line length', function () {
+      var inHtml = '<p>' +longstr(100) + '</p>';
+      var outHtml80 = lineNumberingService.insertLineNumbers(inHtml, 80);
+      var outHtml70 = lineNumberingService.insertLineNumbers(inHtml, 70);
+      expect(outHtml70).not.toBe(outHtml80);
+    });
+  });
 });


### PR DESCRIPTION
The cache was based only on the html string, not the line length. Therefore, when changing the line length, the result of the function did not change until the page was reloaded.

This should fix #3107.