### PR TITLE
Fixing import for new isort version

### DIFF
--- a/openslides/agenda/views.py
+++ b/openslides/agenda/views.py
@@ -20,7 +20,6 @@ from ..utils.auth import has_perm
 from .access_permissions import ItemAccessPermissions
 from .models import Item, Speaker
 
-
 # Viewsets for the REST API
 
 class ItemViewSet(ListModelMixin, RetrieveModelMixin, UpdateModelMixin, GenericViewSet):

--- a/openslides/assignments/views.py
+++ b/openslides/assignments/views.py
@@ -18,7 +18,6 @@ from .access_permissions import AssignmentAccessPermissions
 from .models import Assignment, AssignmentPoll, AssignmentRelatedUser
 from .serializers import AssignmentAllPollSerializer
 
-
 # Viewsets for the REST API
 
 class AssignmentViewSet(ModelViewSet):

--- a/openslides/core/views.py
+++ b/openslides/core/views.py
@@ -51,7 +51,6 @@ from .models import (
     Tag,
 )
 
-
 # Special Django views
 
 class IndexView(utils_views.CSRFMixin, utils_views.View):

--- a/openslides/mediafiles/views.py
+++ b/openslides/mediafiles/views.py
@@ -3,7 +3,6 @@ from ..utils.rest_api import ModelViewSet, ValidationError
 from .access_permissions import MediafileAccessPermissions
 from .models import Mediafile
 
-
 # Viewsets for the REST API
 
 class MediafileViewSet(ModelViewSet):

--- a/openslides/motions/views.py
+++ b/openslides/motions/views.py
@@ -43,7 +43,6 @@ from .models import (
 )
 from .serializers import MotionPollSerializer
 
-
 # Viewsets for the REST API
 
 class MotionViewSet(ModelViewSet):

--- a/openslides/users/views.py
+++ b/openslides/users/views.py
@@ -25,7 +25,6 @@ from .access_permissions import GroupAccessPermissions, UserAccessPermissions
 from .models import Group, User
 from .serializers import GroupSerializer, PermissionRelatedField
 
-
 # Viewsets for the REST API
 
 class UserViewSet(ModelViewSet):

--- a/openslides/utils/plugins.py
+++ b/openslides/utils/plugins.py
@@ -12,7 +12,6 @@ from openslides.utils.main import (
     get_win32_portable_user_data_path,
 )
 
-
 # Methods to collect plugins.
 
 def collect_plugins_from_entry_points():


### PR DESCRIPTION
Changes required for the new isort version (4.2.8, 31.5.16). Interesting bug/feature: the `--check-only` doen't work for me anymore. Also with this flag, isort changes the code.

If this is not wanted, we should lock isort down until this is fixed rather than mergin this PR. @normanjaeckel Your opinion?