### PR TITLE
Downgrade angular-pdf to 1.3.0 (Fixed #3552).

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "angular-formly-templates-bootstrap": "~6.2.0",
     "angular-gettext": "~2.3.7",
     "angular-messages": "~1.5.8",
-    "angular-pdf": "~1.3.0",
+    "angular-pdf": "1.3.0",
     "angular-sanitize": "~1.5.8",
     "angular-scroll-glue": "~2.0.7",
     "angular-ui-router": "~0.3.1",


### PR DESCRIPTION
using pdfjs-dist#1.3.100
angular-pdf 1.3.1 does not work in Firefox with PDF documents >127kb.