### PR TITLE
parse UL/OL list styling in PDF (Fixes #3228)

### DIFF
--- a/openslides/core/static/js/core/pdf.js
+++ b/openslides/core/static/js/core/pdf.js
@@ -843,6 +843,7 @@ angular.module('OpenSlidesApp.core.pdf', [])
                                 case "ul":
                                 case "ol":
                                     var list = create(nodeName);
+                                    ComputeStyle(list, styles);
                                     if (lineNumberMode == "outside") {
                                         var lines = extractLineNumbers(element);
                                         currentParagraph = parseChildren(list[nodeName], element, currentParagraph, styles, diff_mode);


### PR DESCRIPTION
Enables parsing of style attributs for UL and LI lists