### PR TITLE
Support voting Plugin with weighted votes [WIP]

### DIFF
--- a/openslides/locale/angular-gettext/template-en.pot
+++ b/openslides/locale/angular-gettext/template-en.pot
@@ -2517,11 +2517,11 @@ msgid "Quorum ({{ option.getVoteYes() - option.majorityReached }}) reached."
 msgstr ""
 
 #: motions/static/templates/motions/motion-detail.html:450
-msgid "Quorum ({{ voteYes.value - isReached() }}) not reached."
+msgid "Quorum ({{ (voteYes.value - isReached()) | number:precision }}) not reached."
 msgstr ""
 
 #: motions/static/templates/motions/motion-detail.html:447
-msgid "Quorum ({{ voteYes.value - isReached() }}) reached."
+msgid "Quorum ({{ (voteYes.value - isReached()) | number:precision }}) reached."
 msgstr ""
 
 #: motions/static/js/motions/docx.js:95

--- a/openslides/motions/projector.py
+++ b/openslides/motions/projector.py
@@ -1,5 +1,6 @@
 from typing import Generator, Type
 
+from ..core.models import Tag
 from ..core.exceptions import ProjectorException
 from ..utils.projector import ProjectorElement
 from .models import Motion, MotionBlock, MotionChangeRecommendation, Workflow
@@ -28,6 +29,7 @@ class MotionSlide(ProjectorElement):
             yield from motion.submitters.all()
             yield from motion.supporters.all()
             yield from MotionChangeRecommendation.objects.filter(motion_version=motion.get_active_version().id)
+            yield from Tag.objects.all()
 
     def get_collection_elements_required_for_this(self, collection_element, config_entry):
         output = super().get_collection_elements_required_for_this(collection_element, config_entry)

--- a/openslides/motions/serializers.py
+++ b/openslides/motions/serializers.py
@@ -8,6 +8,7 @@ from ..utils.rest_api import (
     CharField,
     DictField,
     Field,
+    FloatField,
     IntegerField,
     ModelSerializer,
     PrimaryKeyRelatedField,
@@ -142,7 +143,7 @@ class MotionPollSerializer(ModelSerializer):
     no = SerializerMethodField()
     abstain = SerializerMethodField()
     votes = DictField(
-        child=IntegerField(min_value=-2, allow_null=True),
+        child=FloatField(min_value=-2, allow_null=True),
         write_only=True)
     has_votes = SerializerMethodField()
 

--- a/openslides/motions/static/js/motions/base.js
+++ b/openslides/motions/static/js/motions/base.js
@@ -922,12 +922,49 @@ angular.module('OpenSlidesApp.motions', [
     }
 ])
 
+.factory('VotingPrinciple', [
+    'Tag',
+    function (Tag) {
+        return {
+            getName: function (value) {
+                // voting principle format: 'name.precision'.
+                var name = typeof value == 'number' ? Tag.get(value).name : value,
+                    i = name.lastIndexOf('.');
+                if (i >= 0) {
+                    return name.substr(0, i);
+                }
+                return name;
+            },
+            getPrecision: function (value) {
+                // voting principle format: 'name.precision'. Max. precision is 6.
+                if (value) {
+                    var name = typeof value == 'number' ? Tag.get(value).name : value,
+                        i = name.lastIndexOf('.');
+                    if (i >= 0) {
+                        var precision = parseInt(name.substr(i + 1));
+                        if (!isNaN(precision) && precision > 0) {
+                            return Math.min(6, precision);
+                        }
+                    }
+                }
+                return 0;
+            },
+            getStep: function (value) {
+                // Step between two values based on precision: 1, 0.1, 0.01 etc.
+                var precision = this.getPrecision(value);
+                return Math.pow(10, -precision);
+            }
+        };
+    }
+])
+
 .run([
     'Motion',
     'Category',
+    'Tag',
     'Workflow',
     'MotionChangeRecommendation',
-    function(Motion, Category, Workflow, MotionChangeRecommendation) {}
+    function(Motion, Category, Tag, Workflow, MotionChangeRecommendation) {}
 ])
 
 

--- a/openslides/motions/static/js/motions/pdf.js
+++ b/openslides/motions/static/js/motions/pdf.js
@@ -6,6 +6,7 @@ angular.module('OpenSlidesApp.motions.pdf', ['OpenSlidesApp.core.pdf'])
 
 .factory('MotionContentProvider', [
     '$q',
+    '$filter',
     'operator',
     'gettextCatalog',
     'PDFLayout',
@@ -16,8 +17,9 @@ angular.module('OpenSlidesApp.motions.pdf', ['OpenSlidesApp.core.pdf'])
     'Config',
     'Motion',
     'MotionComment',
-    function($q, operator, gettextCatalog, PDFLayout, PdfMakeConverter, ImageConverter, HTMLValidizer,
-        Category, Config, Motion, MotionComment) {
+    'VotingPrinciple',
+    function($q, $filter, operator, gettextCatalog, PDFLayout, PdfMakeConverter, ImageConverter, HTMLValidizer,
+        Category, Config, Motion, MotionComment, VotingPrinciple) {
         /**
          * Provides the content as JS objects for Motions in pdfMake context
          * @constructor
@@ -171,6 +173,7 @@ angular.module('OpenSlidesApp.motions.pdf', ['OpenSlidesApp.core.pdf'])
 
                 // voting result
                 if (params.include.votingresult && motion.polls.length > 0 && motion.polls[0].has_votes) {
+                    var precision = VotingPrinciple.getPrecision(motion.tags[0]);
                     var column1 = [];
                     var column2 = [];
                     var column3 = [];
@@ -185,37 +188,37 @@ angular.module('OpenSlidesApp.motions.pdf', ['OpenSlidesApp.core.pdf'])
                             // yes
                             var yes = poll.getVote(poll.yes, 'yes');
                             column1.push(gettextCatalog.getString('Yes') + ':');
-                            column2.push(yes.value);
+                            column2.push($filter('number')(yes.value, precision));
                             column3.push(yes.percentStr);
                             // no
                             var no = poll.getVote(poll.no, 'no');
                             column1.push(gettextCatalog.getString('No') + ':');
-                            column2.push(no.value);
+                            column2.push($filter('number')(no.value, precision));
                             column3.push(no.percentStr);
                             // abstain
                             var abstain = poll.getVote(poll.abstain, 'abstain');
                             column1.push(gettextCatalog.getString('Abstain') + ':');
-                            column2.push(abstain.value);
+                            column2.push($filter('number')(abstain.value, precision));
                             column3.push(abstain.percentStr);
                             // votes valid
                             if (poll.votesvalid) {
                                 var valid = poll.getVote(poll.votesvalid, 'votesvalid');
                                 column1.push(gettextCatalog.getString('Valid votes') + ':');
-                                column2.push(valid.value);
+                                column2.push($filter('number')(valid.value, precision));
                                 column3.push(valid.percentStr);
                             }
                             // votes invalid
                             if (poll.votesvalid) {
                                 var invalid = poll.getVote(poll.votesinvalid, 'votesinvalid');
                                 column1.push(gettextCatalog.getString('Invalid votes') + ':');
-                                column2.push(invalid.value);
+                                column2.push($filter('number')(invalid.value, precision));
                                 column3.push(invalid.percentStr);
                             }
                             // votes cast
                             if (poll.votescast) {
                                 var cast = poll.getVote(poll.votescast, 'votescast');
                                 column1.push(gettextCatalog.getString('Votes cast') + ':');
-                                column2.push(cast.value);
+                                column2.push($filter('number')(cast.value, precision));
                                 column3.push(cast.percentStr);
                             }
                         }

--- a/openslides/motions/static/js/motions/projector.js
+++ b/openslides/motions/static/js/motions/projector.js
@@ -21,14 +21,20 @@ angular.module('OpenSlidesApp.motions.projector', [
     'Motion',
     'MotionChangeRecommendation',
     'User',
-    function($scope, Motion, MotionChangeRecommendation, User) {
+    'VotingPrinciple',
+    function($scope, Motion, MotionChangeRecommendation, User, VotingPrinciple) {
         // Attention! Each object that is used here has to be dealt on server side.
         // Add it to the coresponding get_requirements method of the ProjectorElement
         // class.
         var id = $scope.element.id;
         $scope.mode = $scope.element.mode || 'original';
 
-        Motion.bindOne(id, $scope, 'motion');
+        $scope.$watch(function () {
+            return Motion.lastModified(id);
+        }, function () {
+            $scope.motion = Motion.get(id);
+            $scope.precision = VotingPrinciple.getPrecision($scope.motion.tags[0]);
+        });
         User.bindAll({}, $scope, 'users');
         MotionChangeRecommendation.bindAll({
             where: {

--- a/openslides/motions/static/js/motions/site.js
+++ b/openslides/motions/static/js/motions/site.js
@@ -565,7 +565,7 @@ angular.module('OpenSlidesApp.motions.site', [
     'gettextCatalog',
     function (gettextCatalog) {
         return {
-            getFormFields: function () {
+            getFormFields: function (step) {
                 return [
                 {
                     key: 'yes',
@@ -573,7 +573,8 @@ angular.module('OpenSlidesApp.motions.site', [
                     templateOptions: {
                         label: gettextCatalog.getString('Yes'),
                         type: 'number',
-                        required: true
+                        required: true,
+                        step: step
                     }
                 },
                 {
@@ -582,7 +583,8 @@ angular.module('OpenSlidesApp.motions.site', [
                     templateOptions: {
                         label: gettextCatalog.getString('No'),
                         type: 'number',
-                        required: true
+                        required: true,
+                        step: step
                     }
                 },
                 {
@@ -591,7 +593,8 @@ angular.module('OpenSlidesApp.motions.site', [
                     templateOptions: {
                         label: gettextCatalog.getString('Abstain'),
                         type: 'number',
-                        required: true
+                        required: true,
+                        step: step
                     }
                 },
                 {
@@ -599,7 +602,8 @@ angular.module('OpenSlidesApp.motions.site', [
                     type: 'input',
                     templateOptions: {
                         label: gettextCatalog.getString('Valid votes'),
-                        type: 'number'
+                        type: 'number',
+                        step: step
                     }
                 },
                 {
@@ -607,7 +611,8 @@ angular.module('OpenSlidesApp.motions.site', [
                     type: 'input',
                     templateOptions: {
                         label: gettextCatalog.getString('Invalid votes'),
-                        type: 'number'
+                        type: 'number',
+                        step: step
                     }
                 },
                 {
@@ -615,7 +620,8 @@ angular.module('OpenSlidesApp.motions.site', [
                     type: 'input',
                     templateOptions: {
                         label: gettextCatalog.getString('Votes cast'),
-                        type: 'number'
+                        type: 'number',
+                        step: step
                     }
                 }];
             }
@@ -920,7 +926,8 @@ angular.module('OpenSlidesApp.motions.site', [
     'MajorityMethodChoices',
     'Config',
     'MotionPollDetailCtrlCache',
-    function ($scope, MajorityMethodChoices, Config, MotionPollDetailCtrlCache) {
+    'VotingPrinciple',
+    function ($scope, MajorityMethodChoices, Config, MotionPollDetailCtrlCache, VotingPrinciple) {
         // Define choices.
         $scope.methodChoices = MajorityMethodChoices;
         // TODO: Get $scope.baseChoices from config_variables.py without copying them.
@@ -944,6 +951,8 @@ angular.module('OpenSlidesApp.motions.site', [
         $scope.hideMajorityCalculation = function () {
             return typeof $scope.isReached() === 'undefined' && $scope.method !== 'disabled';
         };
+
+        $scope.precision = VotingPrinciple.getPrecision($scope.poll.motion.category_id);
 
         // Save current values to cache on detroy of this controller.
         $scope.$on('$destroy', function() {
@@ -2058,17 +2067,20 @@ angular.module('OpenSlidesApp.motions.site', [
     'gettextCatalog',
     'MotionPoll',
     'MotionPollForm',
+    'VotingPrinciple',
     'motionpollId',
     'voteNumber',
     'ErrorMessage',
-    function($scope, gettextCatalog, MotionPoll, MotionPollForm, motionpollId,
+    function($scope, gettextCatalog, MotionPoll, MotionPollForm, VotingPrinciple, motionpollId,
         voteNumber, ErrorMessage) {
         // set initial values for form model by create deep copy of motionpoll object
         // so detail view is not updated while editing poll
         var motionpoll = MotionPoll.get(motionpollId);
         $scope.model = angular.copy(motionpoll);
         $scope.voteNumber = voteNumber;
-        $scope.formFields = MotionPollForm.getFormFields();
+        $scope.formFields = MotionPollForm.getFormFields(
+            VotingPrinciple.getStep(motionpoll.motion.tags[0])
+        );
         $scope.alert = {};
 
         // save motionpoll

--- a/openslides/motions/static/templates/motions/motion-detail.html
+++ b/openslides/motions/static/templates/motions/motion-detail.html
@@ -370,7 +370,7 @@
                     <td ng-init="voteYes = poll.getVote(poll.yes, 'yes')">
                       <span class="result-label"><translate>Yes</translate>:</span>
                       <span class="result_value">
-                        {{ voteYes.value }} {{ voteYes.percentStr }}
+                        {{ voteYes.value | number:precision }} {{ voteYes.percentStr }}
                       </span>
                       <div ng-if="voteYes.percentNumber">
                         <uib-progressbar value="voteYes.percentNumber" type="success"></uib-progressbar>
@@ -382,7 +382,7 @@
                     <td ng-init="voteNo = poll.getVote(poll.no, 'no')">
                       <span class="result-label"><translate>No</translate>:</span>
                       <span class="result_value" >
-                        {{ voteNo.value }} {{ voteNo.percentStr }}
+                        {{ voteNo.value | number:precision }} {{ voteNo.percentStr }}
                       </span>
                       <div ng-if="voteNo.percentNumber">
                         <uib-progressbar value="voteNo.percentNumber" type="danger"></uib-progressbar>
@@ -394,7 +394,7 @@
                     <td ng-init="voteAbstain = poll.getVote(poll.abstain, 'abstain')">
                       <span class="result-label"><translate>Abstain</translate>:</span>
                       <span class="result_value">
-                        {{ voteAbstain.value }} {{ voteAbstain.percentStr }}
+                        {{ voteAbstain.value | number:precision }} {{ voteAbstain.percentStr }}
                       </span>
                       <div ng-if="voteAbstain.percentNumber">
                         <uib-progressbar value="voteAbstain.percentNumber" type="warning"></uib-progressbar>
@@ -406,7 +406,7 @@
                     <td ng-init="votesValid = poll.getVote(poll.votesvalid, 'votesvalid')">
                       <span class="result-label"><translate>Valid votes</translate>:</span>
                       <span class="result_value">
-                        {{ votesValid.value }} {{ votesValid.percentStr }}
+                        {{ votesValid.value | number:precision }} {{ votesValid.percentStr }}
                       </span>
                   <!-- invalid votes -->
                   <tr ng-if="poll.votesinvalid !== null">
@@ -415,7 +415,7 @@
                     <td ng-init="votesInvalid = poll.getVote(poll.votesinvalid, 'votesinvalid')">
                       <span class="result-label"><translate>Invalid votes</translate>:</span>
                       <span class="result_value">
-                        {{ votesInvalid.value }} {{ votesInvalid.percentStr }}
+                        {{ votesInvalid.value | number:precision }} {{ votesInvalid.percentStr }}
                       </span>
                   <!-- votes cast -->
                   <tr class="total" ng-if="poll.votescast !== null">
@@ -424,7 +424,7 @@
                     <td ng-init="votesCast = poll.getVote(poll.votescast, 'votescast')">
                       <span class="result-label"><translate>Votes cast</translate>:</span>
                       <span class="result_value">
-                        {{ votesCast.value }} {{ votesCast.percentStr }}
+                        {{ votesCast.value | number:precision }} {{ votesCast.percentStr }}
                       </span>
 
                   <!-- majority calculation -->
@@ -445,10 +445,10 @@
                     <td>
                       <div os-perms="motions.can_manage">
                         <span class="text-success" ng-if="isReached() >= 0" translate>
-                          Quorum ({{ voteYes.value - isReached() }}) reached.
+                          Quorum ({{ (voteYes.value - isReached()) | number:precision }}) reached.
                         </span>
                         <span class="text-danger" ng-if="isReached() < 0" translate>
-                          Quorum ({{ voteYes.value - isReached() }}) not reached.
+                          Quorum ({{ (voteYes.value - isReached()) | number:precision }}) not reached.
                        </span>
                       </div>
 

--- a/openslides/motions/static/templates/motions/slide_motion.html
+++ b/openslides/motions/static/templates/motions/slide_motion.html
@@ -31,7 +31,7 @@
               <td ng-init="voteYes = poll.getVote(poll.yes, 'yes')">
                 <span class="result_label"><translate>Yes</translate>:</span>
                 <span class="result_value">
-                  {{ voteYes.value }} {{ voteYes.percentStr }}
+                  {{ voteYes.value | number:precision }} {{ voteYes.percentStr }}
                 </span>
                 <div ng-if="voteYes.percentNumber">
                   <uib-progressbar value="voteYes.percentNumber" type="success"></uib-progressbar>
@@ -43,7 +43,7 @@
               <td ng-init="voteNo = poll.getVote(poll.no, 'no')">
                 <span class="result_label"><translate>No</translate>:</span>
                 <span class="result_value" >
-                  {{ voteNo.value }} {{ voteNo.percentStr }}
+                  {{ voteNo.value | number:precision }} {{ voteNo.percentStr }}
                 </span>
                 <div ng-if="voteNo.percentNumber">
                   <uib-progressbar value="voteNo.percentNumber" type="danger"></uib-progressbar>
@@ -55,7 +55,7 @@
               <td ng-init="voteAbstain = poll.getVote(poll.abstain, 'abstain')">
                 <span class="result_label"><translate>Abstain</translate>:</span>
                 <span class="result_value">
-                  {{ voteAbstain.value }} {{ voteAbstain.percentStr }}
+                  {{ voteAbstain.value | number:precision }} {{ voteAbstain.percentStr }}
                 </span>
                 <div ng-if="voteAbstain.percentNumber">
                   <uib-progressbar value="voteAbstain.percentNumber" type="warning"></uib-progressbar>

--- a/openslides/poll/models.py
+++ b/openslides/poll/models.py
@@ -44,7 +44,7 @@ class BaseVote(models.Model):
     Subclasses have to define an option field. This must be a ForeignKeyField
     to a subclass of BasePoll.
     """
-    weight = models.IntegerField(default=1, null=True)  # Use MinMaxIntegerField
+    weight = models.FloatField(default=1, null=True, blank=True)
     value = models.CharField(max_length=255, null=True)
 
     class Meta:
@@ -72,9 +72,9 @@ class CollectDefaultVotesMixin(models.Model):
     Mixin for a poll to collect the default vote values for valid votes,
     invalid votes and votes cast.
     """
-    votesvalid = MinMaxIntegerField(null=True, blank=True, min_value=-2)
-    votesinvalid = MinMaxIntegerField(null=True, blank=True, min_value=-2)
-    votescast = MinMaxIntegerField(null=True, blank=True, min_value=-2)
+    votesvalid = models.FloatField(null=True, blank=True)
+    votesinvalid = models.FloatField(null=True, blank=True)
+    votescast = models.FloatField(null=True, blank=True)
 
     class Meta:
         abstract = True

--- a/openslides/utils/rest_api.py
+++ b/openslides/utils/rest_api.py
@@ -17,6 +17,7 @@ from rest_framework.serializers import (  # noqa
     DictField,
     Field,
     FileField,
+    FloatField,
     IntegerField,
     JSONField,
     ListField,


### PR DESCRIPTION
These changes are requested to allow a Voting plugin to use voting principles (categories of voting shares). A typical application is an owners meeting ("Eigentümerversammlungen") which might use two voting principles: (1) Property shares ("Eigentumsanteile") and (2) Objects (e. g. number of apartments owned).

For certain motions principle (1) will be used, for other motions principle (2) will be used. In either case an owner's vote is a _weighted vote_. For example: Hans Schmidt has (1) 150 property shares owning (2) 3 apartments.
