### PR TITLE
Fixing error when downloading

### DIFF
--- a/openslides/motions/static/js/motions/pdf.js
+++ b/openslides/motions/static/js/motions/pdf.js
@@ -706,6 +706,7 @@ angular.module('OpenSlidesApp.motions.pdf', ['OpenSlidesApp.core.pdf'])
                 });
             },
             export: function (motions, params, singleMotion) {
+                params = params || {};
                 _.defaults(params, {
                     filename: gettextCatalog.getString('motions') + '.pdf',
                 });


### PR DESCRIPTION
When clicking on 'Export (all)' without permissions to see the export dialog, you will get an error, because `params` is undefined and `_.defaults` does nothing on undefined.