### PR TITLE
Fixed IE11 Error in pdfjs-dist

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -64,6 +64,8 @@ gulp.task('js-libs', function () {
         .pipe(sourcemaps.write())
         .pipe(inject.prepend("/* set basepath of CKEditor */\n" +
                 "window.CKEDITOR_BASEPATH = '/static/ckeditor/';\n\n"))
+        .pipe(inject.prepend("/* Workaround for IE and pdfjs-dist#1.3.100 (see PR#3714) */\n" +
+                "PDFJS = {workerSrc: 'not used but set'};\n\n"))
         .pipe(gulpif(argv.production, uglify()))
         .pipe(gulp.dest(path.join(output_directory, 'js')));
 });


### PR DESCRIPTION
To summarize:
- angular-pdf 1.3.0 depends on pdfjs-dist 1.3.100 --> IE11 error
- angular-pdf 1.3.1 depends on pdfjs-dist 1.5.188 --> Black screen bug

The solution is now to take angular-pdf with version 1.3.0 and fix the IE11 incompability. We use the `build/pdf.combined.js` file (See `bower.json`). At the very end the script tries to get the worker source (a js file named like the current script but with `.worker.js` instead of `.js` at the end). The attribute `document.currentScript` is not supported in IE11, thus the error. But the `PDFJS.workerSrc` isn't even used, so we can set this to an unused value before the script runs, because then the `document.currentScript` is skipped.
This is done by just setting this value on top of our worker libs script. The good thing: No forking required :)