### PR TITLE
Fixing mediafiles list view for medifiles without a type

### DIFF
--- a/openslides/mediafiles/static/js/mediafiles/resources.js
+++ b/openslides/mediafiles/static/js/mediafiles/resources.js
@@ -85,7 +85,7 @@ angular.module('OpenSlidesApp.mediafiles.resources', [
                     return /\/(.+?)$/.exec(filename)[1];
                 }],
                 filetype: [function () {
-                    return this.mediafile.type;
+                    return this.mediafile.type || gettext('undefined');
                 }],
                 title_or_filename: ['title', 'mediafile', function (title) {
                     return title || this.filename;


### PR DESCRIPTION
I added a file 'some_code.asm' to the files. The filetype is empty, so the listview does not show this file. Setting a default to 'undefined' seems ok instead of a blank field.