### PR TITLE
Improve zip creation and fixing page numbers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,7 @@ Motions:
 - Removed server side image to base64 transformation and
   added local transformation [#3181]
 - Added support for export motions in a zip archive [#3189].
+- Performance improvement for zip creation [#3251]
 - Bugfix: changing motion line length did not invalidate cache [#3202]
 - Bugfix: Added more distance in motion PDF for DEL-tags in new lines [#3211].
 - Added warning message if an edit dialog was already opened by another
@@ -48,7 +49,7 @@ Core:
 General:
 - Switched from npm to Yarn [#3188].
 - Several bugfixes and minor improvements.
-- Bugfixes for PDF creation [#3227]
+- Bugfixes for PDF creation [#3227, #3251]
 
 
 Version 2.1.1 (2017-04-05)


### PR DESCRIPTION
When creating the motion zip archive, for every motion a worker is instantiated. Result with 100 motions: Browser freeze and no reaction at all.
Now: Just instantiate one worker, that does all converting.

Also fixed broken page counting and cleaned up the worker.