### PR TITLE
navigate to main page after click on the logo

### DIFF
--- a/client/src/app/site/site.component.html
+++ b/client/src/app/site/site.component.html
@@ -2,7 +2,7 @@
     <mat-sidenav #sideNav [mode]="vp.isMobile ? 'push' : 'side'" [opened]='!vp.isMobile' disableClose='!vp.isMobile' class="side-panel">
         <mat-toolbar class='nav-toolbar'>
             <!-- logo -->
-            <mat-toolbar-row class='os-logo-container'>
+            <mat-toolbar-row class='os-logo-container' (click)= navigateToMainPage()>
             </mat-toolbar-row>
         </mat-toolbar>
 

--- a/client/src/app/site/site.component.scss
+++ b/client/src/app/site/site.component.scss
@@ -10,6 +10,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     background-position: center;
+    cursor: pointer;
 }
 
 .side-panel {

--- a/client/src/app/site/site.component.ts
+++ b/client/src/app/site/site.component.ts
@@ -123,4 +123,8 @@ export class SiteComponent extends BaseComponent implements OnInit {
     public logout(): void {
         this.authService.logout();
     }
+
+    public navigateToMainPage(): void {
+        this.router.navigate(['/']);
+    }
 }


### PR DESCRIPTION
addresses a wish from #3896 : On clicking on the os-logo (top left), one is redirected to the start page.
I'm not sure if this is *always* a good idea.
