### PR TITLE
Add a easier command to run the karma-tests

### DIFF
--- a/DEVELOPMENT.rst
+++ b/DEVELOPMENT.rst
@@ -137,7 +137,7 @@ b. Running AngularJS test cases
 
 Run client tests by starting karma::
 
-    $ node_modules/.bin/karma start tests/karma/karma.conf.js
+    $ yarn run karma
 
 
 OpenSlides in big mode

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "openslides",
   "private": true,
   "scripts": {
-    "prepublish": "bower install && gulp"
+    "prepublish": "bower install && gulp",
+    "karma": "karma start tests/karma/karma.conf.js"
   },
   "devDependencies": {
     "angular-mocks": "~1.5.11",


### PR DESCRIPTION
"yarn run karma" (or "npm run karma", for that matter) is just so much easier to remember than "node_modules/.bin/karma start tests/karma/karma.conf.js".