### PR TITLE
Save default password with createopenslidesuser command.

### DIFF
--- a/openslides/users/management/commands/createopenslidesuser.py
+++ b/openslides/users/management/commands/createopenslidesuser.py
@@ -35,6 +35,7 @@ class Command(BaseCommand):
         user_data = {
             'first_name': options['first_name'],
             'last_name': options['last_name'],
+            'default_password': options['password'],
         }
         user = User.objects.create_user(options['username'], options['password'], **user_data)
         if options['groups_id'].isdigit():


### PR DESCRIPTION
Command is used by OpenSlides manager to create local admin user. For the send-password-by-email-feature we need the default password.