### PR TITLE
os3: Change default font to Roboto

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -34,6 +34,7 @@
         "@ngx-translate/http-loader": "^3.0.1",
         "core-js": "^2.5.4",
         "ngx-mat-select-search": "^1.4.0",
+        "roboto-fontface": "^0.10.0",
         "rxjs": "^6.3.3",
         "uuid": "^3.3.2",
         "zone.js": "^0.8.26"

--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -4,6 +4,7 @@
 /** Import brand theme and (new) component themes */
 @import './assets/styles/openslides-theme';
 @import './app/site/site.component.scss-theme';
+@import '../node_modules/roboto-fontface/css/roboto/roboto-fontface.css';
 @mixin openslides-components-theme($theme) {
     @include os-site-theme($theme);
     /** More components are added here */
@@ -12,7 +13,7 @@
 @include angular-material-theme($openslides-theme);
 @include openslides-components-theme($openslides-theme);
 * {
-    font-family: Arial, Helvetica, sans-serif !important;
+    font-family: Roboto, Arial, Helvetica, sans-serif;
 }
 
 body {


### PR DESCRIPTION
Roboto was used in Openslides 2, and seems a good, readable choice (roboto condensed is too narrow).

(Still unsure if this is working on a fresh install, needs some more testing)