### PR TITLE
Limit the reason display width

### DIFF
--- a/openslides/motions/static/templates/motions/motion-detail.html
+++ b/openslides/motions/static/templates/motions/motion-detail.html
@@ -489,7 +489,8 @@
           </div>
         </div>
       </div>
-
+    </div>
+    <div class="col-md-8">
       <!-- reason -->
       <div ng-if="motion.getReason(version) != ''">
         <h3 translate>Reason</h3>


### PR DESCRIPTION
The motion text and reason is limited to 2/3 of the container width, if the linenumber mode is none or inline (See the exclaimed line). I changed this to full width, but I'm not happy with this. On FullHD this text is too wide to read it easy.

Rather to set the width to fixed 2/3, I would propose to set a max-width of about 900px. If the screen gets smaller, the text will fill the whole container.