### PR TITLE
Adds elements to restricted data cache only if cache already exists

### DIFF
--- a/openslides/utils/autoupdate.py
+++ b/openslides/utils/autoupdate.py
@@ -99,7 +99,7 @@ def ws_add_site(message: Any) -> None:
 
                 output.append(formatted_data)
                 # Cache restricted data for user
-                restricted_data_cache.add_element(
+                restricted_data_cache.update_element(
                     user_id,
                     collection.collection_string,
                     data['id'],
@@ -293,7 +293,7 @@ def send_data(message: ChannelMessageFormat) -> None:
         for collection_element in collection_elements:
             formatted_data = collection_element.as_autoupdate_for_user(user)
             if formatted_data['action'] == 'changed':
-                restricted_data_cache.add_element(
+                restricted_data_cache.update_element(
                     user_id or 0,
                     collection_element.collection_string,
                     collection_element.id,

--- a/openslides/utils/cache.py
+++ b/openslides/utils/cache.py
@@ -363,6 +363,17 @@ class RestrictedDataCache:
 
     base_cache_key = 'restricted_user_cache'
 
+    def update_element(self, user_id: int, collection_string: str, id: int, data: object) -> None:
+        """
+        Adds on element to the cache only if the cache exists for the user.
+
+        Note: This method is not atomic. So in very rare cases it is possible
+        that the restricted date cache can become corrupt. The best solution would be to
+        use a lua script instead. See also #3427.
+        """
+        if self.exists_for_user(user_id):
+            self.add_element(user_id, collection_string, id, data)
+
     def add_element(self, user_id: int, collection_string: str, id: int, data: object) -> None:
         """
         Adds one element to the cache. If the cache does not exists for the user,
@@ -412,6 +423,9 @@ class DummyRestrictedDataCache:
     """
     Dummy RestrictedDataCache that does nothing.
     """
+
+    def update_element(self, user_id: int, collection_string: str, id: int, data: object) -> None:
+        pass
 
     def add_element(self, user_id: int, collection_string: str, id: int, data: object) -> None:
         pass


### PR DESCRIPTION
Hotfix for #3427.
Prevents corrupt cache if restricted data cache is cleared while runtime.

Successfully tested with online instance.
@ostcar @FinnStutzenstein Please review.