### PR TITLE
Fixed the logo config migration (fixed #3782)

### DIFF
--- a/openslides/core/migrations/0008_changed_logo_fields.py
+++ b/openslides/core/migrations/0008_changed_logo_fields.py
@@ -18,6 +18,7 @@ def logos_available_default_to_database(apps, schema_editor):
     except ConfigStore.DoesNotExist:
         return  # The key is not in the database, nothing to change here
 
+    # Set the default value and save the db entry
     default_value = config.config_variables['logos_available'].default_value
     logos_available.value = default_value
     logos_available.save()
@@ -42,6 +43,10 @@ def move_old_logo_settings(apps, schema_editor):
             logo_pdf_L = ConfigStore.objects.get(key=new_value_key)
         except ConfigStore.DoesNotExist:
             logo_pdf_L = ConfigStore(key=new_value_key)
+
+        # Check, if the default was saved into the db. If not, get it and set it to the value
+        if not isinstance(logo_pdf_L.value, dict):
+            logo_pdf_L.value = config.config_variables[new_value_key].default_value
 
         # Move the path to the new configentry
         logo_pdf_L.value['path'] = logo_pdf.value.get('path', '')


### PR DESCRIPTION
The default values might not be saved in the database yet, so the
dict-assignment fails. If there isn't a default loaded yet, get it and
set it to the database field before setting the new path-value.