### PR TITLE
Updates files for big mode

### DIFF
--- a/DEVELOPMENT.rst
+++ b/DEVELOPMENT.rst
@@ -25,9 +25,6 @@ For Ubuntu 16.04 e. g. follow `Yarn installation instructions
 
     $ sudo apt-get install git nodejs nodejs-legacy npm build-essential python3-dev
 
-*Note: For Ubuntu 14.04 you have to update Node.js before. The distribution
-version is 0.10.25 which is not sufficient.*
-
 
 b. Get OpenSlides source code
 '''''''''''''''''''''''''''''
@@ -166,15 +163,8 @@ Then add database user and database. For Ubuntu 16.04 e. g. run::
     $ sudo -u postgres createdb --owner=openslides openslides
 
 
-2. Install additional packages
-------------------------------
 
-Install some more required Python packages::
-
-    $ pip install -r requirements_big_mode.txt
-
-
-3. Change OpenSlides settings
+2. Change OpenSlides settings
 -----------------------------
 
 Create OpenSlides settings file if it does not exist::
@@ -190,17 +180,20 @@ Populate your new database::
     $ python manage.py migrate
 
 
-4. Run OpenSlides
+3. Run OpenSlides
 -----------------
 
-To start Daphne as protocol server run::
+To start gunicorn with uvicorn as protocol server run::
 
     $ export DJANGO_SETTINGS_MODULE=settings
     $ export PYTHONPATH=personal_data/var/
-    $ daphne openslides.asgi:channel_layer
+    $ gunicorn -w 4 -k uvicorn.workers.UvicornWorker openslides.asgi:application
+
+This example uses 4 instances. The recommendation is to use CPU cores * 2.
 
 
-5. Use Nginx (optional)
+4. Use Nginx (optional)
+-----------------------
 
 When using Nginx as a proxy for delivering staticfiles the performance of the setup will increase very much. For delivering staticfiles you have to collect those::
 
@@ -240,10 +233,3 @@ This is an example configuration for a single Daphne listen on port 8000::
              proxy_set_header X-Scheme $scheme;
          }
      }
-
-Using Nginx as a load balancer is fairly easy. Just start multiple Daphnes on different ports, change the `proxy_pass` to `http://openslides/` and add this on top of the Nginx configuration::
-
-    upstream openslides {
-        server localhost:2001;
-        server localhost:2002;
-    }

--- a/README.rst
+++ b/README.rst
@@ -139,22 +139,21 @@ file (usually called settings.py).
 
 The configuration values that have to be altered are:
 
-* CACHES
 * CHANNEL_LAYERS
 * DATABASES
 * SESSION_ENGINE
+* REDIS_ADDRESS
 
 You should use a webserver like Apache HTTP Server or nginx to serve the
 static and media files as proxy server in front of your OpenSlides
 interface server. You also should use a database like PostgreSQL and Redis
 as channels backend, cache backend and session engine. Finally you should
-start one or more interface servers (Daphne).
+use gunicorn with uvicorn as interface server.
 
 Please see the respective section in the `DEVELOPMENT.rst
 <https://github.com/OpenSlides/OpenSlides/blob/master/DEVELOPMENT.rst>`_ and:
 
 * https://channels.readthedocs.io/en/latest/deploying.html
-* https://docs.djangoproject.com/en/1.10/topics/cache/
 * https://github.com/sebleier/django-redis-cache
 * https://docs.djangoproject.com/en/1.10/ref/settings/#databases
 

--- a/requirements_big_mode.txt
+++ b/requirements_big_mode.txt
@@ -6,3 +6,7 @@ channels-redis>=2.2,<2.3
 django-redis-sessions>=0.6.1,<0.7
 psycopg2-binary>=2.7.3.2,<2.8
 aioredis>=1.1.0,<1.2
+
+# Requirements for fast asgi server
+gunicorn>=19.9<20
+uvicorn>=0.3.2<1.1


### PR DESCRIPTION
Channels2 adds the possibility to use gunicorn with uvicorn instead of daphne. This helps to start and manage many server processes at the same time at the same port. It is also **a lot** faster.

This is a perfect alternative for geiss and it can be installed via pip.