### PR TITLE
fixing docx parser missing text

### DIFF
--- a/openslides/core/static/js/core/docx.js
+++ b/openslides/core/static/js/core/docx.js
@@ -259,7 +259,7 @@ angular.module('OpenSlidesApp.core.docx', [])
                     // remove whitespaces and > brackets. Leave < brackets in there to check, whether
                     // the following string is a tag or text.
                     html = _.filter(html, function (part) {
-                        var skippedCharsRegex = new RegExp('^([\s\n\r]|>)*$', 'gm');
+                        var skippedCharsRegex = new RegExp('^([\s\n\r]|>)*$', 'g');
                         return !skippedCharsRegex.test(part);
                     });
 


### PR DESCRIPTION
If you have lines like "      text with whitespaces at the beginning" these lines were skipped, because of a wrong regex.