### PR TITLE
Do not reload all projector elements on every autoupdate (fixes #3259).

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -48,6 +48,9 @@ Core:
 - Enhanced performance esp. for server restart and first connection of all
   clients by refactorting autoupdate, Collection and AccessPermission [#3223].
 
+Mediafiles:
+- Fixed reloading of PDF on page change [#3274]
+
 General:
 - Switched from npm to Yarn [#3188].
 - Several bugfixes and minor improvements.

--- a/openslides/mediafiles/static/js/mediafiles/projector.js
+++ b/openslides/mediafiles/static/js/mediafiles/projector.js
@@ -18,10 +18,35 @@ angular.module('OpenSlidesApp.mediafiles.projector', [
 
 .controller('SlideMediafileCtrl', [
     '$scope',
+    '$timeout',
     'Mediafile',
-    function ($scope, Mediafile) {
+    function ($scope, $timeout, Mediafile) {
         // load mediafile object
         Mediafile.bindOne($scope.element.id, $scope, 'mediafile');
+
+        $scope.showPdf = true;
+
+        // Watch for page changes in the projector element. Adjust the page
+        // in the canvas scope, so the viewer can change the size automatically.
+        $scope.$watch(function () {
+            return $scope.element.page;
+        }, function () {
+            var canvasScope = angular.element('#pdf-canvas').scope();
+            if (canvasScope) {
+                canvasScope.pageNum = $scope.element.page;
+            }
+        });
+
+        // Watch for scale changes. If the scale is changed, reload the pdf
+        // viewer by just disable and re-enable it.
+        $scope.$watch(function () {
+            return $scope.element.scale;
+        }, function () {
+            $scope.showPdf = false;
+            $timeout(function () {
+                $scope.showPdf = true;
+            }, 1);
+        });
 
         // Allow the elements to render properly
         setTimeout(function() {

--- a/openslides/mediafiles/static/templates/mediafiles/slide_mediafile.html
+++ b/openslides/mediafiles/static/templates/mediafiles/slide_mediafile.html
@@ -1,7 +1,7 @@
 <div ng-controller="SlideMediafileCtrl" class="content" ng-class="{'fullscreen': element.fullscreen, 'video-container': element.is_video}">
     <!-- PDF -->
-    <ng-pdf ng-if="mediafile.is_pdf" template-url="/static/templates/mediafiles/slide_mediafile_partial.html"
-         ng-attr-scale="{{ element.scale }}"
+    <ng-pdf ng-if="mediafile.is_pdf && showPdf" template-url="/static/templates/mediafiles/slide_mediafile_partial.html"
+         scale="{{ element.scale }}"
          ng-attr-page="{{ element.page }}">
     </ng-pdf>
 


### PR DESCRIPTION
@emanuelschuetze Zooming and page changing are working. To fix the little loading delay, I think we have to write our own viewer to load next pages in the background. The current viewer does not do this.

This has to be tested more carefully: I do not exactly know, if any slide needs the reloading when the element changes. Maybe a watcher is missing, but until now on every change the element gets reloaded, so this watcher was not necessary. This is changed with this PR!