### PR TITLE
Change recommendations for motion titles

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,7 @@ Agenda:
 Motions:
 - New export dialog [#3185].
 - New feature: Personal notes for motions [#3190, #3267, #3404].
+- New feature: Change recommendations for the title of a motion [#3626].
 - Fixed issue when creating/deleting motion comment fields in the
   settings [#3187].
 - Fixed empty motion comment field in motion update form [#3194].

--- a/openslides/motions/serializers.py
+++ b/openslides/motions/serializers.py
@@ -280,8 +280,12 @@ class MotionChangeRecommendationSerializer(ModelSerializer):
             'text',
             'creation_time',)
 
+    def is_title_cr(self, data):
+        return int(data['line_from']) == 0 and int(data['line_to']) == 0
+
     def validate(self, data):
-        if 'text' in data:
+        # Change recommendations for titles are stored as plain-text, thus they don't need to be html-escaped
+        if 'text' in data and not self.is_title_cr(data):
             data['text'] = validate_html(data['text'])
         return data
 

--- a/openslides/motions/static/css/motions/_change-recommendation-overview.scss
+++ b/openslides/motions/static/css/motions/_change-recommendation-overview.scss
@@ -4,7 +4,7 @@
     border-radius: 3px;
     margin-bottom: 5px;
     margin-top: -15px;
-    padding-top: 5px;
+    padding: 5px 5px 0 5px;
 
     h3 {
         margin-top: 10px;

--- a/openslides/motions/static/css/motions/_site.scss
+++ b/openslides/motions/static/css/motions/_site.scss
@@ -106,16 +106,12 @@
     left: 20px;
 }
 
-.line-numbers-outside .os-line-number.selectable:hover:before, .line-numbers-outside .os-line-number.selected:before {
+@mixin addChangeRecommendationBtn {
     cursor: pointer;
     content: "\f067";
-    display: inline-block;
-    position: absolute;
     width: 14px;
     height: 14px;
     border-radius: 0.25em;
-    top: 4px;
-    left: 43px;
     font-family: FontAwesome;
     font-size: 12px;
     color: white;
@@ -123,6 +119,55 @@
     text-align: center;
     background-color: #337ab7;
 }
+
+.line-numbers-outside .os-line-number.selectable:hover:before, .line-numbers-outside .os-line-number.selected:before {
+    position: absolute;
+    top: 4px;
+    left: 43px;
+    display: inline-block;
+    @include addChangeRecommendationBtn();
+}
+
+.motion-header {
+  .submenu {
+    position: relative;
+    z-index: 2;
+  }
+  .motion-title {
+    position: relative;
+    z-index: 1;
+
+    // Grab the left padding of the parent element to catch hover-events for the :before element
+    margin-left: -20px;
+    padding-left: 20px;
+
+    .change-title {
+        position: relative;
+        width: 0;
+        height: 0;
+    }
+    .change-title:before {
+        position: absolute;
+        top: 18px;
+        left: -17px;
+        @include addChangeRecommendationBtn();
+        display: none;
+    }
+    &:hover .change-title.selectable:before {
+        display: block;
+    }
+    .title-change-indicator {
+        background-color: #0333ff;
+        position: absolute;
+        width: 4px;
+        height: 32px;
+        left: 10px;
+        top: 5px;
+        cursor: pointer;
+    }
+  }
+}
+
 
 .tt_change_recommendation_create_help {
     display: none;
@@ -187,6 +232,13 @@
         & > *:after {
             content: ':';
         }
+    }
+}
+
+.diff-box-title {
+    margin-bottom: 10px;
+    .description {
+        font-weight: bold;
     }
 }
 

--- a/openslides/motions/static/js/motions/docx.js
+++ b/openslides/motions/static/js/motions/docx.js
@@ -49,7 +49,7 @@ angular.module('OpenSlidesApp.motions.docx', ['OpenSlidesApp.core.docx'])
 
             // motions
             data.tableofcontents_translation = gettextCatalog.getString('Table of contents');
-            data.motions_list = getMotionShortData(motions);
+            data.motions_list = getMotionShortData(motions, params);
             data.no_motions = gettextCatalog.getString('No motions available.');
 
             return $q(function (resolve) {
@@ -77,11 +77,11 @@ angular.module('OpenSlidesApp.motions.docx', ['OpenSlidesApp.core.docx'])
             return _.orderBy(categories, [sortKey]);
         };
 
-        var getMotionShortData = function (motions) {
+        var getMotionShortData = function (motions, params) {
             return _.map(motions, function (motion) {
                 return {
                     identifier: motion.identifier || '',
-                    title: motion.getTitle(),
+                    title: motion.getTitleWithChanges(params.changeRecommendationMode),
                 };
             });
         };
@@ -97,6 +97,7 @@ angular.module('OpenSlidesApp.motions.docx', ['OpenSlidesApp.core.docx'])
             var sequential_enabled = Config.get('motions_export_sequential_number').value;
             // promises for create the actual motion data
             var promises = _.map(motions, function (motion) {
+                var title = motion.getTitleWithChanges(params.changeRecommendationMode);
                 var text = params.include.text ? motion.getTextByMode(params.changeRecommendationMode, null, null, false) : '';
                 var reason = params.include.reason ? motion.getReason() : '';
                 var comments = getMotionComments(motion, params.includeComments);
@@ -114,7 +115,7 @@ angular.module('OpenSlidesApp.motions.docx', ['OpenSlidesApp.core.docx'])
                     // Actual data
                     id: motion.id,
                     identifier: motion.identifier || '',
-                    title: motion.getTitle(),
+                    title: title,
                     submitters: params.include.submitters ?  _.map(motion.submitters, function (submitter) {
                                     return submitter.get_full_name();
                                 }).join(', ') : '',

--- a/openslides/motions/static/templates/motions/motion-detail.html
+++ b/openslides/motions/static/templates/motions/motion-detail.html
@@ -1,4 +1,4 @@
-<div class="header">
+<div class="header motion-header">
   <div class="title">
     <div class="submenu">
       <a ui-sref="motions.motion.list" class="btn btn-sm btn-default">
@@ -59,13 +59,22 @@
         <translate>PDF</translate>
       </a>
     </div>
-    <h1>
-      {{ motion.getTitle() }}
-      <i class="fa pointer" ng-class="motion.personalNote.star ? 'fa-star' : 'fa-star-o'"
-        ng-if="operator.user"
-        title="{{ 'Set as favorite' | translate }}" ng-click="toggleStar()"></i>
-    </h1>
-    <div class="row">
+
+      <h1 class="motion-title">
+          <span class="title-change-indicator"
+              ng-if="viewChangeRecommendations.mode == 'original' && title_change_recommendation"
+              ng-click="viewChangeRecommendations.scrollToDiffBox(title_change_recommendation.id)"></span>
+          <span class="change-title"
+                ng-if="motion.isAllowed('update') && viewChangeRecommendations.mode == 'original' && !title_change_recommendation"></span>
+
+          <span>{{ motion.getTitleWithChanges(viewChangeRecommendations.mode) }}</span>
+
+          <i class="fa pointer" ng-class="motion.personalNote.star ? 'fa-star' : 'fa-star-o'"
+             ng-if="operator.user"
+             title="{{ 'Set as favorite' | translate }}" ng-click="toggleStar()"></i>
+      </h1>
+
+      <div class="row">
       <div class="col-sm-6">
         <h2>
             <translate>Motion</translate> {{ motion.identifier }}

--- a/openslides/motions/static/templates/motions/motion-detail/change-summary.html
+++ b/openslides/motions/static/templates/motions/motion-detail/change-summary.html
@@ -11,7 +11,16 @@
       <translate>Reject all change recommendations</translate>
     </button>
 
-    <ul ng-if="change_recommendations.length > 0">
+    <ul ng-if="change_recommendations.length > 0 || title_change_recommendation">
+        <li ng-if="title_change_recommendation">
+            <a href='' ng-click="viewChangeRecommendations.scrollToDiffBox(title_change_recommendation.id)">
+                <span class="line-number"><translate>Title</translate>:</span>
+                <span class="operation"><translate>Replacement</translate></span>
+                <span class="status">
+                    <translate ng-if="title_change_recommendation.rejected">Rejected</translate>
+                </span>
+            </a>
+        </li>
         <li ng-repeat="change in (changes = (change_recommendations | filter:{motion_version_id:version}:true | orderBy: 'line_from')) ">
           <a href='' ng-click="viewChangeRecommendations.scrollToDiffBox(change.id)">
             <span ng-if="change.line_from >= change.line_to - 1" class="line-number">
@@ -35,7 +44,7 @@
         </li>
     </ul>
 
-    <div ng-if="change_recommendations.length == 0" class="no-changes">
+    <div ng-if="change_recommendations.length == 0 && !title_change_recommendation" class="no-changes">
         <translate>No change recommendations yet</translate>
     </div>
 </section>

--- a/openslides/motions/static/templates/motions/motion-detail/toolbar.html
+++ b/openslides/motions/static/templates/motions/motion-detail/toolbar.html
@@ -92,7 +92,7 @@
 </div>
 
 <!-- View Modes (Original, Diff, Changed) -->
-<div class="motion-toolbar" ng-if="change_recommendations.length > 0">
+<div class="motion-toolbar" ng-if="change_recommendations.length > 0 || title_change_recommendation">
     <div class="toolbar-left">
 
         <!-- change recommendations for resonsive size medium/large (button group) -->

--- a/openslides/motions/static/templates/motions/motion-detail/view-diff.html
+++ b/openslides/motions/static/templates/motions/motion-detail/view-diff.html
@@ -1,4 +1,48 @@
 <div ng-if="viewChangeRecommendations.mode == 'diff'">
+    <!-- The changed title -->
+    <div ng-if="title_change_recommendation" ng-class="motion.isAllowed('can_manage') ? 'diff-box' : ''"
+         class="diff-box-{{ title_change_recommendation.id }} diff-box-title clearfix">
+        <div class="action-row" ng-if="motion.isAllowed('can_manage')">
+            <div class="btn-group" data-toggle="buttons">
+                <label class="btn btn-sm btn-default" ng-class="{active: !title_change_recommendation.rejected}"
+                       title="{{ 'Not rejected' | translate }}"
+                       ng-click="title_change_recommendation.rejected = false; title_change_recommendation.saveStatus();">
+                    <input type="radio" name="changeRecommendationRejected[{{ title_change_recommendation.id }}]" value="0"
+                           ng-change="title_change_recommendation.saveStatus()" ng-model="change.rejected"
+                           ng-checked="title_change_recommendation.rejected == false">
+                    <i class="fa fa-thumbs-up"></i>
+                </label>
+                <label class="btn btn-sm btn-default" ng-class="{active: title_change_recommendation.rejected}"
+                       title="{{ 'Rejected' | translate }}" ng-click="title_change_recommendation.rejected = true; title_change_recommendation.saveStatus();">
+                    <input type="radio" name="changeRecommendationRejected[{{ title_change_recommendation.id }}]" value="1"
+                           ng-change="title_change_recommendation.saveStatus()" ng-model="change.rejected"
+                           ng-checked="title_change_recommendation.rejected == true">
+                    <i class="fa fa-thumbs-down"></i>
+                </label>
+            </div>
+
+            <button class="btn btn-default btn-sm pull-right btn-delete"
+                    ng-bootbox-confirm="{{ 'Are you sure you want to delete this change recommendation?' | translate }}"
+                    ng-bootbox-confirm-action="viewChangeRecommendations.delete(title_change_recommendation.id)"
+                    title="{{ 'Delete' | translate }}">
+                <i class="fa fa-trash"></i>
+            </button>
+
+            <button class="btn btn-default btn-sm pull-right btn-edit"
+                    ng-click="createChangeRecommendation.editTitleDialog(title_change_recommendation)"
+                    title="{{ 'Edit' | translate }}">
+                <i class="fa fa-pencil"></i>
+            </button>
+        </div>
+        <div class="status-row" ng-if="!motion.isAllowed('can_manage') && title_change_recommendation.rejected">
+            <translate>Rejected</translate>
+        </div>
+
+        <div class="motion-text motion-text-diff line-numbers-{{ lineNumberMode }}">
+            <div class="description"><translate>New title</translate>:</div>
+            <div>{{ title_change_recommendation.text }}</div>
+        </div>
+    </div>
 
     <!-- The actual diff view -->
     <div class="motion-text-with-diffs line-numbers-{{ lineNumberMode }}">
@@ -31,7 +75,7 @@
                         <i class="fa fa-trash"></i>
                     </button>
 
-                    <button class="btn btn-default btn-sm pull-right btn-edit" ng-click="createChangeRecommendation.editDialog(change)"
+                    <button class="btn btn-default btn-sm pull-right btn-edit" ng-click="createChangeRecommendation.editTextDialog(change)"
                             title="{{ 'Edit' | translate }}">
                         <i class="fa fa-pencil"></i>
                     </button>


### PR DESCRIPTION
A change recommendation for a motion title can be created in the original view when hovering over the title at the top, then clicking at the small plus at the left:
<img width="344" alt="bildschirmfoto 2018-03-03 um 20 03 18" src="https://user-images.githubusercontent.com/533440/36938168-0c4f8cfa-1f1e-11e8-99b3-875244c09346.png">

The new title appears in the diff view:
<img width="474" alt="bildschirmfoto 2018-03-03 um 20 03 36" src="https://user-images.githubusercontent.com/533440/36938171-19564308-1f1e-11e8-89ab-2f934f6c6e37.png">
and as the new title at the top in the "changed" view and in the "agreed" view unless it has been rejected.

To Do:
- [x] Is this the way the feature was meant?
- [x] Test if this works with different versions / unprivileged users
- [x] Integrate it into PDF/Docx

Implementation hints:
- The MotionChangeRecommendation-table is reused for this, with ``line_from==0`` and ``line_to==0`` indicating a change recommendation regarding the title.
- For creating and updating the title-change, I created two new controllers, instead of reusing the old two controllers and putting quite a lot of if/then-clauses into them.