### PR TITLE
make the privacy policy available for non logged in users (closes #3757)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ openslides_*
 
 # Mypy cache for typechecking
 .mypy_cache
+
+# Development of a new client. Easier to switch branches with this entry
+client/*

--- a/openslides/core/apps.py
+++ b/openslides/core/apps.py
@@ -115,7 +115,13 @@ class CoreAppConfig(AppConfig):
             'name': 'OpenSlidesConfigVariables',
             'value': config_groups}
 
-        return [client_settings, config_variables]
+        # Send the privacy policy to the client. A user should view them, even he is
+        # not logged in (so does not have the config values yet).
+        privacy_policy = {
+            'name': 'PrivacyPolicy',
+            'value': config['general_event_privacy_policy']}
+
+        return [client_settings, config_variables, privacy_policy]
 
 
 def call_save_default_values(**kwargs):

--- a/openslides/core/static/templates/core/login-form.html
+++ b/openslides/core/static/templates/core/login-form.html
@@ -25,5 +25,6 @@
       </button>
       <template-hook hook-name="loginFormButtons"></template-hook>
     </div>
+    <a href="" ng-click="openPrivacyPolicyDialog()" translate>Privacy policy</a>
   </div>
 </form>

--- a/openslides/core/static/templates/privacypolicydialog.html
+++ b/openslides/core/static/templates/privacypolicydialog.html
@@ -1,0 +1,9 @@
+<h1 translate>Privacy policy</h1>
+<div ng-if="privacyPolicy" ng-bind-html="privacyPolicy | translate"></div>
+<div ng-if="!privacyPolicy" translate>
+  The event manager hasn't set up a privacy policy yet.
+</div>
+
+<button ng-click="closeThisDialog()" class="btn btn-default spacer-top" translate>
+  Close
+</button>

--- a/openslides/users/static/js/users/site.js
+++ b/openslides/users/static/js/users/site.js
@@ -1778,6 +1778,26 @@ angular.module('OpenSlidesApp.users.site', [
             $scope.closeThisDialog();
             $state.go('home');
         };
+        // quick fix, that we cannot change the state to the main privacy
+        // policy view. Display it in a dialog..
+        $scope.openPrivacyPolicyDialog = function () {
+            ngDialog.open({
+                template: 'static/templates/privacypolicydialog.html',
+                className: 'ngdialog-theme-default wide-form',
+                controller: 'PrivacyPolicyDialogCtrl',
+                showClose: true,
+                closeByEscape: true,
+                closeByDocument: true,
+            });
+        };
+    }
+])
+
+.controller('PrivacyPolicyDialogCtrl', [
+    '$scope',
+    'PrivacyPolicy',
+    function ($scope, PrivacyPolicy) {
+        $scope.privacyPolicy = PrivacyPolicy;
     }
 ])
 

--- a/tests/unit/core/test_views.py
+++ b/tests/unit/core/test_views.py
@@ -173,6 +173,7 @@ class WebclientJavaScriptView(TestCase):
     @patch('openslides.core.config.config')
     @patch('django.contrib.auth.models.Permission.objects.all')
     def test_permissions_as_constant(self, mock_permissions_all, mock_config):
+        mock_config.__getitem__.return_value = ''
         self.view_instance = views.WebclientJavaScriptView()
         self.view_instance.request = self.request
         response = self.view_instance.get(realm='site')


### PR DESCRIPTION
Note: If the policy is changed, the server has to be restarted, because the policy is now put as a constant in the main JS-View. This view is cached, so changes do not reflect there.

And yes, this is a very hacky, but fast solution. If we want to enable the `/privacypolicy` page, we need to refactor the whole client-state-authentication-system.