### PR TITLE
adding working privacy policy

### DIFF
--- a/openslides/core/config_variables.py
+++ b/openslides/core/config_variables.py
@@ -58,6 +58,15 @@ def get_config_variables():
         subgroup='Event')
 
     yield ConfigVariable(
+        name='general_event_privacy_policy',
+        default_value='',
+        input_type='markupText',
+        label='Privacy policy',
+        weight=132,
+        group='General',
+        subgroup='Event')
+
+    yield ConfigVariable(
         name='general_event_welcome_title',
         default_value='Welcome to OpenSlides',
         label='Front page title',

--- a/openslides/core/static/js/core/site.js
+++ b/openslides/core/static/js/core/site.js
@@ -359,6 +359,15 @@ angular.module('OpenSlidesApp.core.site', [
                 },
             })
 
+            // privacy policy
+            .state('privacypolicy', {
+                url: '/privacypolicy',
+                controller: 'PrivacyPolicyCtrl',
+                data: {
+                    title: gettext('Privacy policy'),
+                },
+            })
+
             //config
             .state('config', {
                 url: '/config',
@@ -1179,6 +1188,9 @@ angular.module('OpenSlidesApp.core.site', [
         });
     }
 ])
+
+// Privacy Policy Controller
+.controller('PrivacyPolicyCtrl', function () {})
 
 // Config Controller
 .controller('ConfigCtrl', [
@@ -2053,6 +2065,7 @@ angular.module('OpenSlidesApp.core.site', [
         gettext('Event location');
         gettext('Event organizer');
         gettext('Legal notice');
+        gettext('Privacy policy');
         gettext('Front page title');
         gettext('Welcome to OpenSlides');
         gettext('Front page text');

--- a/openslides/core/static/templates/index.html
+++ b/openslides/core/static/templates/index.html
@@ -222,7 +222,8 @@
         <!-- footer -->
         <div id="footer">
           &copy; Copyright by <a href="http://www.openslides.org" target="_blank">OpenSlides</a> |
-          <a ui-sref="legalnotice" translate>Legal notice</a>
+          <a ui-sref="legalnotice" translate>Legal notice</a> |
+          <a ui-sref="privacypolicy" translate>Privacy Policy</a>
         </div><!--end footer-->
     </div>
 

--- a/openslides/core/static/templates/privacypolicy.html
+++ b/openslides/core/static/templates/privacypolicy.html
@@ -1,0 +1,9 @@
+<div class="header">
+  <div class="title">
+    <h1 translate>Privacy Policy</h1>
+  </div>
+</div>
+
+<div class="details">
+  <div ng-bind-html="config('general_event_privacy_policy') | translate"></div>
+</div>


### PR DESCRIPTION
In order to archive GDPR compliance we need a privacy policy.

I know that this way around is yet far from perfect. In further additions, we could add a standard-version of the GDPR to the translations to the *po files and let the translations happen there. But until then, we should have something valid for coming friday.