### PR TITLE
Patch userdetails without redundant declaration of users details

### DIFF
--- a/openslides/users/serializers.py
+++ b/openslides/users/serializers.py
@@ -57,18 +57,22 @@ class UserFullSerializer(ModelSerializer):
 
     def validate(self, data):
         """
-        Checks that first_name or last_name is given. Generates the
+        Checks if the given data is empty. Generates the
         username if it is empty.
         """
-        if not (data.get('username') or data.get('first_name') or data.get('last_name')):
-            raise ValidationError({'detail': _('Username, given name and surname can not all be empty.')})
 
-        # Generate username. But only if it is not set and the serializer is not
-        # called in a PATCH context (partial_update).
         try:
             action = self.context['view'].action
         except (KeyError, AttributeError):
             action = None
+
+        # Check if we are in Patch context, if not, check if we have the mandatory fields
+        if action != 'partial_update':
+            if not (data.get('username') or data.get('first_name') or data.get('last_name')):
+                raise ValidationError({'detail': _('Username, given name and surname can not all be empty.')})
+
+        # Generate username. But only if it is not set and the serializer is not
+        # called in a PATCH context (partial_update).
 
         if not data.get('username') and action != 'partial_update':
             data['username'] = User.objects.generate_username(


### PR DESCRIPTION
Before this patch you'd have to send either the username, first_name or last_name with any given PATCH request to a user, even though you know his unique identifier: The User ID.

After this patch you just have to send any details and you can update the user information with just the knowledge of the users ID. This simplifies user information updates significantly, because you don't have to GET all information beforehand, if you just want to update one users details. Especially when an 3rd party system manages the users; it just has to map their user information to the ID in OpenSlides without any additional knowledge and is then able to update the users information.

Additionally: The mechanism in place was a bit awkward with patches: If you send, i.e. an update for the title and an update for the username, it changed both; therefore the requirement for having the username there in first place, is redundant and ineffective for a double-check; therefore I updated the check in a way that at least some information has to be in place, if you want to update a given user.