### PR TITLE
Diff-Bugfix: Whitespace was inserted after <br>

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -38,7 +38,7 @@ Motions:
 - Bugfix: Several bugfixes regarding splitting list items in
   change recommendations [#3288].
 - Bugfix: Several bugfixes regarding diff version [#3407, #3408, #3410,
-  #3440, #3450, #3465, #3537, #3546].
+  #3440, #3450, #3465, #3537, #3546, #3548].
 - Added inline Editing for motion reason [#3361].
 - Added multiselect filter for motion comments [#3372].
 - Added support for pinning personal notes to the window [#3360].

--- a/openslides/motions/static/js/motions/diff.js
+++ b/openslides/motions/static/js/motions/diff.js
@@ -675,6 +675,9 @@ angular.module('OpenSlidesApp.motions.diff', ['OpenSlidesApp.motions.lineNumberi
             for (var ent in entities) {
                 html = html.replace(new RegExp(ent, 'g'), entities[ent]);
             }
+
+            // Newline characters: after closing block-level-elements, but not after BR (which is inline)
+            html = html.replace(/(<br *\/?>)\n/gi, "$1");
             html = html.replace(/[ \n\t]+/gi, ' ');
             html = html.replace(/(<\/(div|p|ul|li|blockquote>)>) /gi, "$1\n");
 

--- a/tests/karma/motions/diff.service.test.js
+++ b/tests/karma/motions/diff.service.test.js
@@ -423,6 +423,14 @@ describe('linenumbering', function () {
       expect(diff).toBe('The <strong>brown</strong> spotted fox <del>jum</del><ins>lea</ins>ped over the rolling log.');
     });
 
+    it('does not insert spaces after a unchanged BR tag', function() {
+      var before = "<p>" + noMarkup(1) + "Hendl Kirwa hod Maßkruag<br>" + noMarkup(2) + "gmahde Wiesn</p>",
+          after = "<p>Hendl Kirwa hod Maßkruag<br>\ngmahde Wiesn</p>";
+      var diff = diffService.diff(before, after);
+
+      expect(diff).toBe(before);
+    });
+
     it('does not mark the last line of a paragraph as change if a long new one is appended', function () {
       var before = "<p><span class=\"os-line-number line-number-5\" data-line-number=\"5\" contenteditable=\"false\">&nbsp;</span>Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</p>",
             after = "<p>Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</p>\n" +
@@ -534,7 +542,7 @@ describe('linenumbering', function () {
           after = "<p>sem. Nulla consequat massa quis enim. TEST<br>\nTEST</p>";
       var diff = diffService.diff(before, after);
 
-      expect(diff).toBe('<p>sem. Nulla consequat massa quis enim.<ins> TEST<br> TEST</ins></p>');
+      expect(diff).toBe('<p>sem. Nulla consequat massa quis enim.<ins> TEST<br>TEST</ins></p>');
     });
 
     it('does not repeat the last word (2)', function () {


### PR DESCRIPTION
Bugfix for the PDF-Problem reported by @emanuelschuetze (inserted empty characters).
This change proposes to remove \n characters (and potentially all whitespace characters) following a \<br\>.