### PR TITLE
Updated pdfmake to 0.1.29

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -52,6 +52,8 @@ General:
 - Switched from npm to Yarn [#3188].
 - Several bugfixes and minor improvements.
 - Bugfixes for PDF creation [#3227, #3251]
+- Improved performance for pdf generation significantly (by upgrading
+  to pdfmake 0.1.29) [#3278].
 
 
 Version 2.1.1 (2017-04-05)

--- a/bower.json
+++ b/bower.json
@@ -35,7 +35,7 @@
     "ngstorage": "~0.3.11",
     "ngBootbox": "~0.1.3",
     "papaparse": "~4.1.2",
-    "pdfmake": "0.1.27",
+    "pdfmake": "0.1.29",
     "roboto-fontface": "~0.6.0"
   },
   "overrides": {


### PR DESCRIPTION
Improved performance to pdf generation significantly!

Test to generate a pdf with 200 pages with Chromium:
pdfmake 0.1.27: 50sec 
pdfmake 0.1.29: 25sec