### PR TITLE
Updating requirements and locking versions

### DIFF
--- a/requirements_big_mode.txt
+++ b/requirements_big_mode.txt
@@ -2,8 +2,8 @@
 -r requirements_production.txt
 
 # Requirements for Redis and PostgreSQL support
-asgi-redis>=1.3,<1.4
-django-redis>=4.7.0,<4.8
+asgi-redis>=1.3,<1.5
+django-redis>=4.7.0,<4.9
 django-redis-sessions>=0.5.6,<0.6
-psycopg2>=2.7,<2.8
+psycopg2-binary>=2.7,<2.8
 txredisapi==1.4.4

--- a/requirements_production.txt
+++ b/requirements_production.txt
@@ -1,10 +1,11 @@
 # Requirements for OpenSlides in production in alphabetical order
-bleach>=1.5.0,<1.6
+bleach>=1.5.0,<2.2
 channels>=1.1,<1.2
+daphne<2
 Django>=1.10.4,<1.11
 djangorestframework>=3.4,<3.5
-jsonfield>=1.0,<1.1
-mypy_extensions>=0.3,<1.1
+jsonfield>=1.0,<2.1
+mypy_extensions>=0.3,<0.4
 PyPDF2>=1.26,<1.27
 roman>=2.0,<2.1
-setuptools>=29.0,<35.0
+setuptools>=29.0,<39.0


### PR DESCRIPTION
Updating the versions (#3522) of  the requirements and locking channels and daphne, because it would break OpenSlides otherwise (#3574).

Also renaming psycopg2 to psycopg2-binary (#3572) to avoid further issues caused by the upcomming renaming.