### PR TITLE
Fixed user form for groups with ids greater than 9

### DIFF
--- a/openslides/core/static/css/app.css
+++ b/openslides/core/static/css/app.css
@@ -1479,6 +1479,7 @@ img {
     vertical-align: top;
     text-align: center;
     min-width: 40px;
+    overflow: hidden;
 }
 
 #groups-table .perm-head {

--- a/openslides/users/static/js/users/site.js
+++ b/openslides/users/static/js/users/site.js
@@ -335,9 +335,8 @@ angular.module('OpenSlidesApp.users.site', [
                     type: 'select-multiple',
                     templateOptions: {
                         label: gettextCatalog.getString('Groups'),
-                        options: Group.getAll(),
-                        ngOptions: 'option.id as option.name | translate for option in to.options | ' +
-                                   'filter: {id: "!1"}',
+                        options: Group.filter({where: {id: {'>': 1}}}),
+                        ngOptions: "option.id as option.name | translate for option in to.options | orderBy: 'id'",
                         placeholder: gettextCatalog.getString('Select or search a group ...')
                     }
                 },
@@ -784,10 +783,8 @@ angular.module('OpenSlidesApp.users.site', [
     '$state',
     'User',
     'UserForm',
-    'Group',
     'ErrorMessage',
-    function($scope, $state, User, UserForm, Group, ErrorMessage) {
-        Group.bindAll({where: {id: {'>': 2}}}, $scope, 'groups');
+    function($scope, $state, User, UserForm, ErrorMessage) {
         $scope.alert = {};
         // get all form fields
         $scope.formFields = UserForm.getFormFields(true);
@@ -814,11 +811,9 @@ angular.module('OpenSlidesApp.users.site', [
     '$state',
     'User',
     'UserForm',
-    'Group',
     'userId',
     'ErrorMessage',
-    function($scope, $state, User, UserForm, Group, userId, ErrorMessage) {
-        Group.bindAll({where: {id: {'>': 2}}}, $scope, 'groups');
+    function($scope, $state, User, UserForm, userId, ErrorMessage) {
         $scope.alert = {};
         // set initial values for form model by create deep copy of user object
         // so list/detail view is not updated while editing


### PR DESCRIPTION
The filter `filter: {id: "!1"}` works well for the default group, but it also filters out groups with id 10, 11, 12, ...
+ Removed unnecessary stuff.