### PR TITLE
Fixing PDF filenames on zip export if no identifier is given

### DIFF
--- a/openslides/motions/static/js/motions/pdf.js
+++ b/openslides/motions/static/js/motions/pdf.js
@@ -723,9 +723,23 @@ angular.module('OpenSlidesApp.motions.pdf', ['OpenSlidesApp.core.pdf'])
 
                 var self = this;
                 var pdfs = {};
+                var usedFilenames = [];
                 var pdfPromises = _.map(motions, function (motion) {
                     var identifier = motion.identifier ? '-' + motion.identifier : '';
-                    var filename = gettextCatalog.getString('Motion') + identifier + '.pdf';
+                    var filename = gettextCatalog.getString('Motion') + identifier;
+
+                    // If the filename is already in use, try to append a number to it (like '(2)')
+                    if (_.includes(usedFilenames, filename)) {
+                        var i = 1;
+                        var filenameWithNumber = filename;
+                        while(_.includes(usedFilenames, filenameWithNumber)) {
+                            filenameWithNumber = filename + ' (' + i + ')';
+                            i++;
+                        }
+                        filename = filenameWithNumber;
+                    }
+                    usedFilenames.push(filename);
+                    filename += '.pdf';
 
                     return $q(function (resolve, reject) {
                         // get documentProvider for every motion.


### PR DESCRIPTION
If you have motions without an identifier, the filename would be "motion.pdf". If you have multiple ones and try to download the motions in a zip file, only one motion gets exported, because all others are overridden in cause of the identical filename.

Now numbers are appended, like "motion.pdf", "motion (1).pdf", "motion (2).pdf", ...
Is this ok, or should we try to include the title of the motion into the filename, if no identifier is given?