### PR TITLE
Use native twisted for daphne

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ docs/_build/*
 *.egg-info
 build/*
 dist/*
-debug/
+debug/*
 .DS_Store
 .idea
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -96,6 +96,7 @@ Core:
 - Added 'go to top'-link [#3404].
 - Added caching for the index views [#3419, #3424].
 - Added projector prioritization [#3425].
+- Use native twisted mode for daphne [#3487].
 
 Mediafiles:
 - Fixed reloading of PDF on page change [#3274].

--- a/openslides/asgi.py
+++ b/openslides/asgi.py
@@ -7,3 +7,6 @@ from .utils.main import setup_django_settings_module
 setup_django_settings_module()
 
 channel_layer = get_channel_layer()
+
+# Use native twisted mode
+channel_layer.extensions.append("twisted")

--- a/requirements_big_mode.txt
+++ b/requirements_big_mode.txt
@@ -6,3 +6,4 @@ asgi-redis>=1.3,<1.4
 django-redis>=4.7.0,<4.8
 django-redis-sessions>=0.5.6,<0.6
 psycopg2>=2.7,<2.8
+txredisapi==1.4.4


### PR DESCRIPTION
Currently we are using daphne with a busy loop. We can use native twisted when enabling it. See this code: https://github.com/django/daphne/blob/master/daphne/server.py#L115

Warning: I do not know whether this is an improvement or just another buffer causing a bottleneck. So please DO NOT MERGE. I need to test this. Also I'm unsure about txredisapi. I needed to install this.

Does anyone have some experience using native twisted?

I hope not using a busy loop will raise performance much. On our multi-instance server all daphnes does have *much* cpu time, so they are heavily used. This may chill the server a bit and raise the throughput of daphne.