### PR TITLE
Fixes for the item projection (fixes #3733)

### DIFF
--- a/openslides/agenda/static/js/agenda/base.js
+++ b/openslides/agenda/static/js/agenda/base.js
@@ -159,7 +159,7 @@ angular.module('OpenSlidesApp.agenda', ['OpenSlidesApp.users'])
                                 },
                             };
                         }
-                        ProjectHelper.project(requestData);
+                        return ProjectHelper.project(requestData);
                     } else {  // Project the content object
                         var contentObject = DS.get(this.content_object.collection, this.content_object.id);
                         return contentObject.project(projectorId);
@@ -214,7 +214,7 @@ angular.module('OpenSlidesApp.agenda', ['OpenSlidesApp.users'])
                             },
                         };
                     }
-                    ProjectHelper.project(requestData);
+                    return ProjectHelper.project(requestData);
                 },
                 // check if list of speakers is projected
                 isListOfSpeakersProjected: function () {

--- a/openslides/agenda/static/js/agenda/site.js
+++ b/openslides/agenda/static/js/agenda/site.js
@@ -381,13 +381,15 @@ angular.module('OpenSlidesApp.agenda.site', [
         };
         // change whether one item or all subitems should be projected
         $scope.changeItemTree = function (item) {
-            var isProjected = item.isProjected(item.tree);
-            if (isProjected > 0) {
-                // Deactivate and reactivate
-                item.project(isProjected, item.tree);
-                item.project(isProjected, !item.tree);
-            }
+            var tree = item.tree;
             item.tree = !item.tree;
+            var isProjected = item.isProjected(tree);
+            _.forEach(isProjected, function (projectorId) {
+                // Deactivate and reactivate
+                item.project(projectorId, tree).then(function (s) {
+                    item.project(projectorId, !tree);
+                });
+            });
         };
         // check if agenda is projected
         $scope.isAgendaProjected = function (tree) {

--- a/openslides/assignments/static/js/assignments/base.js
+++ b/openslides/assignments/static/js/assignments/base.js
@@ -371,7 +371,7 @@ angular.module('OpenSlidesApp.assignments', [])
                             },
                         };
                     }
-                    ProjectHelper.project(requestData);
+                    return ProjectHelper.project(requestData);
                 },
                 // override isProjected function of jsDataModel factory
                 isProjected: function (poll_id, anyPoll) {

--- a/openslides/core/static/js/core/base.js
+++ b/openslides/core/static/js/core/base.js
@@ -744,7 +744,7 @@ angular.module('OpenSlidesApp.core', [
                     element: {name: this.getResourceName(), id: this.id},
                 };
             }
-            ProjectHelper.project(requestData);
+            return ProjectHelper.project(requestData);
         };
         BaseModel.prototype.isProjected = function() {
             // Returns the ids of all projectors if there is a projector element
@@ -1265,9 +1265,10 @@ angular.module('OpenSlidesApp.core', [
 // with the given data. Also it does the changes done by the server
 // locally and may reverts them, if something went wrong.
 .factory('ProjectHelper', [
+    '$q',
     '$http',
     'Projector',
-    function ($http, Projector) {
+    function ($q, $http, Projector) {
         var uuid4 = function () {
             function s8() {
                 return Math.floor((1 + Math.random()) * 0x100000000)
@@ -1336,12 +1337,15 @@ angular.module('OpenSlidesApp.core', [
 
                 Projector.inject(projectorsChanged);
 
-                $http.post('/rest/core/projector/project/', data).then(null,
-                    function (error) {
+                return $q(function (resolve, reject) {
+                    $http.post('/rest/core/projector/project/', data).then(function (success) {
+                        resolve(success);
+                    }, function (error) {
                         // revert the changed made earlier
                         Projector.inject(originalProjectors);
-                    }
-                );
+                        reject(error);
+                    });
+                });
             },
         };
     }

--- a/openslides/motions/static/js/motions/base.js
+++ b/openslides/motions/static/js/motions/base.js
@@ -685,7 +685,7 @@ angular.module('OpenSlidesApp.motions', [
                             },
                         };
                     }
-                    ProjectHelper.project(requestData);
+                    return ProjectHelper.project(requestData);
                 },
                 isProjected: function (mode) {
                     var self = this;


### PR DESCRIPTION
There was a race between deprojection and projection when changing the subitem. Now, the client waits that the deprojection is finished before project the new one. This causes a flickering in the client (which is technically correct). This special case for changing the subitems projection state can be handled seperately, but not in this PR. THis just fixes the issue and eliminates the race between two requests.