### PR TITLE
Fixing strange umlauts when copy text from word

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -75,7 +75,7 @@ General:
 - Switched from npm to Yarn [#3188].
 - Improved performance for PDF generation significantly (by upgrading
   to pdfmake 0.1.30) [#3278, #3285].
-- Bugfixes for PDF creation [#3227, #3251, #3279, #3286, #3346, #3347].
+- Bugfixes for PDF creation [#3227, #3251, #3279, #3286, #3346, #3347, #3342].
 - Improvements for plugin integration [#3330].
 
 

--- a/openslides/core/static/js/core/pdf.js
+++ b/openslides/core/static/js/core/pdf.js
@@ -119,10 +119,21 @@ angular.module('OpenSlidesApp.core.pdf', [])
 .factory('HTMLValidizer', function() {
     var HTMLValidizer = {};
 
+    // In some cases copying from word to OpenSlides results in umlauts
+    // that are the base letter and then the entity #776; to make the dots
+    // above the base letter. This breaks the PDF.
+    HTMLValidizer.replaceMalformedUmlauts = function (text) {
+        return text.replace(/([aeiouAEIOUy])[\u0308]/g, function (match, baseChar) {
+            return '&' + baseChar + 'uml;';
+        });
+    };
+
     //checks if str is valid HTML. Returns valid HTML if not,
     //return emptystring if empty
     HTMLValidizer.validize = function(str) {
         if (str) {
+            str = HTMLValidizer.replaceMalformedUmlauts(str);
+
             var a = document.createElement('div');
             a.innerHTML = str;
             angular.forEach(a.childNodes, function (child) {


### PR DESCRIPTION
This [unicode char](http://www.fileformat.info/info/unicode/char/0308/index.htm) is behind a 'u o a' to make the dots above.