### PR TITLE
some changes in the example data plugin

### DIFF
--- a/openslides/utils/settings.py.tpl
+++ b/openslides/utils/settings.py.tpl
@@ -23,6 +23,9 @@ OPENSLIDES_USER_DATA_PATH = %(openslides_user_data_path)s
 
 INSTALLED_PLUGINS += (
 #    'plugin_module_name',
+
+# Built-in plugins:
+#    'tests.example_data_generator',
 )
 
 INSTALLED_APPS += INSTALLED_PLUGINS


### PR DESCRIPTION
@normanjaeckel Whats about checking, if `user0` uo to `userXX` exists and then to create e.g. 100 new users `userXX+1` up to `userXX+100`? This happens, if the script is runned multiple times. As a quick bug fix I catch the IntegrityError, so the script doesn't break.