### PR TITLE
Diff: use comma as a word separator

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,7 +37,7 @@ Motions:
 - Added config value for pagenumber alignment in PDF [#3327].
 - Bugfix: Several bugfixes regarding splitting list items in
   change recommendations [#3288].
-- Bugfix: Several bugfixes regarding diff version [#3407, #3408, #3410].
+- Bugfix: Several bugfixes regarding diff version [#3407, #3408, #3410, #3440].
 - Added inline Editing for motion reason [#3361].
 - Added multiselect filter for motion comments [#3372].
 - Added support for pinning personal notes to the window [#3360].

--- a/openslides/motions/static/js/motions/diff.js
+++ b/openslides/motions/static/js/motions/diff.js
@@ -931,6 +931,7 @@ angular.module('OpenSlidesApp.motions.diff', ['OpenSlidesApp.motions.lineNumberi
             arr = splitArrayEntriesEmbedSeparator(arr, '>', false);
             arr = splitArrayEntriesSplitSeparator(arr, " ");
             arr = splitArrayEntriesSplitSeparator(arr, ".");
+            arr = splitArrayEntriesSplitSeparator(arr, ",");
             arr = splitArrayEntriesEmbedSeparator(arr, "\n", false);
 
             var arrWithoutEmptes = [];

--- a/tests/karma/motions/diff.service.test.js
+++ b/tests/karma/motions/diff.service.test.js
@@ -471,6 +471,14 @@ describe('linenumbering', function () {
       expect(diff).toBe('Test Test<ins>append</ins>');
     });
 
+    it('recognizes commas as a word separator', function () {
+      var before = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat",
+          after = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat";
+      var diff = diffService.diff(before, after);
+
+      expect(diff).toBe('Lorem ipsum dolor sit amet, consetetur sadipscing elitr<del> sed</del><ins>,</ins> diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat');
+    });
+
     it('cannot handle changing CSS-classes', function () {
       var before = "<p class='p1'>Test1 Test2</p>",
           after = "<p class='p2'>Test1 Test2</p>";


### PR DESCRIPTION
This should solve the first two of the three problems mentioned in Emanuel's email.

OLD: Some text and some more text
NEW: Some text, some more text
DIFF (before): Some \<del>text and\</del>\<ins>text,\</ins> some more text
DIFF (now): Some text\<del> and\</del>\<ins>,\</ins> some more text