### PR TITLE
Inline-Diff when the first word in a paragraph is replaced - fixes #3401

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,7 +21,7 @@ Motions:
 - Fixed empty motion comment field in motion update form [#3194].
 - Fixed error on category sort [#3318].
 - Removed server side image to base64 transformation and
-  added local transformation [#3181]
+  added local transformation [#3181].
 - Added support for export motions in a ZIP archive [#3189].
 - Performance improvement for ZIP creation [#3251].
 - Bugfix: Changing motion line length did not invalidate cache [#3202].
@@ -36,7 +36,8 @@ Motions:
   pdf/docx export [#3329].
 - Added config value for pagenumber alignment in PDF [#3327].
 - Bugfix: Several bugfixes regarding splitting list items in
-  change recommendations [#3288]
+  change recommendations [#3288].
+- Bugfix: Several bugfixes regarding diff version [#3407, #3408].
 - Added inline Editing for motion reason [#3361].
 - Added multiselect filter for motion comments [#3372].
 - Added support for pinning personal notes to the window [#3360].

--- a/tests/karma/motions/diff.service.test.js
+++ b/tests/karma/motions/diff.service.test.js
@@ -433,6 +433,14 @@ describe('linenumbering', function () {
       expect(diff).toBe('<DEL>Test1 Test2 Test3 Test4 Test5 Test9</DEL><INS>Test1 Test6 Test7 Test8 Test9</INS>');
     });
 
+    it('does not result in separate paragraphs when only the first word has changed', function () {
+      var before = '<p class="os-split-after"><span class="os-line-number line-number-1" data-line-number="1" contenteditable="false">&nbsp;</span>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor </p>',
+          after = '<p class="os-split-after">Bla ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor</p>';
+      var diff = diffService.diff(before, after);
+
+      expect(diff).toBe('<p class="os-split-after"><span class="line-number-1 os-line-number" data-line-number="1" contenteditable="false">&nbsp;</span><del>Lorem</del><ins>Bla</ins> ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor</p>');
+    });
+
     it('merges multiple inserts and deletes', function () {
       var before = "Some additional text to circumvent the threshold Test1 Test2 Test3 Test4 Test5 Test9",
           after = "Some additional text to circumvent the threshold Test1 Test6 Test7 Test8 Test9";
@@ -538,10 +546,10 @@ describe('linenumbering', function () {
               brMarkup(14) + 'gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.</p>',
           after= '<p>Test</p>';
       var diff = diffService.diff(before, after).toLowerCase(),
-          expected = '<p class="delete">' +
-          noMarkup(13).replace(/&nbsp;/, "\u00A0") + 'diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd ' +
-          brMarkup(14).replace(/&nbsp;/, "\u00A0") + 'gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.</p>' +
-          '<p class="insert">Test</p>';
+          expected = '<p>' +
+              noMarkup(13) + '<del>diam voluptua. at vero eos et accusam et justo duo dolores et ea rebum. stet clita kasd </del>' +
+              brMarkup(14) + '<del>gubergren, no sea takimata sanctus est lorem ipsum dolor sit amet.</del>' +
+              '<ins>test</ins></p>';
 
       expect(diff).toBe(expected.toLowerCase());
     });


### PR DESCRIPTION
This fixes the problem that the paragraph-based diff is used instead of the inline-diff as a fallback when the first word of the paragraph is changed.

This affects another behavior: if a longer paragraph (containing multiple line breaks) is replaced by another text, the algorithm previously resulted in two paragraphs - one "deleted" paragraph with the old text, one "inserted" paragraph with the new text. Now, it will result in one paragraph, where each line is deleted individually, the line break and line number not being nested in the DEL-tag anymore, followed by the inserted text within an INS.
This hopefully should not negatively affect anything (like the PDF-export).