### PR TITLE
Broken anonymous fix (fixes #3377)

### DIFF
--- a/openslides/users/access_permissions.py
+++ b/openslides/users/access_permissions.py
@@ -185,21 +185,23 @@ class PersonalNoteAccessPermissions(BaseAccessPermissions):
         # Expand full_data to a list if it is not one.
         full_data = container.get_full_data() if isinstance(container, Collection) else [container.get_full_data()]
 
-        # Parse data.
-        for full in full_data:
-            if full['user_id'] == user.id:
-                data = [full]
-                break
-        else:
-            data = []
+        restricted_data = None
+        if user is not None:
+            # Parse data.
+            for full in full_data:
+                if full['user_id'] == user.id:
+                    data = [full]
+                    break
+            else:
+                data = []
 
-        # Reduce result to a single item or None if it was not a collection at
-        # the beginning of the method.
-        if isinstance(container, Collection):
-            restricted_data = data
-        elif data:
-            restricted_data = data[0]
-        else:
-            restricted_data = None
+            # Reduce result to a single item or None if it was not a collection at
+            # the beginning of the method.
+            if isinstance(container, Collection):
+                restricted_data = data
+            elif data:
+                restricted_data = data[0]
+            else:
+                restricted_data = None
 
         return restricted_data


### PR DESCRIPTION
@normanjaeckel Set a personal note for a motion and enable the anonmous. Log off and reload. The error in #3377 is fixed, but now I get this:
```Traceback (most recent call last):
  File "/home/finn/OpenSlides/.venv/lib/python3.5/site-packages/channels/worker.py", line 119, in run
    consumer(message, **kwargs)
  File "/home/finn/OpenSlides/.venv/lib/python3.5/site-packages/channels/sessions.py", line 192, in inner
    result = func(message, *args, **kwargs)
  File "/home/finn/OpenSlides/.venv/lib/python3.5/site-packages/channels/auth.py", line 73, in inner
    return func(message, *args, **kwargs)
  File "/home/finn/OpenSlides/.venv/lib/python3.5/site-packages/channels/sessions.py", line 70, in inner
    return func(message, *args, **kwargs)
  File "/home/finn/OpenSlides/.venv/lib/python3.5/site-packages/channels/auth.py", line 89, in inner
    return func(message, *args, **kwargs)
  File "/home/finn/OpenSlides/OpenSlides/openslides/utils/autoupdate.py", line 100, in ws_add_site
    for data in restricted_data:
TypeError: 'NoneType' object is not iterable
```

I wonder why the autoupdate does not accept `None` because we always return `None` from a `get_restricted_data()` call, if the user is not allowed to see this data.