### PR TITLE
Fixing wrong styles in PDF

### DIFF
--- a/openslides/core/static/js/core/pdf.js
+++ b/openslides/core/static/js/core/pdf.js
@@ -590,7 +590,7 @@ angular.module('OpenSlidesApp.core.pdf', [])
                          * @param {number} diff_mode
                          */
                         ParseElement = function(alreadyConverted, element, currentParagraph, styles, diff_mode) {
-                            styles = styles || [];
+                            styles = styles ? _.clone(styles) : [];
                             var classes = [];
                             if (element.getAttribute) {
                                 var nodeStyle = element.getAttribute("style");


### PR DESCRIPTION
The issue: Make a new motion with some text and set the color of one word. Export the pdf -> everything after this word gets the same style..

Fixed by cloning the styles array on every recursion step. Previous, when adding a style, the caller function does get the style, too, because the list is passed by reference. Now, when leaving the function, the caller has the original styles-array.