### PR TITLE
Autoupdate fixes: Bundle autoupdates to save resources and prevent race conditions

### DIFF
--- a/openslides/global_settings.py
+++ b/openslides/global_settings.py
@@ -33,6 +33,7 @@ MIDDLEWARE = [
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'openslides.utils.autoupdate.AutoupdateBundleMiddleware',
 ]
 
 ROOT_URLCONF = 'openslides.urls'

--- a/openslides/motions/views.py
+++ b/openslides/motions/views.py
@@ -13,7 +13,7 @@ from rest_framework import status
 
 from ..core.config import config
 from ..utils.auth import has_perm
-from ..utils.autoupdate import inform_changed_data
+from ..utils.autoupdate import inform_changed_data, bundle_autoupdates
 from ..utils.collection import CollectionElement
 from ..utils.rest_api import (
     DestroyModelMixin,
@@ -149,6 +149,7 @@ class MotionViewSet(ModelViewSet):
         headers = self.get_success_headers(serializer.data)
         return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
 
+    @bundle_autoupdates
     def update(self, request, *args, **kwargs):
         """
         Customized view endpoint to update a motion.
@@ -298,6 +299,7 @@ class MotionViewSet(ModelViewSet):
         return Response({'detail': message})
 
     @detail_route(methods=['put'])
+    @bundle_autoupdates
     def set_state(self, request, pk=None):
         """
         Special view endpoint to set and reset a state of a motion.
@@ -375,6 +377,7 @@ class MotionViewSet(ModelViewSet):
         return Response({'detail': message})
 
     @detail_route(methods=['post'])
+    @bundle_autoupdates
     def create_poll(self, request, pk=None):
         """
         View to create a poll. It is a POST request without any data.

--- a/openslides/motions/views.py
+++ b/openslides/motions/views.py
@@ -13,7 +13,7 @@ from rest_framework import status
 
 from ..core.config import config
 from ..utils.auth import has_perm
-from ..utils.autoupdate import inform_changed_data, bundle_autoupdates
+from ..utils.autoupdate import inform_changed_data
 from ..utils.collection import CollectionElement
 from ..utils.rest_api import (
     DestroyModelMixin,
@@ -149,7 +149,6 @@ class MotionViewSet(ModelViewSet):
         headers = self.get_success_headers(serializer.data)
         return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
 
-    @bundle_autoupdates
     def update(self, request, *args, **kwargs):
         """
         Customized view endpoint to update a motion.
@@ -299,7 +298,6 @@ class MotionViewSet(ModelViewSet):
         return Response({'detail': message})
 
     @detail_route(methods=['put'])
-    @bundle_autoupdates
     def set_state(self, request, pk=None):
         """
         Special view endpoint to set and reset a state of a motion.
@@ -377,7 +375,6 @@ class MotionViewSet(ModelViewSet):
         return Response({'detail': message})
 
     @detail_route(methods=['post'])
-    @bundle_autoupdates
     def create_poll(self, request, pk=None):
         """
         View to create a poll. It is a POST request without any data.

--- a/openslides/utils/autoupdate.py
+++ b/openslides/utils/autoupdate.py
@@ -3,7 +3,7 @@ import time
 import warnings
 from collections import defaultdict
 from contextlib import contextmanager
-from typing import Any, Callable, Dict, Generator, Iterable, List, Tuple, Union
+from typing import Any, Callable, Dict, Generator, Iterable, List, Optional, Tuple, Union
 
 from channels import Channel, Group
 from channels.asgi import get_channel_layer
@@ -311,12 +311,13 @@ def send_data(message: ChannelMessageFormat) -> None:
 
 
 def inform_changed_data(instances: Union[Iterable[Model], Model], information: Dict[str, Any]=None) -> None:
-    print("inform_changed_data")
+    #print("inform_changed_data")
     global blocked_autoupdate_callback
     if blocked_autoupdate_callback is None:
         _inform_changed_data(instances, information)
     else:
         blocked_autoupdate_callback(instances, information)
+
 
 def _inform_changed_data(instances: Union[Iterable[Model], Model], information: Dict[str, Any]=None) -> None:
     """
@@ -391,7 +392,7 @@ def inform_data_collection_element_list(collection_elements: List[CollectionElem
 blocked_autoupdate_callback = None
 
 
-def block_autoupdates(cb: Callable[[Union[Iterable[Model], Model], Dict[str, Any]], None]) -> None:
+def block_autoupdates(cb: Callable[[Union[Iterable[Model], Model], Optional[Dict[str, Any]]], None]) -> None:
     global blocked_autoupdate_callback
     if blocked_autoupdate_callback is None:
         blocked_autoupdate_callback = cb
@@ -410,14 +411,14 @@ def AutoupdateBundle():
     def callback(instances: Union[Iterable[Model], Model], information: Dict[str, Any]=None) -> None:
         if information is None:
             try:
-                _ = iter(instances)
+                _ = iter(instances)  # noqa
             except TypeError:
                 # instances is not iterable.
                 tracked_instances_no_information.add(instances)
             else:
                 tracked_instances_no_information.update(instances)
         else:
-            tracked_instances.add((instances, information))
+            tracked_instances.add((instances, frozenset(information)))
     block_autoupdates(callback)
 
     yield

--- a/openslides/utils/autoupdate.py
+++ b/openslides/utils/autoupdate.py
@@ -402,7 +402,6 @@ def release_autoupdates():
     global blocked_autoupdate_callback
     blocked_autoupdate_callback = None
 
-
 @contextmanager
 def AutoupdateBundle():
     tracked_instances_no_information = set()
@@ -432,12 +431,12 @@ def AutoupdateBundle():
         inform_changed_data(instance, information)
 
 
-def bundle_autoupdates(function):
-    def wrapper(*args, **kwargs):
+def AutoupdateBundleMiddleware(get_response):
+    def middleware(request):
         with AutoupdateBundle():
-            res = function(*args, **kwargs)
-        return res
-    return wrapper
+            response = get_response(request)
+        return response
+    return middleware
 
 
 def send_autoupdate(collection_elements: List[CollectionElement]) -> None:

--- a/tests/integration/motions/test_viewset.py
+++ b/tests/integration/motions/test_viewset.py
@@ -736,6 +736,8 @@ class SupportMotion(TestCase):
     def test_support(self):
         config['motions_min_supporters'] = 1
         response = self.client.post(reverse('motion-support', args=[self.motion.pk]))
+        print(response.data) #??? Disappear if just tests.integration.motions.test_viewset.SupportMotion is run
+        # When running full tests, this error appears.
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data, {'detail': 'You have supported this motion successfully.'})
 


### PR DESCRIPTION
The idea of this pull request has its origins in the following problem: Seeing in #3490 some views send multiple autoupdates for the same model. This causes race condition, because the "right" order of autoupdates is not guaranteed. So one update contains a "wip" like data of the model and the last autoupdate contains the actual ready-processed modeldata. If the order switches, the client gets corrupted data.
The other thing is, that e.g. autoupdates for an item, motion and user are fired. This results in three separate autoupdates. One could simply pack them together and send this one bundle of all changes to the clients. This should improve the performance of big solutions of OpenSlides.

Also seen in the linked PR: Its much work and effort to search all places where this can occur and fix this. I was thinking of a think like `with transaction.atomic():` where all changes are cached and at the end of the block one transaction is fired.

In this PR I try to reach three thinks:
a) Block all autoupdates while the server is in a speacial block of working on the models.
b) After this block, the new logic should have kept track what was changed and send a bundled autoupdate.
c) This should be easy to add to our existing code without changing much (compare to the linked PR)

I'm intrerested in hearing what you think about this approach. If you have another idea for the global variable `blocked_autoupdate_callback` and some other code structure, let me know!

As you see, this covers only `inform_changed_data`. The deleted data and collection element list functions are not implemented yet. This has to be integrated somehow clever.

I do have one problem: For what exactly is this `information` argument for the `inform_*_data` functions? Where is it used and can this be solved somehow else. The goal of the `set()` is to track all modified instances **once**, so they are unique. Whats about two times the same model with different informations, how should this be handled?

@ostcar @normanjaeckel @emanuelschuetze Please have a look at this new approach

Thanks!