### PR TITLE
Template improvements for motions and projector

### DIFF
--- a/openslides/agenda/static/js/agenda/site.js
+++ b/openslides/agenda/static/js/agenda/site.js
@@ -515,12 +515,6 @@ angular.module('OpenSlidesApp.agenda.site', [
                 case 'removeAll':
                     return (operator.hasPerms('agenda.can_manage_list_of_speakers') &&
                             $scope.speakers.length > 0);
-                case 'beginNextSpeech':
-                    return (operator.hasPerms('agenda.can_manage_list_of_speakers') &&
-                            $scope.nextSpeakers.length > 0);
-                case 'endCurrentSpeech':
-                    return (operator.hasPerms('agenda.can_manage_list_of_speakers') &&
-                            $scope.currentSpeaker.length > 0);
                 case 'showLastSpeakers':
                     return $scope.lastSpeakers.length > 0;
             }
@@ -682,7 +676,7 @@ angular.module('OpenSlidesApp.agenda.site', [
             var isProjected = $scope.currentListOfSpeakers.isProjectedWithOverlayStatus();
             $scope.currentListOfSpeakersAsOverlay = isProjected[0].overlay;
         } else {
-            $scope.currentListOfSpeakersAsOverlay = true;
+            $scope.currentListOfSpeakersAsOverlay = false;
         }
         $scope.setOverlay = function (overlay) {
             $scope.currentListOfSpeakersAsOverlay = overlay;

--- a/openslides/agenda/static/templates/agenda/list-of-speakers-partial-management.html
+++ b/openslides/agenda/static/templates/agenda/list-of-speakers-partial-management.html
@@ -22,18 +22,6 @@
       </button>
     </span>
   </div>
-
-  <!-- Start/Stop controls -->
-  <button ng-if="isAllowed('endCurrentSpeech')" ng-click="endSpeech()"
-      class="btn btn-sm btn-default">
-    <i class="fa fa-stop"></i>
-    <translate>End current speech</translate>
-  </button>
-  <button ng-if="isAllowed('beginNextSpeech')" ng-click="beginSpeech()"
-      class="btn btn-sm btn-default">
-    <i class="fa fa-play"></i>
-    <translate>Begin next speech</translate>
-  </button>
 </div>
 
   <!-- text for empty list -->
@@ -44,7 +32,7 @@
   <template-hook hook-name="itemDetailListOfSpeakersButtons"></template-hook>
 
   <!-- Last speakers -->
-  <div class="spacer-top-lg">
+  <div class="spacer-top-lg spacer-bottom">
     <button ng-if="isAllowed('showLastSpeakers')" ng-click="$parent.showOldSpeakers = !$parent.showOldSpeakers"
         class="btn btn-xs btn-default">
       <translate ng-if="!$parent.showOldSpeakers">Last speakers</translate>

--- a/openslides/agenda/static/templates/agenda/partial-slide-current-list-of-speakers.html
+++ b/openslides/agenda/static/templates/agenda/partial-slide-current-list-of-speakers.html
@@ -1,9 +1,13 @@
 <div class="content scrollcontent">
-  <div class="title">
-    <h1 translate>Current list of speakers</h1>
-    <h2> {{ agendaItem.getTitle() }}
-      <span class="slimlabel label label-danger ng-scope"
-        ng-if="agendaItem.speaker_list_closed" translate>Closed</span>
+
+  <!-- Title -->
+  <div id="title">
+    <h1>{{ agendaItem.getTitle() }}</h1>
+    <h2>
+      <span translate>List of speakers</span>
+      <span ng-if="(agendaItem.speakers | filter: {begin_time: null}).length > 0">
+      &ndash; {{ (agendaItem.speakers | filter: {begin_time: null}).length }} <translate>speakers</translate>
+      <span ng-if="agendaItem.speaker_list_closed" class="slimlabel label label-danger" translate>Closed</span>
     </h2>
   </div>
 

--- a/openslides/core/migrations/0002_misc_features.py
+++ b/openslides/core/migrations/0002_misc_features.py
@@ -94,7 +94,7 @@ def add_projection_defaults(apps, schema_editor):
         projector=default_projector))
     projectiondefaults.append(ProjectionDefault(
         name='motionBlocks',
-        display_name='Motion Blocks',
+        display_name='Motion blocks',
         projector=default_projector))
     projectiondefaults.append(ProjectionDefault(
         name='assignments',

--- a/openslides/core/static/css/projector.css
+++ b/openslides/core/static/css/projector.css
@@ -224,17 +224,16 @@ h3 {
     margin-bottom: 5px;
 }
 #motioncontent {
-    width: calc(100% - 260px);
+    width: calc(100% - 230px);
 }
 #sidebox {
     width: 260px;
-    float: right;
-    margin: 75px -50px 20px 10px;
     right: 0;
+    margin-top: 75px;
     background: #d3d3d3;
     border-radius: 7px 0 0 7px;
     padding: 3px 7px 10px 19px;
-    position: absolute;
+    position: fixed;
     z-index: 5;
 }
 #sidebox h3 {
@@ -595,12 +594,15 @@ p.os-split-after {
 }
 .motion-block > div {
     width: 50%;
+    font-size: 1.1em;
     margin-bottom: 15px;
     padding-right: 15px;
     line-height: 1em;
 }
 .motion-block .label {
     text-align: left;
+    padding: 5px 10px;
+    margin-top: 3px;
 }
 
 /*** Video and Image projection ***/

--- a/openslides/motions/static/templates/motions/motion-detail.html
+++ b/openslides/motions/static/templates/motions/motion-detail.html
@@ -139,7 +139,7 @@
 
           <div ng-if="motion.isAllowed('can_see_amendments')">
             <h3 translate>Amendments</h3>
-            <div ng-repeat="amendment in amendments">
+            <div ng-repeat="amendment in amendments | orderBy: 'identifier'">
               <a ui-sref="motions.motion.detail({id: amendment.id})">
                 <translate>Motion</translate> {{ amendment.identifier || amendment.getTitle() }}
               </a>

--- a/openslides/motions/static/templates/motions/slide_motion.html
+++ b/openslides/motions/static/templates/motions/slide_motion.html
@@ -1,4 +1,4 @@
-<div ng-controller="SlideMotionCtrl" class="content scrollcontent">
+<div ng-controller="SlideMotionCtrl" class="content">
   <div id="sidebox">
     <!-- State -->
     <h3 translate>State</h3>
@@ -65,7 +65,7 @@
       </div>
   </div>
 
-  <div id="motioncontent">
+  <div id="motioncontent" class="scrollcontent">
     <!-- Title -->
     <div id="title">
       <h1>{{  motion.getTitle() }}</h1>

--- a/openslides/motions/static/templates/motions/slide_motion_block.html
+++ b/openslides/motions/static/templates/motions/slide_motion_block.html
@@ -10,11 +10,9 @@
     <div ng-repeat="motion in motionBlock.motions">
       {{ motion.identifier }}
       <br>
-      <small>
-        <span class="label" ng-class="'label-'+motion.recommendation.css_class">
-              {{ motion.getRecommendationName() }}
-        </span>
-      </small>
+      <span class="label" ng-class="'label-'+motion.recommendation.css_class">
+        {{ motion.getRecommendationName() }}
+      </span>
     </div>
   </div>
 </div>


### PR DESCRIPTION
- Use same title layout for (current) list of speakers slide.
- Set default choose for current list of speakers slide to 'project as slide'
  if more than one projectors available.
- Remove additional control bottons in list of speakers view to stop/end current/next speech.
  (User should better use the start/stop buttons behind the speaker names.)
- Fix typo in projection defaults.
- Set sidebox in motion slide to fix position (should not scroll).
- Fix order of amendments in motion detail template.
- Increase font size of motion block items on slide.