### PR TITLE
Extend gitignore for plugin development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ dist/*
 # Unit test and coverage reports
 .coverage
 tests/file/*
+
+# Plugin development
+openslides_*


### PR DESCRIPTION
Purpose: For Plugin development, or having plugins enabled when working on OpenSlides, I put a symlink in the openslides directory. I do not want git to track my plugins, when working on OpenSlides.
This should work for all plugins with `openslides_` as prefix.