### PR TITLE
Creating / Editing / Showing statute paragraph amendments

### DIFF
--- a/client/src/app/core/marked-translations.ts
+++ b/client/src/app/core/marked-translations.ts
@@ -115,6 +115,7 @@ _('Default text version for change recommendations');
 // subgroup Amendments
 _('Amendments');
 _('Activate amendments');
+_('Activate statutes');
 _('Show amendments together with motions');
 _('Prefix for the identifier for amendments');
 _('The title of the motion is always applied.');

--- a/client/src/app/shared/models/motions/motion.ts
+++ b/client/src/app/shared/models/motions/motion.ts
@@ -30,6 +30,7 @@ export class Motion extends AgendaBaseModel {
     public state_id: number;
     public state_extension: string;
     public state_required_permission_to_see: string;
+    public statute_paragraph_id: number;
     public recommendation_id: number;
     public recommendation_extension: string;
     public tags_id: number[];

--- a/client/src/app/site/motions/components/motion-detail/motion-detail.component.html
+++ b/client/src/app/site/motions/components/motion-detail/motion-detail.component.html
@@ -259,7 +259,7 @@
     <form class="motion-content" [formGroup]='contentForm' (ngSubmit)='saveMotion()'>
 
         <!-- Line Number and Diff buttons-->
-        <div *ngIf="!editMotion" class="motion-text-controls">
+        <div *ngIf="motion && !editMotion && !motion.isStatuteAmendment()" class="motion-text-controls">
             <button type="button" mat-icon-button [matMenuTriggerFor]="lineNumberingMenu" matTooltip="{{ 'Line numbering' | translate }}">
                 <mat-icon>format_list_numbered</mat-icon>
             </button>
@@ -268,11 +268,29 @@
             </button>
         </div>
 
+        <!-- Selecting statute paragraphs for amendment -->
+        <div class="statute-amendment-selector" *ngIf="editMotion && statuteParagraphs.length > 0 && statutesEnabled">
+            <mat-checkbox formControlName='statute_amendment' translate (change)="onStatuteAmendmentChange($event)">
+                Statute amendment
+            </mat-checkbox>
+
+            <mat-form-field *ngIf="contentForm.value.statute_amendment">
+                <mat-select [placeholder]="'Select paragraph to amend' | translate"
+                            formControlName='statute_paragraph_id'
+                            (valueChange)="onStatuteParagraphChange($event)">
+                    <mat-option *ngFor="let paragraph of statuteParagraphs" [value]="paragraph.id">
+                        {{ paragraph.title }}
+                    </mat-option>
+                </mat-select>
+            </mat-form-field>
+        </div>
+
         <!-- Title -->
         <div *ngIf="motion && motion.title || editMotion">
             <div *ngIf='!editMotion'>
                 <h4>{{motion.title}}</h4>
             </div>
+
             <mat-form-field *ngIf="editMotion" class="wide-form">
                 <input matInput osAutofocus placeholder="{{ 'Title' | translate }}" formControlName='title' [value]='motionCopy.title'
                     required>
@@ -283,7 +301,7 @@
         <!-- Text -->
         <!-- TODO: this is a config variable. Read it out -->
         <span class="text-prefix-label" translate>The assembly may decide:</span>
-        <ng-container *ngIf='motion && !editMotion'>
+        <ng-container *ngIf='motion && !editMotion && !motion.isStatuteAmendment()'>
             <div *ngIf="!isRecoModeDiff()" class="motion-text" [class.line-numbers-none]="isLineNumberingNone()"
                 [class.line-numbers-inline]="isLineNumberingInline()" [class.line-numbers-outside]="isLineNumberingOutside()">
                 <os-motion-detail-original-change-recommendations *ngIf="isLineNumberingOutside() && isRecoModeOriginal()"
@@ -294,6 +312,10 @@
             <os-motion-detail-diff *ngIf="isRecoModeDiff()" [motion]="motion" [changes]="allChangingObjects"
                 [scrollToChange]="scrollToChange" (createChangeRecommendation)="createChangeRecommendation($event)"></os-motion-detail-diff>
         </ng-container>
+        <div class="motion-text line-numbers-none" *ngIf="motion && !editMotion && motion.isStatuteAmendment()"
+             [innerHTML]="getFormattedStatuteAmendment()">
+        </div>
+
         <mat-form-field *ngIf="motion && editMotion" class="wide-form">
             <textarea matInput placeholder="{{ 'Motion text' | translate }}" formControlName='text' [value]='motionCopy.text' required></textarea>
         </mat-form-field>

--- a/client/src/app/site/motions/components/motion-detail/motion-detail.component.scss
+++ b/client/src/app/site/motions/components/motion-detail/motion-detail.component.scss
@@ -113,6 +113,12 @@ span {
     }
 }
 
+.statute-amendment-selector {
+    mat-form-field {
+        margin-left: 20px;
+    }
+}
+
 .motion-content {
     h4 {
         margin: 10px 10px 15px 0;

--- a/client/src/app/site/motions/components/motion-list/motion-list.component.html
+++ b/client/src/app/site/motions/components/motion-list/motion-list.component.html
@@ -96,7 +96,7 @@
         <span translate>Comment sections</span>
     </button>
 
-    <button mat-menu-item routerLink="statute-paragraphs">
+    <button mat-menu-item routerLink="statute-paragraphs" *ngIf="statutesEnabled">
         <mat-icon>account_balance</mat-icon>
         <span translate>Statute paragraphs</span>
     </button>

--- a/client/src/app/site/motions/components/motion-list/motion-list.component.ts
+++ b/client/src/app/site/motions/components/motion-list/motion-list.component.ts
@@ -9,6 +9,7 @@ import { ViewMotion } from '../../models/view-motion';
 import { WorkflowState } from '../../../../shared/models/motions/workflow-state';
 import { ListViewBaseComponent } from '../../../base/list-view-base';
 import { MatSnackBar } from '@angular/material';
+import { ConfigService } from "../../../../core/services/config.service";
 
 /**
  * Component that displays all the motions in a Table using DataSource.
@@ -32,12 +33,20 @@ export class MotionListComponent extends ListViewBaseComponent<ViewMotion> imple
     public columnsToDisplayFullWidth = ['identifier', 'title', 'state', 'speakers'];
 
     /**
+     * Value of the configuration variable `motions_statutes_enabled` - are statutes enabled?
+     * @TODO replace by direct access to config variable, once it's available from the templates
+     */
+    public statutesEnabled: boolean;
+
+    /**
      * Constructor implements title and translation Module.
      *
      * @param titleService Title
      * @param translate Translation
+     * @param matSnackBar
      * @param router Router
      * @param route Current route
+     * @param configService The configuration provider
      * @param repo Motion Repository
      */
     public constructor(
@@ -46,6 +55,7 @@ export class MotionListComponent extends ListViewBaseComponent<ViewMotion> imple
         matSnackBar: MatSnackBar,
         private router: Router,
         private route: ActivatedRoute,
+        private configService: ConfigService,
         private repo: MotionRepositoryService
     ) {
         super(titleService, translate, matSnackBar);
@@ -68,6 +78,9 @@ export class MotionListComponent extends ListViewBaseComponent<ViewMotion> imple
                     return a.id - b.id;
                 }
             });
+        });
+        this.configService.get('motions_statutes_enabled').subscribe((enabled: boolean): void => {
+            this.statutesEnabled = enabled;
         });
     }
 

--- a/client/src/app/site/motions/models/view-motion.ts
+++ b/client/src/app/site/motions/models/view-motion.ts
@@ -138,6 +138,10 @@ export class ViewMotion extends BaseViewModel {
         return this.motion && this.motion.recommendation_id ? this.motion.recommendation_id : null;
     }
 
+    public get statute_paragraph_id(): number {
+        return this.motion && this.motion.statute_paragraph_id ? this.motion.statute_paragraph_id : null;
+    }
+
     public get recommendation(): WorkflowState {
         return this.recommendation_id && this.workflow ? this.workflow.getStateById(this.recommendation_id) : null;
     }
@@ -267,6 +271,10 @@ export class ViewMotion extends BaseViewModel {
 
     public hasSupporters(): boolean {
         return !!(this.supporters && this.supporters.length > 0);
+    }
+
+    public isStatuteAmendment(): boolean {
+        return !!this.statute_paragraph_id;
     }
 
     /**

--- a/client/src/app/site/motions/services/motion-repository.service.ts
+++ b/client/src/app/site/motions/services/motion-repository.service.ts
@@ -14,6 +14,7 @@ import { DiffService, LineRange, ModificationType } from './diff.service';
 import { ViewChangeReco } from '../models/view-change-reco';
 import { MotionChangeReco } from '../../../shared/models/motions/motion-change-reco';
 import { ViewUnifiedChange } from '../models/view-unified-change';
+import { ViewStatuteParagraph }  from '../models/view-statute-paragraph';
 import { Identifiable } from '../../../shared/models/base/identifiable';
 import { CollectionStringModelMapperService } from '../../../core/services/collectionStringModelMapper.service';
 import { HttpService } from 'app/core/services/http.service';
@@ -223,6 +224,13 @@ export class MotionRepositoryService extends BaseRepository<ViewMotion, Motion> 
         } else {
             return null;
         }
+    }
+
+    public formatStatuteAmendment(paragraphs: ViewStatuteParagraph[], amendment: ViewMotion, lineLength: number): string {
+        const origParagraph = paragraphs.find(paragraph => paragraph.id === amendment.statute_paragraph_id);
+        let diffHtml = this.diff.diff(origParagraph.text, amendment.text);
+        diffHtml = this.lineNumbering.insertLineBreaksWithoutNumbers(diffHtml, lineLength, true);
+        return diffHtml;
     }
 
     /**

--- a/openslides/motions/config_variables.py
+++ b/openslides/motions/config_variables.py
@@ -138,6 +138,17 @@ def get_config_variables():
         group='Motions',
         subgroup='General')
 
+    # Statutes
+
+    yield ConfigVariable(
+        name='motions_statutes_enabled',
+        default_value=False,
+        input_type='boolean',
+        label='Activate statutes',
+        weight=334,
+        group='Motions',
+        subgroup='General')
+
     # Amendments
     yield ConfigVariable(
         name='motions_amendments_enabled',

--- a/openslides/motions/serializers.py
+++ b/openslides/motions/serializers.py
@@ -406,6 +406,7 @@ class MotionSerializer(ModelSerializer):
             'state',
             'state_extension',
             'state_required_permission_to_see',
+            'statute_paragraph',
             'workflow_id',
             'recommendation',
             'recommendation_extension',
@@ -461,6 +462,7 @@ class MotionSerializer(ModelSerializer):
         motion.motion_block = validated_data.get('motion_block')
         motion.origin = validated_data.get('origin', '')
         motion.parent = validated_data.get('parent')
+        motion.statute_paragraph = validated_data.get('statute_paragraph')
         motion.reset_state(validated_data.get('workflow_id'))
         motion.agenda_item_update_information['type'] = validated_data.get('agenda_type')
         motion.agenda_item_update_information['parent_id'] = validated_data.get('agenda_parent_id')


### PR DESCRIPTION
A very basic first implementation of the specification for the statute paragraphs:
- If statute paragraphs are defined: When creating a motion, a checkbox appears to set this motion as a statute paragraph amendment. If the checkbox is activated, a SELECT appears, allowing to select the paragraph. If one is selected, the title and text below are pre-filled.
- After creating the statute amendment, the amendment is shown in simple diff view.

Questions for potential enhancements would be:
- Do statute amendments have line numbering? Or does the statute in itself have line numbers, for that matter? (If so, it would probably have to be continuous along the different paragraph objects)
- What views does such an amendment have? Diff, obviously. But also the "changed" view?
- How to handle the workflows? I'd be glad if that could be implemented by someone else, as I'm not very familiar with them.