### PR TITLE
improved reconnect handling if the server was flushed (fixed #3295)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -49,6 +49,7 @@ Core:
 - Enhanced performance esp. for server restart and first connection of all
   clients by refactoring autoupdate, Collection and AccessPermission [#3223].
 - Fixes autoupdate bug for a user without user.can_see_name permission [#3233].
+- Improved reconnect handling if the server was flushed [#3297].
 
 Mediafiles:
 - Fixed reloading of PDF on page change [#3274]


### PR DESCRIPTION
If you flush the cache and restart daphne, the user is now forced to relogin and the client does not try to reconnect with websockets.