### PR TITLE
Fixing wrong err call

### DIFF
--- a/openslides/core/static/js/core/pdf.js
+++ b/openslides/core/static/js/core/pdf.js
@@ -503,7 +503,7 @@ angular.module('OpenSlidesApp.core.pdf', [])
                                 }
                                 return '#' + decimalColors.join('');
                             } else {
-                                console.err('Could not parse color "' + color + '"');
+                                console.error('Could not parse color "' + color + '"');
                                 return color;
                             }
                         },


### PR DESCRIPTION
@emanuelschuetze @normanjaeckel Please merge this. console does not have a `err` function, so the generation of pdfs fails in some browsers. I changed this to `log` to can see, which browsers uses which color formats.