### PR TITLE
New url schema

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@
 
 https://openslides.org/
 
+Version 3.0 (unreleased)
+========================
+
+Core:
+ - Change URL schema [#3798].
+ - Update to channels2
+
+
 Version 2.3 (unreleased)
 ========================
 
@@ -22,7 +30,7 @@ Motions:
    be edited [#3781].
  - New config to show amendments also in motions table [#3792]
 
- Core:
+Core:
  - Python 3.4 is not supported anymore [#3777].
  - Support Python 3.7 [#3786].
  - Updated pdfMake to 0.1.37 [#3766].

--- a/DEVELOPMENT.rst
+++ b/DEVELOPMENT.rst
@@ -214,9 +214,6 @@ This is an example configuration for a single Daphne listen on port 8000::
 
          server_name _;
 
-         location ~* ^/(?!ws|wss|webclient|core/servertime|core/version|users/whoami|users/login|users/logout|users/setpassword|motions/docxtemplate|agenda/docxtemplate|projector|real-projector|static|media|rest).*$ {
-             rewrite ^.*$ /static/templates/index.html;
-         }
          location ~* ^/projector.*$ {
              rewrite ^.*$ /static/templates/projector-container.html;
          }
@@ -228,6 +225,9 @@ This is an example configuration for a single Daphne listen on port 8000::
          }
          location /static {
              alias <your path to>/collected-static;
+         }
+         location ~* ^/(?!ws|wss|media|rest|views).*$ {
+             rewrite ^.*$ /static/templates/index.html;
          }
 
          location / {

--- a/openslides/core/urls.py
+++ b/openslides/core/urls.py
@@ -4,26 +4,11 @@ from . import views
 
 
 urlpatterns = [
-    url(r'^core/servertime/$',
+    url(r'^servertime/$',
         views.ServerTime.as_view(),
         name='core_servertime'),
 
-    url(r'^core/version/$',
+    url(r'^version/$',
         views.VersionView.as_view(),
         name='core_version'),
-
-    url(r'^webclient/(?P<realm>site|projector)/$',
-        views.WebclientJavaScriptView.as_view(),
-        name='core_webclient_javascript'),
-
-    # View for the projectors are handled by angular.
-    url(r'^projector/(\d+)/$', views.ProjectorView.as_view()),
-
-    # Original view without resolutioncontrol for the projectors are handled by angular.
-    url(r'^real-projector/(\d+)/$', views.RealProjectorView.as_view()),
-
-    # Main entry point for all angular pages.
-    # Has to be the last entry in the urls.py
-    url(r'^.*$', views.IndexView.as_view(), name="index"),
-
 ]

--- a/openslides/old_urls.py
+++ b/openslides/old_urls.py
@@ -3,28 +3,22 @@ from django.conf.urls import include, url
 from django.contrib.staticfiles.urls import urlpatterns
 from django.views.generic import RedirectView
 
+from openslides.core import views as core_views
 from openslides.mediafiles.views import protected_serve
+from openslides.utils.plugins import get_all_plugin_urlpatterns
 from openslides.utils.rest_api import router
 
-from .core import views as core_views
 
-
-# Urls for /static/ are already in urlpatterns
+urlpatterns += get_all_plugin_urlpatterns()
 
 urlpatterns += [
-    # URLs for /media/
     url(r'^%s(?P<path>.*)$' % settings.MEDIA_URL.lstrip('/'), protected_serve, {'document_root': settings.MEDIA_ROOT}),
-
-    # When a url without a leading slash is requested, redirect to the url with
-    # the slash. This line has to be after static and media files.
     url(r'^(?P<url>.*[^/])$', RedirectView.as_view(url='/%(url)s/', permanent=True)),
-
-    # URLs for the rest system
     url(r'^rest/', include(router.urls)),
-
-    # Other urls defined by modules and plugins
-    url(r'^apps/', include('openslides.urls_apps')),
-
+    url(r'^agenda/', include('openslides.agenda.urls')),
+    url(r'^motions/', include('openslides.motions.urls')),
+    url(r'^users/', include('openslides.users.urls')),
+    url(r'^core/', include('openslides.core.urls')),
     # The old angular webclient
     # TODO: Change me or at least my comment
     url(r'^webclient/(?P<realm>site|projector)/$',

--- a/openslides/urls_apps.py
+++ b/openslides/urls_apps.py
@@ -1,0 +1,13 @@
+from django.conf.urls import include, url
+
+from openslides.utils.plugins import get_all_plugin_urlpatterns
+
+
+urlpatterns = get_all_plugin_urlpatterns()
+
+urlpatterns += [
+    url(r'^core/', include('openslides.core.urls')),
+    url(r'^agenda/', include('openslides.agenda.urls')),
+    url(r'^motions/', include('openslides.motions.urls')),
+    url(r'^users/', include('openslides.users.urls')),
+]

--- a/tests/integration/users/test_views.py
+++ b/tests/integration/users/test_views.py
@@ -1,12 +1,13 @@
 import json
 
+from django.urls import reverse
 from rest_framework.test import APIClient
 
 from openslides.utils.test import TestCase
 
 
 class TestWhoAmIView(TestCase):
-    url = '/users/whoami/'
+    url = reverse('user_whoami')
 
     def test_get_anonymous(self):
         response = self.client.get(self.url)
@@ -32,7 +33,7 @@ class TestWhoAmIView(TestCase):
 
 
 class TestUserLogoutView(TestCase):
-    url = '/users/logout/'
+    url = reverse('user_logout')
 
     def test_get(self):
         response = self.client.get(self.url)
@@ -55,7 +56,7 @@ class TestUserLogoutView(TestCase):
 
 
 class TestUserLoginView(TestCase):
-    url = '/users/login/'
+    url = reverse('user_login')
 
     def setUp(self):
         self.client = APIClient()


### PR DESCRIPTION
The goal is, to easier root requests from nginx. Currently, all urls (also from plugins) have to be set in nginx (see nginx-config in DEVELOPMENT.rst). With this pull request, all individual urls (also from plugins) have the prefix `views/`. This makes it a lot easier to configure nginx.

The prefix `views/` is open to discussion.

Set `ROOT_URLCONF = 'openslides.old_urls'` in your personal settings, to use the old url schema (needed if you want to use the old client).

When the new client is ready, the old_urls-file has to be removed.

@FinnStutzenstein you could change the url-files to that the urls.py uses the new client and the old_urls.py uses the old client automatically
