### PR TITLE
Use newer version of django-redis-sessions, new settings format

### DIFF
--- a/openslides/utils/settings.py.tpl
+++ b/openslides/utils/settings.py.tpl
@@ -79,6 +79,15 @@ DATABASES = {
 use_redis = False
 
 if use_redis:
+    # Redis configuration for django-redis-session. Keep this synchronized to
+    # the caching settings
+
+    SESSION_REDIS = {
+        'host': '127.0.0.1',
+        'post': 6379,
+        'db': 0,
+    }
+
     # Django Channels
 
     # Unless you have only a small assembly uncomment the following lines to

--- a/requirements_big_mode.txt
+++ b/requirements_big_mode.txt
@@ -4,6 +4,6 @@
 # Requirements for Redis and PostgreSQL support
 asgi-redis>=1.3,<1.5
 django-redis>=4.7.0,<4.10
-django-redis-sessions>=0.5.6,<0.7
+django-redis-sessions>=0.6.1,<0.7
 psycopg2-binary>=2.7,<2.8
 txredisapi==1.4.4


### PR DESCRIPTION
I locked the version of django-redis-sessions to 1.6.1, because the settings format has changed and may depend on what version pip will install. This was an issue on our production servers. 

https://github.com/martinrusev/django-redis-sessions/blob/master/CHANGELOG.md

I also added the configuration for the session with the new format. The settings will be inconsistend, if the user only changes the `CACHES` section.