### PR TITLE
ensures test on startup

### DIFF
--- a/openslides/core/apps.py
+++ b/openslides/core/apps.py
@@ -21,6 +21,7 @@ class CoreAppConfig(AppConfig):
         # Import all required stuff.
         from .config import config
         from ..utils.rest_api import router
+        from ..utils.cache import element_cache
         from .projector import get_projector_elements
         from .signals import (
             delete_django_app_permissions,
@@ -73,6 +74,13 @@ class CoreAppConfig(AppConfig):
         router.register(self.get_model('ConfigStore').get_collection_string(), ConfigViewSet, 'config')
         router.register(self.get_model('ProjectorMessage').get_collection_string(), ProjectorMessageViewSet)
         router.register(self.get_model('Countdown').get_collection_string(), CountdownViewSet)
+
+        # Sets the cache
+        try:
+            element_cache.ensure_cache()
+        except (ImproperlyConfigured, OperationalError):
+            # This happens in the tests or in migrations. Do nothing
+            pass
 
     def get_config_variables(self):
         from .config_variables import get_config_variables

--- a/openslides/core/config.py
+++ b/openslides/core/config.py
@@ -236,7 +236,6 @@ OnChangeType = Callable[[], None]
 ConfigVariableDict = TypedDict('ConfigVariableDict', {
     'key': str,
     'default_value': Any,
-    'value': Any,
     'input_type': str,
     'label': str,
     'help_text': str,
@@ -303,7 +302,6 @@ class ConfigVariable:
         return ConfigVariableDict(
             key=self.name,
             default_value=self.default_value,
-            value=config[self.name],
             input_type=self.input_type,
             label=self.label,
             help_text=self.help_text,

--- a/openslides/utils/autoupdate.py
+++ b/openslides/utils/autoupdate.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
-from django.conf import settings
 from django.db.models import Model
 
 from .cache import element_cache, get_element_id
@@ -146,12 +145,7 @@ async def send_autoupdate(collection_elements: Iterable[CollectionElement]) -> N
             else:
                 cache_elements[element_id] = element.get_full_data()
 
-        if not getattr(settings, 'SKIP_CACHE', False):
-            # Hack for django 2.0 and channels 2.1 to stay in the same thread.
-            # This is needed for the tests.
-            change_id = await element_cache.change_elements(cache_elements)
-        else:
-            change_id = 1
+        change_id = await element_cache.change_elements(cache_elements)
 
         channel_layer = get_channel_layer()
         # TODO: don't await. They can be send in parallel

--- a/openslides/utils/collection.py
+++ b/openslides/utils/collection.py
@@ -12,7 +12,6 @@ from typing import (
 
 from asgiref.sync import async_to_sync
 from django.apps import apps
-from django.conf import settings
 from django.db.models import Model
 from mypy_extensions import TypedDict
 
@@ -201,12 +200,7 @@ class CollectionElement:
             if self.instance is None:
                 # The type of data has to be set for mypy
                 data: Optional[Dict[str, Any]] = None
-                if getattr(settings, 'SKIP_CACHE', False):
-                    # Hack for django 2.0 and channels 2.1 to stay in the same thread.
-                    # This is needed for the tests.
-                    data = self.get_element_from_db()
-                else:
-                    data = async_to_sync(element_cache.get_element_full_data)(self.collection_string, self.id)
+                data = async_to_sync(element_cache.get_element_full_data)(self.collection_string, self.id)
                 if data is None:
                     raise self.get_model().DoesNotExist(
                         "Collection {} with id {} does not exist".format(self.collection_string, self.id))
@@ -278,12 +272,7 @@ class Collection(Cachable):
         if self.full_data is None:
             # The type of all_full_data has to be set for mypy
             all_full_data: Dict[str, List[Dict[str, Any]]] = {}
-            if getattr(settings, 'SKIP_CACHE', False):
-                # Hack for django 2.0 and channels 2.1 to stay in the same thread.
-                # This is needed for the tests.
-                all_full_data = self.get_elements_from_db()
-            else:
-                all_full_data = async_to_sync(element_cache.get_all_full_data)()
+            all_full_data = async_to_sync(element_cache.get_all_full_data)()
             self.full_data = all_full_data.get(self.collection_string, [])
         return self.full_data  # type: ignore
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,8 @@ from django.test import TestCase, TransactionTestCase
 from pytest_django.django_compat import is_django_unittest
 from pytest_django.plugin import validate_django_db
 
+from openslides.utils.cache import element_cache
+
 
 def pytest_collection_modifyitems(items):
     """
@@ -57,3 +59,13 @@ def constants(request):
     else:
         # Else: Use fake constants
         set_constants({'constant1': 'value1', 'constant2': 'value2'})
+
+
+@pytest.fixture(autouse=True)
+def reset_cache(request):
+    """
+    Resetts the cache for every test
+    """
+    if 'django_db' in request.node.keywords or is_django_unittest(request):
+        # When the db is created, use the original cachables
+        element_cache.ensure_cache(reset=True)

--- a/tests/integration/assignments/test_viewset.py
+++ b/tests/integration/assignments/test_viewset.py
@@ -5,6 +5,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from openslides.assignments.models import Assignment
+from openslides.utils.autoupdate import inform_changed_data
 from openslides.utils.test import TestCase
 
 from ..helpers import count_queries
@@ -77,6 +78,7 @@ class CanidatureSelf(TestCase):
         group_delegates = type(group_admin).objects.get(name='Delegates')
         admin.groups.add(group_delegates)
         admin.groups.remove(group_admin)
+        inform_changed_data(admin)
 
         response = self.client.post(reverse('assignment-candidature-self', args=[self.assignment.pk]))
 
@@ -123,6 +125,7 @@ class CanidatureSelf(TestCase):
         group_delegates = type(group_admin).objects.get(name='Delegates')
         admin.groups.add(group_delegates)
         admin.groups.remove(group_admin)
+        inform_changed_data(admin)
 
         response = self.client.delete(reverse('assignment-candidature-self', args=[self.assignment.pk]))
 
@@ -203,6 +206,7 @@ class CandidatureOther(TestCase):
         group_delegates = type(group_admin).objects.get(name='Delegates')
         admin.groups.add(group_delegates)
         admin.groups.remove(group_admin)
+        inform_changed_data(admin)
 
         response = self.client.post(
             reverse('assignment-candidature-other', args=[self.assignment.pk]),
@@ -258,6 +262,7 @@ class CandidatureOther(TestCase):
         group_delegates = type(group_admin).objects.get(name='Delegates')
         admin.groups.add(group_delegates)
         admin.groups.remove(group_admin)
+        inform_changed_data(admin)
 
         response = self.client.delete(
             reverse('assignment-candidature-other', args=[self.assignment.pk]),

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -50,9 +50,6 @@ async def set_config(key, value):
     """
     Set a config variable in the element_cache without hitting the database.
     """
-    if not await element_cache.exists_full_data():
-        # Encure that the cache exists and the default values of the config are in it.
-        await element_cache.build_full_data()
     collection_string = config.get_collection_string()
     config_id = config.key_to_id[key]  # type: ignore
     full_data = {'id': config_id, 'key': key, 'value': value}

--- a/tests/integration/users/test_viewset.py
+++ b/tests/integration/users/test_viewset.py
@@ -7,6 +7,7 @@ from rest_framework.test import APIClient
 from openslides.core.config import config
 from openslides.users.models import Group, PersonalNote, User
 from openslides.users.serializers import UserFullSerializer
+from openslides.utils.autoupdate import inform_changed_data
 from openslides.utils.test import TestCase
 
 from ..helpers import count_queries
@@ -62,6 +63,7 @@ class UserGetTest(TestCase):
         app_label, codename = permission_string.split('.')
         permission = group.permissions.get(content_type__app_label=app_label, codename=codename)
         group.permissions.remove(permission)
+        inform_changed_data(group)
         config['general_system_enable_anonymous'] = True
         guest_client = APIClient()
 

--- a/tests/integration/utils/test_collection.py
+++ b/tests/integration/utils/test_collection.py
@@ -1,25 +1,9 @@
-from unittest import skip
-
 from openslides.topics.models import Topic
 from openslides.utils import collection
 from openslides.utils.test import TestCase
 
 
 class TestCollectionElementCache(TestCase):
-    @skip("Does not work as long as caching does not work in the tests")
-    def test_clean_cache(self):
-        """
-        Tests that the data is retrieved from the database.
-        """
-        topic = Topic.objects.create(title='test topic')
-
-        with self.assertNumQueries(3):
-            collection_element = collection.CollectionElement.from_values('topics/topic', 1)
-            instance = collection_element.get_full_data()
-
-        self.assertEqual(topic.title, instance['title'])
-
-    @skip("Does not work as long as caching does not work in the tests")
     def test_with_cache(self):
         """
         Tests that no db query is used when the valie is in the cache.
@@ -44,21 +28,7 @@ class TestCollectionElementCache(TestCase):
             collection.CollectionElement.from_values('topics/topic', 999)
 
 
-@skip("Does not work as long as caching does not work in the tests")
 class TestCollectionCache(TestCase):
-    def test_clean_cache(self):
-        """
-        Tests that the instances are retrieved from the database.
-        """
-        Topic.objects.create(title='test topic1')
-        Topic.objects.create(title='test topic2')
-        Topic.objects.create(title='test topic3')
-        topic_collection = collection.Collection('topics/topic')
-
-        with self.assertNumQueries(3):
-            instance_list = list(topic_collection.get_full_data())
-        self.assertEqual(len(instance_list), 3)
-
     def test_with_cache(self):
         """
         Tests that no db query is used when the list is received twice.

--- a/tests/integration/utils/test_consumers.py
+++ b/tests/integration/utils/test_consumers.py
@@ -24,22 +24,22 @@ from ..helpers import TConfig, TUser, set_config
 
 
 @pytest.fixture(autouse=True)
-def prepare_element_cache(settings):
+async def prepare_element_cache(settings):
     """
     Resets the element cache.
 
     Uses a cacheable_provider for tests with example data.
     """
-    settings.SKIP_CACHE = False
-    element_cache.cache_provider.clear_cache()
+    await element_cache.cache_provider.clear_cache()
     orig_cachable_provider = element_cache.cachable_provider
     element_cache.cachable_provider = get_cachable_provider([Collection1(), Collection2(), TConfig(), TUser()])
     element_cache._cachables = None
+    await sync_to_async(element_cache.ensure_cache)()
     yield
     # Reset the cachable_provider
     element_cache.cachable_provider = orig_cachable_provider
     element_cache._cachables = None
-    element_cache.cache_provider.clear_cache()
+    await element_cache.cache_provider.clear_cache()
 
 
 @pytest.fixture

--- a/tests/old/config/test_config.py
+++ b/tests/old/config/test_config.py
@@ -1,7 +1,7 @@
 
 
 from openslides.core.config import ConfigVariable, config
-from openslides.core.exceptions import ConfigError, ConfigNotFound
+from openslides.core.exceptions import ConfigError
 from openslides.utils.test import TestCase
 
 
@@ -32,17 +32,6 @@ class HandleConfigTest(TestCase):
     def set_config_var(self, key, value):
         config[key] = value
 
-    def test_get_config_default_value(self):
-        self.assertEqual(config['string_var'], 'default_string_rien4ooCZieng6ah')
-        self.assertTrue(config['bool_var'])
-        self.assertEqual(config['integer_var'], 3)
-        self.assertEqual(config['choices_var'], '1')
-        self.assertEqual(config['none_config_var'], None)
-        with self.assertRaisesMessage(
-                ConfigNotFound,
-                'The config variable unknown_config_var was not found.'):
-            self.get_config_var('unknown_config_var')
-
     def test_get_multiple_config_var_error(self):
         with self.assertRaisesMessage(
                 ConfigError,
@@ -53,14 +42,6 @@ class HandleConfigTest(TestCase):
         self.assertRaises(TypeError, ConfigVariable)
         self.assertRaises(TypeError, ConfigVariable, name='foo')
         self.assertRaises(TypeError, ConfigVariable, default_value='foo')
-
-    def test_change_config_value(self):
-        self.assertEqual(config['string_var'], 'default_string_rien4ooCZieng6ah')
-        config['string_var'] = 'other_special_unique_string dauTex9eAiy7jeen'
-        self.assertEqual(config['string_var'], 'other_special_unique_string dauTex9eAiy7jeen')
-
-    def test_missing_cache_(self):
-        self.assertEqual(config['string_var'], 'default_string_rien4ooCZieng6ah')
 
     def test_config_exists(self):
         self.assertTrue(config.exists('string_var'))

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -42,7 +42,7 @@ DATABASES = {
         'ENGINE': 'django.db.backends.sqlite3',
     }
 }
-
+REDIS_ADDRESS = "redis://127.0.0.1"
 SESSION_ENGINE = "django.contrib.sessions.backends.cache"
 
 # Internationalization
@@ -75,7 +75,3 @@ MOTION_IDENTIFIER_MIN_DIGITS = 1
 PASSWORD_HASHERS = [
     'django.contrib.auth.hashers.MD5PasswordHasher',
 ]
-
-# At least in Django 2.1 and Channels 2.1 the django transactions can not be shared between
-# threads. So we have to skip the asyncio-cache.
-SKIP_CACHE = True

--- a/tests/unit/utils/cache_provider.py
+++ b/tests/unit/utils/cache_provider.py
@@ -72,11 +72,11 @@ class TTestCacheProvider(MemmoryCacheProvider):
     testing.
     """
 
-    async def del_lock_restricted_data_after_wait(self, user_id: int, future: asyncio.Future = None) -> None:
+    async def del_lock_after_wait(self, lock_name: str, future: asyncio.Future = None) -> None:
         if future is None:
-            asyncio.ensure_future(self.del_lock_restricted_data(user_id))
+            asyncio.ensure_future(self.del_lock(lock_name))
         else:
             async def set_future() -> None:
-                await self.del_lock_restricted_data(user_id)
+                await self.del_lock(lock_name)
                 future.set_result(1)  # type: ignore
             asyncio.ensure_future(set_future())


### PR DESCRIPTION
This pull request is necessary for the history mode.

It loads the cache on startup. It is not allowed to clear the cache when OpenSlides is running. You have to stop end restart openslides, when you want to flushall redis (the same, when you want to clear the sql-database)