### PR TITLE
Index and Webclient View caching

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -85,6 +85,8 @@ Core:
 - Added custom translations in config [#3383].
 - Added dynamic webpage title [#3404].
 - Added 'go to top'-link [#3404].
+- Added caching for the index views. When using a Webserver for serving
+  static files see the example configuration in the PR [#3419].
 
 Mediafiles:
 - Fixed reloading of PDF on page change [#3274].

--- a/openslides/utils/views.py
+++ b/openslides/utils/views.py
@@ -1,5 +1,8 @@
 from typing import Any, Dict, List  # noqa
 
+from django.contrib.staticfiles import finders
+from django.core.exceptions import ImproperlyConfigured
+from django.http import HttpResponse
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.generic.base import View
 from rest_framework.response import Response
@@ -45,3 +48,22 @@ class APIView(_APIView):
     # Add the http-methods and delete the method "method_call"
     get = post = put = patch = delete = head = options = trace = method_call
     del method_call
+
+
+class IndexView(View):
+    """
+    A view to serve a single cached template file. Subclasses has to provide 'template_name'.
+    """
+    template_name = None  # type: str
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+        if self.template_name is None:
+            raise ImproperlyConfigured("'template_name' is not provided")
+
+        with open(finders.find(self.template_name)) as template:
+            self.template = template.read()
+
+    def get(self, *args: Any, **kwargs: Any) -> HttpResponse:
+        return HttpResponse(self.template)

--- a/tests/unit/core/test_views.py
+++ b/tests/unit/core/test_views.py
@@ -169,10 +169,11 @@ class ProjectorAPI(TestCase):
 class WebclientJavaScriptView(TestCase):
     def setUp(self):
         self.request = MagicMock()
-        self.view_instance = views.WebclientJavaScriptView()
-        self.view_instance.request = self.request
 
     @patch('django.contrib.auth.models.Permission.objects.all')
     def test_permissions_as_constant(self, mock_all):
-        self.view_instance.get()
-        self.assertEqual(mock_all.call_count, 1)
+        self.view_instance = views.WebclientJavaScriptView()
+        self.view_instance.request = self.request
+        response = self.view_instance.get(realm='site')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(mock_all.call_count, 2)


### PR DESCRIPTION
The new gulp task is for delivering the three main views with a Webserver. For every request to `/`, `/projector` and `/real-projector` the matching staticfile should be delivered. You can test this, if you put e.g. `localhost:8000/static/html/index.html` in your browser. The Nginx configuration is:
```
location ~* ^/(?!ws|wss|webclient|core/servertime|users/whoami|users/login|users/logout|users/setpassword|motions/docxtemplate|projector|real-projector|static|media|rest).*$ {
    rewrite ^.*$ /static/templates/index.html;
} 
location ~* ^/projector.*$ {
   rewrite ^.*$ /static/templates/projector-container.html;
} 
location ~* ^/real-projector.*$ {
    rewrite ^.*$ /static/templates/projector.html;
}
```

For setups without a Webserver the templates are cached to raise performance in this case.