### PR TITLE
Supported server side setup of new agenda items (type and parent).

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@ Agenda:
 - Fixed wrong sorting of last speakers [#3193].
 - Fixed issue when sorting a new inserted speaker [#3210].
 - New permission for managing lists of speakers [#3366].
+- Fixed multiple request on creation of agenda related items [#3341].
 
 Motions:
 - New export dialog [#3185].

--- a/openslides/agenda/signals.py
+++ b/openslides/agenda/signals.py
@@ -15,18 +15,17 @@ def listen_to_related_object_post_save(sender, instance, created, **kwargs):
     django.db.models.signals.post_save during app loading.
 
     The agenda_item_update_information container may have fields like type,
-    parent or skip_autoupdate.
+    parent_id, comment, duration, weight or skip_autoupdate.
 
-    Do not run caching and autoupdate if the instance as a key
+    Do not run caching and autoupdate if the instance has a key
     skip_autoupdate in the agenda_item_update_information container.
     """
     if hasattr(instance, 'get_agenda_title'):
         if created:
             attrs = {}
-            if instance.agenda_item_update_information.get('type'):
-                attrs['type'] = instance.agenda_item_update_information.get('type')
-            if instance.agenda_item_update_information.get('parent'):
-                attrs['parent'] = instance.agenda_item_update_information.get('parent')
+            for attr in ('type', 'parent_id', 'comment', 'duration', 'weight'):
+                if instance.agenda_item_update_information.get(attr):
+                    attrs[attr] = instance.agenda_item_update_information.get(attr)
             Item.objects.create(content_object=instance, **attrs)
 
             # If the object is created, the related_object has to be sent again.

--- a/openslides/agenda/static/js/agenda/base.js
+++ b/openslides/agenda/static/js/agenda/base.js
@@ -21,32 +21,6 @@ angular.module('OpenSlidesApp.agenda', ['OpenSlidesApp.users'])
     }
 ])
 
-.factory('AgendaUpdate',[
-    'Agenda',
-    'operator',
-    function(Agenda, operator) {
-        return {
-            saveChanges: function (item_id, changes) {
-                // change agenda item only if user has the permission to do that
-                if (operator.hasPerms('agenda.can_manage agenda.can_see_hidden_items')) {
-                    Agenda.find(item_id).then(function (item) {
-                        var something = false;
-                        _.each(changes, function(change) {
-                            if (change.value !== item[change.key]) {
-                                item[change.key] = change.value;
-                                something = true;
-                            }
-                        });
-                        if (something === true) {
-                            Agenda.save(item);
-                        }
-                    });
-                }
-            }
-        };
-    }
-])
-
 .factory('Agenda', [
     '$http',
     'DS',

--- a/openslides/assignments/models.py
+++ b/openslides/assignments/models.py
@@ -333,7 +333,7 @@ class Assignment(RESTModelMixin, models.Model):
     """
     Container for runtime information for agenda app (on create or update of this instance).
     """
-    agenda_item_update_information = {}
+    agenda_item_update_information = {}  # type: Dict[str, Any]
 
     def get_agenda_title(self):
         return str(self)

--- a/openslides/assignments/models.py
+++ b/openslides/assignments/models.py
@@ -330,6 +330,11 @@ class Assignment(RESTModelMixin, models.Model):
                 vote_results_dict[candidate].append(votes)
         return vote_results_dict
 
+    """
+    Container for runtime information for agenda app (on create or update of this instance).
+    """
+    agenda_item_update_information = {}
+
     def get_agenda_title(self):
         return str(self)
 

--- a/openslides/assignments/serializers.py
+++ b/openslides/assignments/serializers.py
@@ -194,6 +194,8 @@ class AssignmentFullSerializer(ModelSerializer):
     """
     assignment_related_users = AssignmentRelatedUserSerializer(many=True, read_only=True)
     polls = AssignmentAllPollSerializer(many=True, read_only=True)
+    agenda_type = IntegerField(write_only=True, required=False, min_value=1, max_value=2)
+    agenda_parent_id = IntegerField(write_only=True, required=False, min_value=1)
 
     class Meta:
         model = Assignment
@@ -207,6 +209,8 @@ class AssignmentFullSerializer(ModelSerializer):
             'poll_description_default',
             'polls',
             'agenda_item_id',
+            'agenda_type',
+            'agenda_parent_id',
             'tags',)
         validators = (posts_validator,)
 
@@ -214,6 +218,19 @@ class AssignmentFullSerializer(ModelSerializer):
         if 'description' in data:
             data['description'] = validate_html(data['description'])
         return data
+
+    def create(self, validated_data):
+        """
+        Customized create method. Set information about related agenda item
+        into agenda_item_update_information container.
+        """
+        agenda_type = validated_data.pop('agenda_type', None)
+        agenda_parent_id = validated_data.pop('agenda_parent_id', None)
+        assignment = Assignment(**validated_data)
+        assignment.agenda_item_update_information['type'] = agenda_type
+        assignment.agenda_item_update_information['parent_id'] = agenda_parent_id
+        assignment.save()
+        return assignment
 
 
 class AssignmentShortSerializer(AssignmentFullSerializer):

--- a/openslides/assignments/static/js/assignments/site.js
+++ b/openslides/assignments/static/js/assignments/site.js
@@ -157,7 +157,7 @@ angular.module('OpenSlidesApp.assignments.site', [
                     }
                 }];
 
-                // parent item
+                // show as agenda item + parent item
                 if (isCreateForm) {
                     formFields.push({
                         key: 'showAsAgendaItem',
@@ -627,9 +627,8 @@ angular.module('OpenSlidesApp.assignments.site', [
     'Assignment',
     'AssignmentForm',
     'Agenda',
-    //'AgendaUpdate',
     'ErrorMessage',
-    function($scope, $state, Assignment, AssignmentForm, Agenda,/* AgendaUpdate,*/ ErrorMessage) {
+    function($scope, $state, Assignment, AssignmentForm, Agenda, ErrorMessage) {
         $scope.model = {};
         // set default value for open posts form field
         $scope.model.open_posts = 1;
@@ -638,13 +637,9 @@ angular.module('OpenSlidesApp.assignments.site', [
         // save assignment
         $scope.save = function(assignment, gotoDetailView) {
             assignment.agenda_type = assignment.showAsAgendaItem ? 1 : 2;
+            // The attribute assignment.agenda_parent_id is set by the form, see form definition.
             Assignment.create(assignment).then(
                 function (success) {
-                    // type: Value 1 means a non hidden agenda item, value 2 means a hidden agenda item,
-                    // see openslides.agenda.models.Item.ITEM_TYPE.
-                    /*var changes = [{key: 'type', value: (assignment.showAsAgendaItem ? 1 : 2)},
-                                   {key: 'parent_id', value: assignment.agenda_parent_item_id}];
-                    AgendaUpdate.saveChanges(success.agenda_item_id,changes);*/
                     if (gotoDetailView) {
                         $state.go('assignments.assignment.detail', {id: success.id});
                     }
@@ -674,20 +669,12 @@ angular.module('OpenSlidesApp.assignments.site', [
         $scope.model = angular.copy(assignment);
         // get all form fields
         $scope.formFields = AssignmentForm.getFormFields();
-        var agenda_item = Agenda.get(assignment.agenda_item_id);
-        for (var i = 0; i < $scope.formFields.length; i++) {
-            if ($scope.formFields[i].key == "showAsAgendaItem") {
-                // get state from agenda item (hidden/internal or agenda item)
-                $scope.formFields[i].defaultValue = !assignment.agenda_item.is_hidden;
-            }
-        }
 
         // save assignment
         $scope.save = function (assignment, gotoDetailView) {
-            assignment.agenda_type = assignment.showAsAgendaItem ? 1 : 2;
             // inject the changed assignment (copy) object back into DS store
             Assignment.inject(assignment);
-            // save change assignment object on server
+            // save changed assignment object on server
             Assignment.save(assignment).then(
                 function(success) {
                     if (gotoDetailView) {

--- a/openslides/motions/models.py
+++ b/openslides/motions/models.py
@@ -628,6 +628,11 @@ class Motion(RESTModelMixin, models.Model):
         if self.recommendation is not None:
             self.set_state(self.recommendation)
 
+    """
+    Container for runtime information for agenda app (on create or update of this instance).
+    """
+    agenda_item_update_information = {}
+
     def get_agenda_title(self):
         """
         Return a simple title string for the agenda.
@@ -894,6 +899,11 @@ class MotionBlock(RESTModelMixin, models.Model):
             name='motions/motion-block',
             id=self.pk)
         return super().delete(skip_autoupdate=skip_autoupdate, *args, **kwargs)  # type: ignore
+
+    """
+    Container for runtime information for agenda app (on create or update of this instance).
+    """
+    agenda_item_update_information = {}
 
     @property
     def agenda_item(self):

--- a/openslides/motions/models.py
+++ b/openslides/motions/models.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict  # noqa
+
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericRelation
 from django.core.exceptions import ImproperlyConfigured, ValidationError
@@ -631,7 +633,7 @@ class Motion(RESTModelMixin, models.Model):
     """
     Container for runtime information for agenda app (on create or update of this instance).
     """
-    agenda_item_update_information = {}
+    agenda_item_update_information = {}  # type: Dict[str, Any]
 
     def get_agenda_title(self):
         """
@@ -903,7 +905,7 @@ class MotionBlock(RESTModelMixin, models.Model):
     """
     Container for runtime information for agenda app (on create or update of this instance).
     """
-    agenda_item_update_information = {}
+    agenda_item_update_information = {}  # type: Dict[str, Any]
 
     @property
     def agenda_item(self):

--- a/openslides/motions/static/js/motions/motion-block.js
+++ b/openslides/motions/static/js/motions/motion-block.js
@@ -69,8 +69,8 @@ angular.module('OpenSlidesApp.motions.motionBlock', [])
                 };
             },
             // Get angular-formly fields.
-            getFormFields: function () {
-                return [
+            getFormFields: function (isCreateForm) {
+                var formFields = [
                     {
                         key: 'title',
                         type: 'input',
@@ -78,7 +78,11 @@ angular.module('OpenSlidesApp.motions.motionBlock', [])
                             label: gettextCatalog.getString('Title')
                         }
                     },
-                    {
+                ];
+
+                // show as agenda item + parent item
+                if (isCreateForm) {
+                    formFields.push({
                         key: 'showAsAgendaItem',
                         type: 'checkbox',
                         templateOptions: {
@@ -86,18 +90,21 @@ angular.module('OpenSlidesApp.motions.motionBlock', [])
                             description: gettextCatalog.getString('If deactivated it appears as internal item on agenda.')
                         },
                         hide: !(operator.hasPerms('motions.can_manage') && operator.hasPerms('agenda.can_manage'))
-                    },
-                    {
-                        key: 'agenda_parent_item_id',
+                    });
+                    formFields.push({
+                        key: 'agenda_parent_id',
                         type: 'select-single',
                         templateOptions: {
                             label: gettextCatalog.getString('Parent item'),
                             options: AgendaTree.getFlatTree(Agenda.getAll()),
                             ngOptions: 'item.id as item.getListViewTitle() for item in to.options | notself : model.agenda_item_id',
                             placeholder: gettextCatalog.getString('Select a parent item ...')
-                        }
-                    }
-                ];
+                        },
+                        hide: !operator.hasPerms('agenda.can_manage')
+                    });
+                }
+
+                return formFields;
             }
         };
     }
@@ -190,24 +197,20 @@ angular.module('OpenSlidesApp.motions.motionBlock', [])
     '$scope',
     'MotionBlock',
     'MotionBlockForm',
-    'AgendaUpdate',
-    function($scope, MotionBlock, MotionBlockForm, AgendaUpdate) {
+    function($scope, MotionBlock, MotionBlockForm) {
         // Prepare form.
         $scope.model = {};
         $scope.model.showAsAgendaItem = true;
 
         // Get all form fields.
-        $scope.formFields = MotionBlockForm.getFormFields();
+        $scope.formFields = MotionBlockForm.getFormFields(true);
 
         // Save form.
         $scope.save = function (motionBlock) {
+            motionBlock.agenda_type = motionBlock.showAsAgendaItem ? 1 : 2;
+            // The attribute motionBlock.agenda_parent_id is set by the form, see form definition.
             MotionBlock.create(motionBlock).then(
                 function (success) {
-                    // type: Value 1 means a non hidden agenda item, value 2 means a hidden agenda item,
-                    // see openslides.agenda.models.Item.ITEM_TYPE.
-                    var changes = [{key: 'type', value: (motionBlock.showAsAgendaItem ? 1 : 2)},
-                                   {key: 'parent_id', value: motionBlock.agenda_parent_item_id}];
-                    AgendaUpdate.saveChanges(success.agenda_item_id, changes);
                     $scope.closeThisDialog();
                 },
                 function (error) {
@@ -230,8 +233,6 @@ angular.module('OpenSlidesApp.motions.motionBlock', [])
     'AgendaUpdate',
     'motionBlockId',
     function($scope, $state, MotionBlock, MotionBlockForm, AgendaUpdate, motionBlockId) {
-        // TODO: Check #2486 and remove some agenda related code.
-        //MotionBlock.loadRelations(motionBlock, 'agenda_item');
         $scope.alert = {};
 
         // Prepare form. Set initial values by creating a deep copy of
@@ -241,23 +242,14 @@ angular.module('OpenSlidesApp.motions.motionBlock', [])
 
         // Get all form fields.
         $scope.formFields = MotionBlockForm.getFormFields();
-        for (var i = 0; i < $scope.formFields.length; i++) {
-            if ($scope.formFields[i].key == 'showAsAgendaItem') {
-                // Get state from agenda item (hidden/internal or agenda item).
-                $scope.formFields[i].defaultValue = !motionBlock.agenda_item.is_hidden;
-            } else if ($scope.formFields[i].key == 'agenda_parent_item_id') {
-                $scope.formFields[i].defaultValue = motionBlock.agenda_item.parent_id;
-            }
-        }
+
         // Save form.
         $scope.save = function (motionBlock) {
+            // inject the changed motionBlock (copy) object back into DS store
+            MotionBlock.inject(motionBlock);
+            // save changed motionBlock object on server
             MotionBlock.create(motionBlock).then(
                 function (success) {
-                    // type: Value 1 means a non hidden agenda item, value 2 means a hidden agenda item,
-                    // see openslides.agenda.models.Item.ITEM_TYPE.
-                    var changes = [{key: 'type', value: (motionBlock.showAsAgendaItem ? 1 : 2)},
-                                   {key: 'parent_id', value: motionBlock.agenda_parent_item_id}];
-                    AgendaUpdate.saveChanges(success.agenda_item_id,changes);
                     $scope.closeThisDialog();
                 },
                 function (error) {

--- a/openslides/motions/static/js/motions/motion-block.js
+++ b/openslides/motions/static/js/motions/motion-block.js
@@ -230,9 +230,8 @@ angular.module('OpenSlidesApp.motions.motionBlock', [])
     '$state',
     'MotionBlock',
     'MotionBlockForm',
-    'AgendaUpdate',
     'motionBlockId',
-    function($scope, $state, MotionBlock, MotionBlockForm, AgendaUpdate, motionBlockId) {
+    function($scope, $state, MotionBlock, MotionBlockForm, motionBlockId) {
         $scope.alert = {};
 
         // Prepare form. Set initial values by creating a deep copy of

--- a/openslides/motions/views.py
+++ b/openslides/motions/views.py
@@ -596,7 +596,8 @@ class CategoryViewSet(ModelViewSet):
                 # Remove old identifiers
                 for motion in motions:
                     motion.identifier = None
-                    motion.agenda_item_update_information['skip_autoupdate'] = True # This line is to skip agenda item autoupdate. See agenda/signals.py.
+                    # This line is to skip agenda item autoupdate. See agenda/signals.py.
+                    motion.agenda_item_update_information['skip_autoupdate'] = True
                     motion.save(skip_autoupdate=True)
 
                 # Set new identifers and change identifiers of amendments.
@@ -615,7 +616,8 @@ class CategoryViewSet(ModelViewSet):
                                 obj['new_identifier'],
                                 child.identifier,
                                 count=1)
-                            child.agenda_item_update_information['skip_autoupdate'] = True  # This line is to skip agenda item autoupdate. See agenda/signals.py.
+                            # This line is to skip agenda item autoupdate. See agenda/signals.py.
+                            child.agenda_item_update_information['skip_autoupdate'] = True
                             child.save(skip_autoupdate=True)
                             instances.append(child)
                             instances.append(child.agenda_item)

--- a/openslides/motions/views.py
+++ b/openslides/motions/views.py
@@ -596,7 +596,7 @@ class CategoryViewSet(ModelViewSet):
                 # Remove old identifiers
                 for motion in motions:
                     motion.identifier = None
-                    motion.skip_autoupdate = True  # This line is to skip agenda item autoupdate. See agenda/signals.py.
+                    motion.agenda_item_update_information['skip_autoupdate'] = True # This line is to skip agenda item autoupdate. See agenda/signals.py.
                     motion.save(skip_autoupdate=True)
 
                 # Set new identifers and change identifiers of amendments.
@@ -615,7 +615,7 @@ class CategoryViewSet(ModelViewSet):
                                 obj['new_identifier'],
                                 child.identifier,
                                 count=1)
-                            child.skip_autoupdate = True  # This line is to skip agenda item autoupdate. See agenda/signals.py.
+                            child.agenda_item_update_information['skip_autoupdate'] = True  # This line is to skip agenda item autoupdate. See agenda/signals.py.
                             child.save(skip_autoupdate=True)
                             instances.append(child)
                             instances.append(child.agenda_item)

--- a/openslides/topics/models.py
+++ b/openslides/topics/models.py
@@ -54,6 +54,11 @@ class Topic(RESTModelMixin, models.Model):
             id=self.pk)
         return super().delete(skip_autoupdate=skip_autoupdate, *args, **kwargs)  # type: ignore
 
+    """
+    Container for runtime information for agenda app (on create or update of this instance).
+    """
+    agenda_item_update_information = {}
+
     @property
     def agenda_item(self):
         """

--- a/openslides/topics/models.py
+++ b/openslides/topics/models.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict  # noqa
+
 from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
 
@@ -57,7 +59,7 @@ class Topic(RESTModelMixin, models.Model):
     """
     Container for runtime information for agenda app (on create or update of this instance).
     """
-    agenda_item_update_information = {}
+    agenda_item_update_information = {}  # type: Dict[str, Any]
 
     @property
     def agenda_item(self):

--- a/openslides/topics/serializers.py
+++ b/openslides/topics/serializers.py
@@ -1,4 +1,4 @@
-from openslides.utils.rest_api import ModelSerializer
+from openslides.utils.rest_api import CharField, IntegerField, ModelSerializer
 from openslides.utils.validate import validate_html
 
 from .models import Topic
@@ -8,11 +8,49 @@ class TopicSerializer(ModelSerializer):
     """
     Serializer for core.models.Topic objects.
     """
+    agenda_type = IntegerField(write_only=True, required=False, min_value=1, max_value=2)
+    agenda_parent_id = IntegerField(write_only=True, required=False, min_value=1)
+    agenda_comment = CharField(write_only=True, required=False, allow_blank=True)
+    agenda_duration = IntegerField(write_only=True, required=False, min_value=1)
+    agenda_weight = IntegerField(write_only=True, required=False, min_value=1)
+
     class Meta:
         model = Topic
-        fields = ('id', 'title', 'text', 'attachments', 'agenda_item_id')
+        fields = (
+            'id',
+            'title',
+            'text',
+            'attachments',
+            'agenda_item_id',
+            'agenda_type',
+            'agenda_parent_id',
+            'agenda_comment',
+            'agenda_duration',
+            'agenda_weight',
+        )
 
     def validate(self, data):
         if 'text' in data:
             data['text'] = validate_html(data['text'])
         return data
+
+    def create(self, validated_data):
+        """
+        Customized create method. Set information about related agenda item
+        into agenda_item_update_information container.
+        """
+        agenda_type = validated_data.pop('agenda_type', None)
+        agenda_parent_id = validated_data.pop('agenda_parent_id', None)
+        agenda_comment = validated_data.pop('agenda_comment', None)
+        agenda_duration = validated_data.pop('agenda_duration', None)
+        agenda_weight = validated_data.pop('agenda_weight', None)
+        attachments = validated_data.pop('attachments', [])
+        topic = Topic(**validated_data)
+        topic.agenda_item_update_information['type'] = agenda_type
+        topic.agenda_item_update_information['parent_id'] = agenda_parent_id
+        topic.agenda_item_update_information['comment'] = agenda_comment
+        topic.agenda_item_update_information['duration'] = agenda_duration
+        topic.agenda_item_update_information['weight'] = agenda_weight
+        topic.save()
+        topic.attachments.add(*attachments)
+        return topic


### PR DESCRIPTION
@FinnStutzenstein First step here. Now we can implement the client sending extra fields like type and parent on creation of agenda related items like motion, motion block, topic and assignment. Do you want to do some things here like changeing client for e. g. assignment. Then we can go on with the server ...

See #3016, #2886, #2779.