### PR TITLE
Disable change ratio detection / Fix marking unchanged dangling line as changed

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,7 +37,8 @@ Motions:
 - Added config value for pagenumber alignment in PDF [#3327].
 - Bugfix: Several bugfixes regarding splitting list items in
   change recommendations [#3288].
-- Bugfix: Several bugfixes regarding diff version [#3407, #3408, #3410, #3440].
+- Bugfix: Several bugfixes regarding diff version [#3407, #3408, #3410,
+  #3440, #3450].
 - Added inline Editing for motion reason [#3361].
 - Added multiselect filter for motion comments [#3372].
 - Added support for pinning personal notes to the window [#3360].

--- a/openslides/motions/static/js/motions/diff.js
+++ b/openslides/motions/static/js/motions/diff.js
@@ -1003,29 +1003,6 @@ angular.module('OpenSlidesApp.motions.diff', ['OpenSlidesApp.motions.lineNumberi
         };
 
         /**
-         * Calculates the ratio of the text affected by inline diff
-         * From 0 (no changes at all) to 1 (everything has changed)
-         *
-         * @param html
-         * @returns {number}
-         * @private
-         */
-        this._calcChangeRatio = function(html) {
-            var lengthChanged = 0;
-
-            html = html.replace(/<del>(.*?)<\/del>/gi, function() { lengthChanged += arguments[1].length; return ""; });
-            html = html.replace(/<ins>(.*?)<\/ins>/gi, function() { lengthChanged += arguments[1].length; return ""; });
-            html = html.replace(/<.*?>/, "").trim();
-
-            var lengthRemaining = html.length;
-            if (lengthRemaining === 0 && lengthChanged === 0) {
-                return 0;
-            } else {
-                return (lengthChanged / (lengthChanged + lengthRemaining));
-            }
-        };
-
-        /**
          *
          * @param {string} html
          * @returns {boolean}
@@ -1064,12 +1041,6 @@ angular.module('OpenSlidesApp.motions.diff', ['OpenSlidesApp.motions.lineNumberi
                 if (inner.match(/<[^>]*>/)) {
                     return true;
                 }
-            }
-
-            // If too much of the text is changed, it's better to separate the old from new new version,
-            // otherwise the result looks strange
-            if (this._calcChangeRatio(html) > 0.66) {
-                return true;
             }
 
             // If non of the conditions up to now is met, we consider the diff as being sane

--- a/tests/karma/motions/diff.service.test.js
+++ b/tests/karma/motions/diff.service.test.js
@@ -423,20 +423,14 @@ describe('linenumbering', function () {
       expect(diff).toBe('The <strong>brown</strong> spotted fox <del>jum</del><ins>lea</ins>ped over the rolling log.');
     });
 
-    it('too many changes result in separate paragraphs', function () {
-      var before = "<p>Test1 Test2 Test3 Test4 Test5 Test9</p>",
-          after = "<p>Test1 Test6 Test7 Test8 Test9</p>";
-      var diff = diffService.diff(before, after);
-
-      expect(diff).toBe('<P class="delete">Test1 Test2 Test3 Test4 Test5 Test9</P><P class="insert">Test1 Test6 Test7 Test8 Test9</P>');
-    });
-
-    it('too many changes result in separate paragraphs - special case with un-wrapped text', function () {
-      var before = "Test1 Test2 Test3 Test4 Test5 Test9",
-          after = "Test1 Test6 Test7 Test8 Test9";
-      var diff = diffService.diff(before, after);
-
-      expect(diff).toBe('<DEL>Test1 Test2 Test3 Test4 Test5 Test9</DEL><INS>Test1 Test6 Test7 Test8 Test9</INS>');
+    it('does not mark the last line of a paragraph as change if a long new one is appended', function () {
+      var before = "<p><span class=\"os-line-number line-number-5\" data-line-number=\"5\" contenteditable=\"false\">&nbsp;</span>Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</p>",
+            after = "<p>Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</p>\n" +
+                "\n" +
+                "<p>Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu.</p>";
+        var diff = diffService.diff(before, after);
+        expect(diff).toBe("<p><span class=\"line-number-5 os-line-number\" contenteditable=\"false\" data-line-number=\"5\">&nbsp;</span>Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</p>\n" +
+            "<p><ins>Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu.</ins></p>");
     });
 
     it('does not result in separate paragraphs when only the first word has changed', function () {
@@ -521,13 +515,6 @@ describe('linenumbering', function () {
             after = "";
         var diff = diffService.diff(before, after);
         expect(diff).toBe("<P class=\"delete\">Ihr könnt ohne Sorge fortgehen.'Da meckerte die Alte und machte sich getrost auf den Weg.</P>");
-    });
-
-    it('does not perform inline diff if there are too many changes', function () {
-        var before = "<P>Dann kam er zurück, klopfte an die Hausthür und rief 'macht auf, ihr lieben Kinder, eure Mutter ist da und hat jedem von Euch etwas mitgebarcht.' Aber der Wolf hatte seine schwarze Pfote in das Fenster gelegt, das sahen die Kinder und riefen</P>",
-            after = "<p>(hier: Missbrauch von bewusstseinsverändernde Mittel - daher Zensiert)</p>";
-        var diff = diffService.diff(before, after);
-        expect(diff).toBe('<P class="delete">Dann kam er zurück, klopfte an die Hausthür und rief \'macht auf, ihr lieben Kinder, eure Mutter ist da und hat jedem von Euch etwas mitgebarcht.\' Aber der Wolf hatte seine schwarze Pfote in das Fenster gelegt, das sahen die Kinder und riefen</P><P class="insert">(hier: Missbrauch von bewusstseinsverändernde Mittel - daher Zensiert)</P>');
     });
 
     it('does not repeat the last word (1)', function () {


### PR DESCRIPTION
The problem reported is that if a longer paragraph is added after another one by selecting the last line of the previous paragraph and adding the new one after it, lead to the selected line as being marked as removed and re-added:
<img width="627" alt="bildschirmfoto 2017-10-15 um 14 49 29" src="https://user-images.githubusercontent.com/533440/31584915-1a039676-b1b8-11e7-9cfb-aede8f690954.png">

This is because we use a change ratio detection for cases where a bigger part of a paragraph is replaced by other text, to avoid a rather confusing inline-diff. This pull request removes this mechanism and therefore fixes the reported problem, but therefore might introduce other strange formattings.

It might be possible to divide change recommendations and the original text to paragraphs, and perform the diff on the paragraphs separately; this would take a couple of hours and increase the computational ressources on the client side quite a bit, so I'm not doing it without further discussion.