### PR TITLE
Get the path of the settings.py file

### DIFF
--- a/openslides/utils/settings.py.tpl
+++ b/openslides/utils/settings.py.tpl
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/1.10/ref/settings/
 import os
 from openslides.global_settings import *
 %(import_function)s
+SETTINGS_FILEPATH = __file__  # Do not change!
 
 # The directory for user specific data files
 


### PR DESCRIPTION
Needed for the saml plugin: If OS is started with `runworker` we do not have any chance of getting the path to the settings. Unfortunately `from django.conf import settings; print(settings.__file__);` does not work, so this workaround has to be taken.