### PR TITLE
Minor bugfixes for 2.3.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,16 @@
 
 https://openslides.org/
 
+Version 2.3.1 (unreleased)
+==========================
+
+Bugfixes:
+ - Fixed image browser in CKEditor plugin to show uploaded images.
+ - Fixed sorting of users in dropdowns for speakers, submitters and candidates.
+ - Fixed election ballot paper layout (more space required for global 'no').
+ - Fixed missing output of special poll values (for motions and elections)
+
+
 Version 2.3 (2018-09-20)
 ========================
 `Release notes <https://github.com/OpenSlides/OpenSlides/wiki/OpenSlides-2.3>`_ ·

--- a/openslides/agenda/static/templates/agenda/list-of-speakers-partial-management.html
+++ b/openslides/agenda/static/templates/agenda/list-of-speakers-partial-management.html
@@ -112,7 +112,7 @@
       <select chosen
           ng-model="speakerSelectBox.selected"
           ng-change="addSpeaker(speakerSelectBox.selected)"
-          ng-options="user.id as user.get_full_name() for user in users"
+          ng-options="user.id as user.get_full_name() for user in users | orderBy: 'full_name'"
           search-contains="true"
           placeholder-text-single="'Select or search a participant ...' | translate"
           no-results-text="'No results available ...' | translate"

--- a/openslides/assignments/static/js/assignments/pdf.js
+++ b/openslides/assignments/static/js/assignments/pdf.js
@@ -120,7 +120,7 @@ angular.module('OpenSlidesApp.assignments.pdf', ['OpenSlidesApp.core.pdf'])
                     if (printLabel) {
                         voteVal += voteObject.label + ': ';
                     }
-                    voteVal += $filter('number')(voteObject.value, precision);
+                    voteVal += $filter('textOrNumber')(voteObject.value, precision);
 
                     if (voteObject.percentStr) {
                         voteVal += ' ' + voteObject.percentStr;
@@ -435,18 +435,18 @@ angular.module('OpenSlidesApp.assignments.pdf', ['OpenSlidesApp.core.pdf'])
                 var rowsperpage;
                 var sheetend;
                 if (poll.pollmethod == 'votes') {
-                    if (poll.options.length <= 4) {
+                    if (poll.options.length <= 3) {
                         sheetend = 105;
                         rowsperpage = 4;
-                    } else if (poll.options.length <= 8) {
+                    } else if (poll.options.length <= 5) {
                         sheetend = 140;
                         rowsperpage = 3;
-                    } else if (poll.options.length <= 12) {
+                    } else if (poll.options.length <= 11) {
                         sheetend = 210;
                         rowsperpage = 2;
                     }
                     else { //works untill ~30 people
-                        sheetend = 418;
+                        sheetend = 417;
                         rowsperpage = 1;
                     }
                 } else {
@@ -460,7 +460,7 @@ angular.module('OpenSlidesApp.assignments.pdf', ['OpenSlidesApp.core.pdf'])
                         sheetend = 210;
                         rowsperpage = 2;
                     } else {
-                        sheetend = 418;
+                        sheetend = 417;
                         rowsperpage = 1;
                     }
                 }
@@ -473,10 +473,10 @@ angular.module('OpenSlidesApp.assignments.pdf', ['OpenSlidesApp.core.pdf'])
                             widths: ['50%', '50%'],
                             body: createTableBody(rowsperpage, sheetend),
                             pageBreak: 'after'
-                            },
-                            layout: PDFLayout.getBallotLayoutLines(),
-                            rowsperpage: rowsperpage
-                        });
+                        },
+                        layout: PDFLayout.getBallotLayoutLines(),
+                        rowsperpage: rowsperpage
+                    });
                 }
                 // fill the last page only partially
                 var lastpage_ballots = amount - (fullpages * page_entries);

--- a/openslides/assignments/static/templates/assignments/assignment-detail.html
+++ b/openslides/assignments/static/templates/assignments/assignment-detail.html
@@ -105,7 +105,7 @@
       </div>
       <div os-perms="assignments.can_nominate_other">
         <select chosen ng-model="candidateSelectBox.selected" ng-change="addCandidate(candidateSelectBox.selected)"
-            ng-options="user.id as user.get_full_name() for user in users"
+            ng-options="user.id as user.get_full_name() for user in users | orderBy: 'full_name'"
             search-contains="true"
             placeholder-text-single="'Select or search a participant ...' | translate"
             no-results-text="'No results available ...' | translate"
@@ -234,7 +234,7 @@
                 <div ng-init="votes = option.getVotes()">
                   <div ng-repeat="vote in votes">
                     <span ng-if="poll.pollmethod == 'yna' || poll.pollmethod == 'yn'">{{ vote.label }}:</span>
-                    {{ vote.value | number:votesPrecision }} {{ vote.percentStr }}
+                    {{ vote.value | textOrNumber:votesPrecision }} {{ vote.percentStr }}
                     <div ng-if="vote.percentNumber >= 0">
                       <uib-progressbar ng-if="$index == 0" value="vote.percentNumber" type="success"></uib-progressbar>
                       <uib-progressbar ng-if="$index == 1" value="vote.percentNumber" type="danger"></uib-progressbar>
@@ -255,31 +255,31 @@
               <td>
                 <translate>Abstain</translate>
               <td>
-                {{ poll.getVote('votesabstain').value | number:votesPrecision }}
+                {{ poll.getVote('votesabstain').value | textOrNumber:votesPrecision }}
                 {{ poll.getVote('votesabstain').percentStr }}
             <tr ng-if="poll.pollmethod === 'votes'">
               <td>
                 <translate>No</translate>
               <td>
-                {{ poll.getVote('votesno').value | number:votesPrecision }}
+                {{ poll.getVote('votesno').value | textOrNumber:votesPrecision }}
                 {{ poll.getVote('votesno').percentStr }}
             <tr>
               <td>
                 <translate>Valid ballots</translate>
               <td>
-                {{ poll.getVote('votesvalid').value | number:votesPrecision }}
+                {{ poll.getVote('votesvalid').value | textOrNumber:votesPrecision }}
                 {{ poll.getVote('votesvalid').percentStr }}
             <tr>
               <td>
                 <translate>Invalid ballots</translate>
               <td>
-                {{ poll.getVote('votesinvalid').value | number:votesPrecision }}
+                {{ poll.getVote('votesinvalid').value | textOrNumber:votesPrecision }}
                 {{ poll.getVote('votesinvalid').percentStr }}
             <tr class="total bg-info">
               <td>
                 <translate>Casted ballots</translate>
               <td>
-                {{ poll.getVote('votescast').value | number:votesPrecision }}
+                {{ poll.getVote('votescast').value | textOrNumber:votesPrecision }}
                 {{ poll.getVote('votescast').percentStr }}
           </table>
 

--- a/openslides/assignments/static/templates/assignments/slide_assignment.html
+++ b/openslides/assignments/static/templates/assignments/slide_assignment.html
@@ -49,16 +49,16 @@
           <div ng-init="votes = option.getVotes()">
             <div ng-show="poll.pollmethod == 'yna' || poll.pollmethod == 'yn'">
               <span ng-show="poll.pollmethod == 'yna'">
-                {{ votes[0].label | translate }}: {{ votes[0].value | number:votesPrecision }} {{ votes[0].percentStr }}<br>
-                {{ votes[1].label | translate }}: {{ votes[1].value | number:votesPrecision }} {{ votes[1].percentStr }}<br>
-                {{ votes[2].label | translate }}: {{ votes[2].value | number:votesPrecision }} {{ votes[2].percentStr }}</span>
+                {{ votes[0].label | translate }}: {{ votes[0].value | textOrNumber:votesPrecision }} {{ votes[0].percentStr }}<br>
+                {{ votes[1].label | translate }}: {{ votes[1].value | textOrNumber:votesPrecision }} {{ votes[1].percentStr }}<br>
+                {{ votes[2].label | translate }}: {{ votes[2].value | textOrNumber:votesPrecision }} {{ votes[2].percentStr }}</span>
               <span ng-show="poll.pollmethod == 'yn'">
-                {{ votes[0].label | translate }}: {{ votes[0].value | number:votesPrecision }} {{ votes[0].percentStr }}<br>
-                {{ votes[1].label | translate }}: {{ votes[1].value | number:votesPrecision }} {{ votes[1].percentStr }}</span>
+                {{ votes[0].label | translate }}: {{ votes[0].value | textOrNumber:votesPrecision }} {{ votes[0].percentStr }}<br>
+                {{ votes[1].label | translate }}: {{ votes[1].value | textOrNumber:votesPrecision }} {{ votes[1].percentStr }}</span>
             </div>
             <div ng-show="poll.pollmethod == 'votes'">
               <div ng-repeat="vote in votes">
-                {{ vote.value | number:votesPrecision }} {{ vote.percentStr }}
+                {{ vote.value | textOrNumber:votesPrecision }} {{ vote.percentStr }}
                 <div style="float:right; width:200px;" ng-if="vote.percentNumber >= 0">
                   <uib-progressbar value="vote.percentNumber" type="success"></uib-progressbar>
                 </div>
@@ -71,29 +71,29 @@
         <td>
           <translate>Abstain</translate>
         <td ng-init="vote = poll.getVote('votesabstain')">
-          {{ vote.value | number:votesPrecision }} {{ vote.percentStr }}
+          {{ vote.value | textOrNumber:votesPrecision }} {{ vote.percentStr }}
       <tr class="total" ng-if="poll.has_votes && poll.pollmethod === 'votes' && poll.getVote('votesno').value !== null">
         <td>
           <translate>No</translate>
         <td ng-init="vote = poll.getVote('votesno')">
-          {{ vote.value | number:votesPrecision }} {{ vote.percentStr }}
+          {{ vote.value | textOrNumber:votesPrecision }} {{ vote.percentStr }}
       <tr class="total" ng-if="poll.has_votes && poll.getVote('votesvalid').value !== null">
         <td>
           <translate>Valid ballots</translate>
         <td ng-init="vote = poll.getVote('votesvalid')">
-          {{ vote.value | number:votesPrecision }} {{ vote.percentStr }}
+          {{ vote.value | textOrNumber:votesPrecision }} {{ vote.percentStr }}
 
       <tr class="total" ng-if="poll.has_votes && poll.getVote('votesinvalid').value !== null">
         <td>
           <translate>Invalid ballots</translate>
         <td ng-init="vote = poll.getVote('votesinvalid')">
-          {{ vote.value | number:votesPrecision }} {{ vote.percentStr }}
+          {{ vote.value | textOrNumber:votesPrecision }} {{ vote.percentStr }}
 
       <tr class="total bg-info" ng-if="poll.has_votes && poll.getVote('votescast').value !== null">
         <td>
           <translate>Casted ballots</translate>
         <td ng-init="vote = poll.getVote('votescast')">
-          {{ vote.value | number:votesPrecision }} {{ vote.percentStr }}
+          {{ vote.value | textOrNumber:votesPrecision }} {{ vote.percentStr }}
       </table>
     </div>
 

--- a/openslides/core/static/js/core/base.js
+++ b/openslides/core/static/js/core/base.js
@@ -1675,6 +1675,20 @@ angular.module('OpenSlidesApp.core', [
     }
 ])
 
+// Returns number with decimal places or (if not a number) string (e.g. majority)
+.filter('textOrNumber', [
+    '$filter',
+    function ($filter) {
+        return function(input, votesPrecision) {
+            if(isNaN(input)) {
+                return input;
+            } else {
+                return $filter('number')(input, votesPrecision);
+            }
+        };
+    }
+])
+
 // Make sure that the DS factories are loaded by making them a dependency
 .run([
     'ChatMessage',

--- a/openslides/motions/static/js/motions/pdf.js
+++ b/openslides/motions/static/js/motions/pdf.js
@@ -191,37 +191,37 @@ angular.module('OpenSlidesApp.motions.pdf', ['OpenSlidesApp.core.pdf'])
                             // yes
                             var yes = poll.getVote(poll.yes, 'yes');
                             column1.push(gettextCatalog.getString('Yes') + ':');
-                            column2.push($filter('number')(yes.value, precision));
+                            column2.push($filter('textOrNumber')(yes.value, precision));
                             column3.push(yes.percentStr);
                             // no
                             var no = poll.getVote(poll.no, 'no');
                             column1.push(gettextCatalog.getString('No') + ':');
-                            column2.push($filter('number')(no.value, precision));
+                            column2.push($filter('textOrNumber')(no.value, precision));
                             column3.push(no.percentStr);
                             // abstain
                             var abstain = poll.getVote(poll.abstain, 'abstain');
                             column1.push(gettextCatalog.getString('Abstain') + ':');
-                            column2.push($filter('number')(abstain.value, precision));
+                            column2.push($filter('textOrNumber')(abstain.value, precision));
                             column3.push(abstain.percentStr);
                             // votes valid
                             if (poll.votesvalid) {
                                 var valid = poll.getVote(poll.votesvalid, 'votesvalid');
                                 column1.push(gettextCatalog.getString('Valid votes') + ':');
-                                column2.push($filter('number')(valid.value, precision));
+                                column2.push($filter('textOrNumber')(valid.value, precision));
                                 column3.push(valid.percentStr);
                             }
                             // votes invalid
                             if (poll.votesvalid) {
                                 var invalid = poll.getVote(poll.votesinvalid, 'votesinvalid');
                                 column1.push(gettextCatalog.getString('Invalid votes') + ':');
-                                column2.push($filter('number')(invalid.value, precision));
+                                column2.push($filter('textOrNumber')(invalid.value, precision));
                                 column3.push(invalid.percentStr);
                             }
                             // votes cast
                             if (poll.votescast) {
                                 var cast = poll.getVote(poll.votescast, 'votescast');
                                 column1.push(gettextCatalog.getString('Votes cast') + ':');
-                                column2.push($filter('number')(cast.value, precision));
+                                column2.push($filter('textOrNumber')(cast.value, precision));
                                 column3.push(cast.percentStr);
                             }
                         }

--- a/openslides/motions/static/templates/motions/motion-detail.html
+++ b/openslides/motions/static/templates/motions/motion-detail.html
@@ -404,7 +404,7 @@
                     <td ng-init="voteYes = poll.getVote(poll.yes, 'yes')">
                       <span class="result-label"><translate>Yes</translate>:</span>
                       <span class="result_value">
-                        {{ voteYes.value | number:votesPrecision }} {{ voteYes.percentStr }}
+                        {{ voteYes.value | textOrNumber:votesPrecision }} {{ voteYes.percentStr }}
                       </span>
                       <div ng-if="voteYes.percentNumber">
                         <uib-progressbar value="voteYes.percentNumber" type="success"></uib-progressbar>
@@ -416,7 +416,7 @@
                     <td ng-init="voteNo = poll.getVote(poll.no, 'no')">
                       <span class="result-label"><translate>No</translate>:</span>
                       <span class="result_value" >
-                        {{ voteNo.value | number:votesPrecision }} {{ voteNo.percentStr }}
+                        {{ voteNo.value | textOrNumber:votesPrecision }} {{ voteNo.percentStr }}
                       </span>
                       <div ng-if="voteNo.percentNumber">
                         <uib-progressbar value="voteNo.percentNumber" type="danger"></uib-progressbar>
@@ -428,7 +428,7 @@
                     <td ng-init="voteAbstain = poll.getVote(poll.abstain, 'abstain')">
                       <span class="result-label"><translate>Abstain</translate>:</span>
                       <span class="result_value">
-                        {{ voteAbstain.value | number:votesPrecision }} {{ voteAbstain.percentStr }}
+                        {{ voteAbstain.value | textOrNumber:votesPrecision }} {{ voteAbstain.percentStr }}
                       </span>
                       <div ng-if="voteAbstain.percentNumber">
                         <uib-progressbar value="voteAbstain.percentNumber" type="warning"></uib-progressbar>
@@ -440,7 +440,7 @@
                     <td ng-init="votesValid = poll.getVote(poll.votesvalid, 'votesvalid')">
                       <span class="result-label"><translate>Valid votes</translate>:</span>
                       <span class="result_value">
-                        {{ votesValid.value | number:votesPrecision }} {{ votesValid.percentStr }}
+                        {{ votesValid.value | textOrNumber:votesPrecision }} {{ votesValid.percentStr }}
                       </span>
                   <!-- invalid votes -->
                   <tr ng-if="poll.votesinvalid !== null">
@@ -449,7 +449,7 @@
                     <td ng-init="votesInvalid = poll.getVote(poll.votesinvalid, 'votesinvalid')">
                       <span class="result-label"><translate>Invalid votes</translate>:</span>
                       <span class="result_value">
-                        {{ votesInvalid.value | number:votesPrecision }} {{ votesInvalid.percentStr }}
+                        {{ votesInvalid.value | textOrNumber:votesPrecision }} {{ votesInvalid.percentStr }}
                       </span>
                   <!-- votes cast -->
                   <tr class="total" ng-if="poll.votescast !== null">
@@ -458,7 +458,7 @@
                     <td ng-init="votesCast = poll.getVote(poll.votescast, 'votescast')">
                       <span class="result-label"><translate>Votes cast</translate>:</span>
                       <span class="result_value">
-                        {{ votesCast.value | number:votesPrecision }} {{ votesCast.percentStr }}
+                        {{ votesCast.value | textOrNumber:votesPrecision }} {{ votesCast.percentStr }}
                       </span>
 
                   <!-- majority calculation -->

--- a/openslides/motions/static/templates/motions/motion-submitters.html
+++ b/openslides/motions/static/templates/motions/motion-submitters.html
@@ -34,7 +34,7 @@
     <select chosen
         ng-model="submitterSelectBox.selected"
         ng-change="addSubmitter(submitterSelectBox.selected)"
-        ng-options="user.id as user.get_full_name() for user in users"
+        ng-options="user.id as user.get_full_name() for user in users | orderBy: 'full_name'"
         search-contains="true"
         placeholder-text-single="'Select or search a participant ...' | translate"
         no-results-text="'No results available ...' | translate"

--- a/openslides/motions/static/templates/motions/slide_motion.html
+++ b/openslides/motions/static/templates/motions/slide_motion.html
@@ -31,7 +31,7 @@
               <td ng-init="voteYes = poll.getVote(poll.yes, 'yes')">
                 <span class="result_label"><translate>Yes</translate>:</span>
                 <span class="result_value">
-                  {{ voteYes.value | number:getPollVotesPrecision(poll) }} {{ voteYes.percentStr }}
+                  {{ voteYes.value | textOrNumber:getPollVotesPrecision(poll) }} {{ voteYes.percentStr }}
                 </span>
                 <div ng-if="voteYes.percentNumber">
                   <uib-progressbar value="voteYes.percentNumber" type="success"></uib-progressbar>
@@ -43,7 +43,7 @@
               <td ng-init="voteNo = poll.getVote(poll.no, 'no')">
                 <span class="result_label"><translate>No</translate>:</span>
                 <span class="result_value" >
-                  {{ voteNo.value | number:getPollVotesPrecision(poll) }} {{ voteNo.percentStr }}
+                  {{ voteNo.value | textOrNumber:getPollVotesPrecision(poll) }} {{ voteNo.percentStr }}
                 </span>
                 <div ng-if="voteNo.percentNumber">
                   <uib-progressbar value="voteNo.percentNumber" type="danger"></uib-progressbar>
@@ -55,7 +55,7 @@
               <td ng-init="voteAbstain = poll.getVote(poll.abstain, 'abstain')">
                 <span class="result_label"><translate>Abstain</translate>:</span>
                 <span class="result_value">
-                  {{ voteAbstain.value | number:getPollVotesPrecision(poll) }} {{ voteAbstain.percentStr }}
+                  {{ voteAbstain.value | textOrNumber:getPollVotesPrecision(poll) }} {{ voteAbstain.percentStr }}
                 </span>
                 <div ng-if="voteAbstain.percentNumber">
                   <uib-progressbar value="voteAbstain.percentNumber" type="warning"></uib-progressbar>


### PR DESCRIPTION
- Fixed sorting of users in dropdowns for speakers, submitters and candidates.
- Fixed assignment ballot paper layout (more space required for global 'no').
- Fixed missing output of special poll values. Use new filter 'textOrNumber'
  to return decimal number or string (e.g. 'majority').