### PR TITLE
Bugfix no word wrap after insertion

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -47,6 +47,7 @@ Motions:
 - Show motion identifier in (current) list of speakers [#3442]
 - Added navigation between single motions [#3459].
 - Improved the multiselect state filter [#3459]. 
+- Added karma:watch command [#3466].
 
 Elections:
 - Added pagination for list view [#3393].

--- a/DEVELOPMENT.rst
+++ b/DEVELOPMENT.rst
@@ -139,6 +139,9 @@ Run client tests by starting karma::
 
     $ yarn run karma
 
+Watch for file changes and run the tests automatically after each change::
+
+    $ yarn run karma:watch
 
 OpenSlides in big mode
 ======================

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "scripts": {
     "prepublish": "bower install && gulp",
-    "karma": "karma start tests/karma/karma.conf.js"
+    "karma": "karma start tests/karma/karma.conf.js",
+    "karma:watch": "karma start tests/karma/karma.conf.js --single-run=false"
   },
   "devDependencies": {
     "angular-mocks": "~1.5.11",

--- a/tests/karma/motions/linenumbering.service.test.js
+++ b/tests/karma/motions/linenumbering.service.test.js
@@ -303,6 +303,12 @@ describe('linenumbering', function () {
       var outHtml = lineNumberingService.insertLineNumbers(inHtml, 80);
       expect(outHtml).toBe("<p>" + noMarkup(1) + "Test 123<br>" + noMarkup(2) + "Test 456</p>");
     });
+
+    it('does not force-break words right after an INS', function () {
+      var inHtml = "<p>" + noMarkup(1) + "012345 <ins>78 01 34567</ins>8901234567890123456789</p>";
+      var outHtml = lineNumberingService.insertLineBreaksWithoutNumbers(inHtml, 20, true);
+      expect(outHtml).toBe("<p>" + noMarkup(1) + "012345 <ins>78 01 <br class=\"os-line-break\">34567</ins>890123456789012<br class=\"os-line-break\">3456789</p>");
+    });
   });
 
   describe('line breaking without adding line numbers', function() {


### PR DESCRIPTION
For once, I added a yarn-command "karma:watch" that runs the tests repetedly.

Then, this should fix a problem with the line numbering algorithm. Before, the line breaking only considered the current text node when deciding where to break. This lead to suboptimal results when the current node is an inline text node starting pretty late on a line and without a whitespace character at the beginning.
Now, a mechanism is added that can break a previous node.