### PR TITLE
Motion formatting and sort fixes

### DIFF
--- a/openslides/core/static/js/core/pdf.js
+++ b/openslides/core/static/js/core/pdf.js
@@ -391,7 +391,8 @@ angular.module('OpenSlidesApp.core.pdf', [])
 
 .factory('PdfMakeConverter', [
     'HTMLValidizer',
-    function(HTMLValidizer) {
+    'Config',
+    function(HTMLValidizer, Config) {
         /**
          * Converter component for HTML->JSON for pdfMake
          * @constructor
@@ -906,19 +907,20 @@ angular.module('OpenSlidesApp.core.pdf', [])
                         },
                         /* Returns the object to push first into every column, that represents the given line. */
                         getLineNumberObject = function (line) {
+                            var standardFontsize = Config.get('general_export_pdf_fontsize').value;
                             return {
                                 width: 20,
                                 text: [
                                     {
                                         text: ' ', // Add a blank with the normal font size here, so in rare cases the text
                                                    // is rendered on the next page and the linenumber on the previous page.
-                                        fontSize: 10,
+                                        fontSize: standardFontsize,
                                         decoration: '',
                                     },
                                     {
                                         text: line,
                                         color: "gray",
-                                        fontSize: 8,
+                                        fontSize: standardFontsize - 2,
                                         decoration: '',
                                     },
                                 ],

--- a/openslides/motions/static/js/motions/pdf.js
+++ b/openslides/motions/static/js/motions/pdf.js
@@ -248,7 +248,7 @@ angular.module('OpenSlidesApp.motions.pdf', ['OpenSlidesApp.core.pdf'])
                 // if pdfmake has fixed this.
                 var metaTableJsonString = {
                     table: {
-                        widths: ['30%','70%'],
+                        widths: ['35%','65%'],
                         body: metaTableBody,
                     },
                     margin: [0, 0, 0, 20],

--- a/openslides/motions/static/js/motions/site.js
+++ b/openslides/motions/static/js/motions/site.js
@@ -896,6 +896,8 @@ angular.module('OpenSlidesApp.motions.site', [
             return Motion.lastModified();
         }, function () {
             $scope.motions = Motion.getAll();
+            // always order by identifier (after custom ordering)
+            $scope.motions = _.orderBy($scope.motions, ['identifier']);
             _.forEach($scope.motions, function (motion) {
                 motion.personalNote = PersonalNoteManager.getNote(motion);
                 // For filtering, we cannot filter for .personalNote.star


### PR DESCRIPTION
- Adapt font size of outside linenumbers in motion pdf, depending on
  selected standard font size.
- Enlarge width of first column in of meta table of motion pdf.
- Fixed order issue in motion list: Sort always by identifier (also
  after selecting a custom sort parameter).