### PR TITLE
OL Offsets - fixes #3643

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -44,7 +44,7 @@ Motions:
 - Bugfix: Several bugfixes regarding splitting list items in
   change recommendations [#3288].
 - Bugfix: Several bugfixes regarding diff version [#3407, #3408, #3410,
-  #3440, #3450, #3465, #3537, #3546, #3548].
+  #3440, #3450, #3465, #3537, #3546, #3548, #3644].
 - Added inline Editing for motion reason [#3361].
 - Added multiselect filter for motion comments [#3372].
 - Added support for pinning personal notes to the window [#3360].

--- a/openslides/motions/static/js/motions/diff.js
+++ b/openslides/motions/static/js/motions/diff.js
@@ -116,13 +116,13 @@ angular.module('OpenSlidesApp.motions.diff', ['OpenSlidesApp.motions.lineNumberi
         this._isWithinNthLIOfOL = function(olNode, descendantNode) {
             var nthLIOfOL = null;
             while (descendantNode.parentNode) {
-                if (descendantNode.parentNode == olNode) {
+                if (descendantNode.parentNode === olNode) {
                     var lisBeforeOl = 0,
                         foundMe = false;
                     for (var i = 0; i < olNode.childNodes.length && !foundMe; i++) {
-                        if (olNode.childNodes[i] == descendantNode) {
+                        if (olNode.childNodes[i] === descendantNode) {
                             foundMe = true;
-                        } else if (olNode.childNodes[i].nodeName == 'LI') {
+                        } else if (olNode.childNodes[i].nodeName === 'LI') {
                             lisBeforeOl++;
                         }
                     }
@@ -406,7 +406,7 @@ angular.module('OpenSlidesApp.motions.diff', ['OpenSlidesApp.motions.lineNumberi
                 innerContextEnd = '',
                 previousHtmlEndSnippet = '',
                 followingHtmlStartSnippet = '',
-                fakeOl;
+                fakeOl, offset;
 
 
             fromChildTraceAbs.shift();
@@ -438,7 +438,14 @@ angular.module('OpenSlidesApp.motions.diff', ['OpenSlidesApp.motions.lineNumberi
                 if (isSplit) {
                     this.addCSSClass(currNode.parentNode, 'os-split-after');
                 }
-                followingHtmlStartSnippet = this._serializeTag(currNode.parentNode) + followingHtmlStartSnippet;
+                if (currNode.parentNode.nodeName === 'OL') {
+                    fakeOl = currNode.parentNode.cloneNode(false);
+                    offset = (currNode.parentNode.getAttribute("start") ? parseInt(currNode.parentNode.getAttribute("start")) - 1 : 0);
+                    fakeOl.setAttribute('start', (this._isWithinNthLIOfOL(currNode.parentNode, toLineNode) + offset).toString());
+                    followingHtmlStartSnippet = this._serializeTag(fakeOl) + followingHtmlStartSnippet;
+                } else {
+                    followingHtmlStartSnippet = this._serializeTag(currNode.parentNode) + followingHtmlStartSnippet;
+                }
                 currNode = currNode.parentNode;
             }
 
@@ -453,7 +460,8 @@ angular.module('OpenSlidesApp.motions.diff', ['OpenSlidesApp.motions.lineNumberi
                     }
                     if (fromChildTraceRel[i].nodeName === 'OL') {
                         fakeOl = fromChildTraceRel[i].cloneNode(false);
-                        fakeOl.setAttribute('start', this._isWithinNthLIOfOL(fromChildTraceRel[i], fromLineNode));
+                        offset = (fromChildTraceRel[i].getAttribute("start") ? parseInt(fromChildTraceRel[i].getAttribute("start")) - 1 : 0);
+                        fakeOl.setAttribute('start', (offset + this._isWithinNthLIOfOL(fromChildTraceRel[i], fromLineNode)).toString());
                         innerContextStart += this._serializeTag(fakeOl);
                     } else {
                         if (i < (fromChildTraceRel.length - 1) && isSplit) {
@@ -491,7 +499,8 @@ angular.module('OpenSlidesApp.motions.diff', ['OpenSlidesApp.motions.lineNumberi
             while (currNode.parentNode) {
                 if (currNode.nodeName === 'OL') {
                     fakeOl = currNode.cloneNode(false);
-                    fakeOl.setAttribute('start', this._isWithinNthLIOfOL(currNode, fromLineNode));
+                    offset = (currNode.getAttribute("start") ? parseInt(currNode.getAttribute("start")) - 1 : 0);
+                    fakeOl.setAttribute('start', (this._isWithinNthLIOfOL(currNode, fromLineNode) + offset).toString());
                     outerContextStart = this._serializeTag(fakeOl) + outerContextStart;
                 } else {
                     outerContextStart = this._serializeTag(currNode) + outerContextStart;

--- a/tests/karma/motions/diff.service.test.js
+++ b/tests/karma/motions/diff.service.test.js
@@ -251,6 +251,15 @@ describe('linenumbering', function () {
         expect(diff.innerContextStart.toLowerCase()).toBe('');
         expect(diff.html.toLowerCase()).toBe('<li class="os-split-after">line 2');
     });
+
+    it('sets the start in a more complex list', function () {
+        var html = '<ol start="10"><li>' + noMarkup(1) + 'Line 1</li><li>' + noMarkup(2) + 'Line 2' + brMarkup(3) + 'Line 3</li>' +
+            '<li>' + noMarkup(4) + 'Line 4</li></ol>';
+        var diff = diffService.extractRangeByLineNumbers(html, 3, 4);
+        expect(diff.previousHtml.toLowerCase()).toContain('start="10"');
+        expect(diff.outerContextStart.toLowerCase()).toContain('start="11"');
+        expect(diff.followingHtmlStartSnippet.toLowerCase()).toContain('start="12"');
+    });
   });
 
   describe('merging two sections', function () {


### PR DESCRIPTION
After this patch, affected change recommendations need to be re-created, as the offset is hard-coded in the HTML of the recommendation.