### PR TITLE
Highlight objects in list view, if related objects are projected

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -50,6 +50,8 @@ Core:
   clients by refactoring autoupdate, Collection and AccessPermission [#3223].
 - Fixes autoupdate bug for a user without user.can_see_name permission [#3233].
 - Improved reconnect handling if the server was flushed [#3297].
+- Highlight list entries in a light blue, if a related object is projected (e.g.
+  a list of speakers of a motion) [#3301]
 
 Mediafiles:
 - Fixed reloading of PDF on page change [#3274].

--- a/openslides/agenda/static/js/agenda/base.js
+++ b/openslides/agenda/static/js/agenda/base.js
@@ -197,6 +197,10 @@ angular.module('OpenSlidesApp.agenda', ['OpenSlidesApp.users'])
                     });
                     return isProjectedIds;
                 },
+                isRelatedProjected: function () {
+                    // related objects for agenda items: list of speakers slide.
+                    return this.isListOfSpeakersProjected();
+                },
                 // project list of speakers
                 projectListOfSpeakers: function(projectorId) {
                     var isProjectedIds = this.isListOfSpeakersProjected();

--- a/openslides/agenda/static/templates/agenda/item-list.html
+++ b/openslides/agenda/static/templates/agenda/item-list.html
@@ -211,7 +211,8 @@
     <!-- main table -->
     <div class="row data-row" ng-mouseover="item.hover=true"
       ng-mouseleave="item.hover=false"
-      ng-class="{'projected': item.isProjected().length}"
+      ng-class="{'projected': item.isProjected().length,
+      'related-projected': item.isRelatedProjected().length}"
       ng-repeat="item in itemsFiltered = (items
         | osFilter: filter.filterString : filter.getObjectQueryString
         | filter: {closed: filter.booleanFilters.closed.value}

--- a/openslides/assignments/static/js/assignments/base.js
+++ b/openslides/assignments/static/js/assignments/base.js
@@ -367,9 +367,11 @@ angular.module('OpenSlidesApp.assignments', [])
                     }
                 },
                 // override isProjected function of jsDataModel factory
-                isProjected: function (poll_id) {
+                isProjected: function (poll_id, anyPoll) {
                     // Returns the ids of all projectors with an element
                     // with the name 'assignments/assignment'. Else returns an empty list.
+                    // Provide a poll_id to query a specific poll or set anyPoll to true, to
+                    // query whether any poll (but not the assignment itself) is projected.
                     var self = this;
                     var predicate = function (element) {
                         var value;
@@ -379,6 +381,12 @@ angular.module('OpenSlidesApp.assignments', [])
                                 typeof element.id !== 'undefined' &&
                                 element.id == self.id &&
                                 typeof element.poll === 'undefined';
+                        } else if (anyPoll) {
+                            // Assignment detail slide with any poll
+                            value = element.name == 'assignments/assignment' &&
+                                typeof element.id !== 'undefined' &&
+                                element.id == self.id &&
+                                typeof element.poll !== 'undefined';
                         } else {
                             // Assignment detail slide with specific poll
                             value = element.name == 'assignments/assignment' &&
@@ -396,7 +404,11 @@ angular.module('OpenSlidesApp.assignments', [])
                         }
                     });
                     return isProjectedIds;
-                }
+                },
+                isRelatedProjected: function () {
+                    var listOfSpeakers = this.agenda_item.isListOfSpeakersProjected();
+                    return listOfSpeakers.concat(this.isProjected(null, true));
+                },
             },
             relations: {
                 belongsTo: {

--- a/openslides/assignments/static/templates/assignments/assignment-list.html
+++ b/openslides/assignments/static/templates/assignments/assignment-list.html
@@ -202,7 +202,8 @@
     <!-- main table -->
     <div class="row data-row" ng-mouseover="assignment.hover=true"
       ng-mouseleave="assignment.hover=false"
-      ng-class="{'projected': assignment.isProjected().length}"
+      ng-class="{'projected': assignment.isProjected().length,
+        'related-projected': assignment.isRelatedProjected().length}"
       ng-repeat="assignment in assignmentsFiltered = (assignments
         | osFilter: filter.filterString : filter.getObjectQueryString
         | MultiselectFilter: filter.multiselectFilters.tag : getItemId.tag

--- a/openslides/core/static/css/app.css
+++ b/openslides/core/static/css/app.css
@@ -1664,6 +1664,10 @@ tr.activeline td, li.activeline, .projected {
     background-color: #bed4de !important;
 }
 
+.related-projected {
+    background-color: #e1ecfe !important;
+}
+
 tr.selected td {
     background-color: #ff9999;
 }

--- a/openslides/core/static/js/core/base.js
+++ b/openslides/core/static/js/core/base.js
@@ -600,6 +600,10 @@ angular.module('OpenSlidesApp.core', [
             });
             return isProjectedIds;
         };
+        // Override this method to get object spzific behavior
+        BaseModel.prototype.isRelatedProjected = function() {
+            throw "needs to be implemented!";
+        };
         return BaseModel;
     }
 ])

--- a/openslides/motions/static/js/motions/base.js
+++ b/openslides/motions/static/js/motions/base.js
@@ -611,6 +611,10 @@ angular.module('OpenSlidesApp.motions', [
                     });
                     return mapping;
                 },
+                isRelatedProjected: function () {
+                    // A motion related object is the list of speakers (through the agenda item)
+                    return this.agenda_item.isListOfSpeakersProjected();
+                },
             },
             relations: {
                 belongsTo: {

--- a/openslides/motions/static/templates/motions/motion-list.html
+++ b/openslides/motions/static/templates/motions/motion-list.html
@@ -429,7 +429,8 @@
     <!-- main table -->
     <div class="row data-row" ng-mouseover="motion.hover=true"
       ng-mouseleave="motion.hover=false"
-      ng-class="{'projected': motion.isProjected().length}"
+      ng-class="{'projected': motion.isProjected().length,
+      'related-projected': motion.isRelatedProjected().length}"
       ng-repeat="motion in motionsFiltered = (motions
         | osFilter: filter.filterString : filter.getObjectQueryString
         | MultiselectFilter: stateFilter : getItemId.state


### PR DESCRIPTION
@emanuelschuetze Color highlighting is done. Whats about a hint for the user (like 'the list of speakers is projected')? Where to put that and how to fit this nice into the template?

Currently highlighted:
 - projecting a list of speakers for motions/assignments (highlight in agenda list view and motion/assignment list view)
 - projecting any ballot of an assignment.