### PR TITLE
Pin angular-ui-tree to last working version v2.22.5. (Fixed #3387)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
     "angular-sanitize": "~1.5.8",
     "angular-scroll-glue": "~2.0.7",
     "angular-ui-router": "~0.3.1",
-    "angular-ui-tree": "~2.22.0",
+    "angular-ui-tree": "2.22.5",
     "angular-xeditable": "~0.5.0",
     "angularjs-slider": "~6.2.2",
     "bootstrap-css-only": "~3.3.6",


### PR DESCRIPTION
Note: You have to rerun `yarn` to test it.
Last release 2.22.6 does not work.