### PR TITLE
Fix error, that user get full_data when restricted_data_cache was enabled

### DIFF
--- a/openslides/utils/consumers.py
+++ b/openslides/utils/consumers.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from typing import Any, Dict, List
 from urllib.parse import parse_qs
 
-from .auth import async_anonymous_is_enabled
+from .auth import async_anonymous_is_enabled, user_to_collection_user
 from .cache import element_cache, split_element_id
 from .collection import AutoupdateFormat
 from .websocket import ProtocollAsyncJsonWebsocketConsumer, get_element_data
@@ -44,7 +44,7 @@ class SiteConsumer(ProtocollAsyncJsonWebsocketConsumer):
 
         if change_id is not None:
             try:
-                data = await get_element_data(self.scope['user'], change_id)
+                data = await get_element_data(user_to_collection_user(self.scope['user']), change_id)
             except ValueError:
                 # When the change_id is to big, do nothing
                 pass
@@ -82,7 +82,10 @@ class SiteConsumer(ProtocollAsyncJsonWebsocketConsumer):
         Send changed or deleted elements to the user.
         """
         change_id = event['change_id']
-        changed_elements, deleted_elements_ids = await element_cache.get_restricted_data(self.scope['user'], change_id, max_change_id=change_id)
+        changed_elements, deleted_elements_ids = await element_cache.get_restricted_data(
+            user_to_collection_user(self.scope['user']),
+            change_id,
+            max_change_id=change_id)
 
         deleted_elements: Dict[str, List[int]] = defaultdict(list)
         for element_id in deleted_elements_ids:

--- a/tests/integration/utils/test_consumers.py
+++ b/tests/integration/utils/test_consumers.py
@@ -93,6 +93,29 @@ async def test_connection_with_change_id(get_communicator):
 
 
 @pytest.mark.asyncio
+async def test_connection_with_change_id_get_restricted_data_with_restricted_data_cache(get_communicator):
+    """
+    Test, that the returned data is the restricted_data when restricted_data_cache is activated
+    """
+    try:
+        # Save the value of use_restricted_data_cache
+        original_use_restricted_data = element_cache.use_restricted_data_cache
+        element_cache.use_restricted_data_cache = True
+
+        await set_config('general_system_enable_anonymous', True)
+        communicator = get_communicator('change_id=0')
+        await communicator.connect()
+
+        response = await communicator.receive_json_from()
+
+        content = response.get('content')
+        assert content['changed']['app/collection1'][0]['value'] == 'restricted_value1'
+    finally:
+        # reset the value of use_restricted_data_cache
+        element_cache.use_restricted_data_cache = original_use_restricted_data
+
+
+@pytest.mark.asyncio
 async def test_connection_with_invalid_change_id(get_communicator):
     await set_config('general_system_enable_anonymous', True)
     communicator = get_communicator('change_id=invalid')


### PR DESCRIPTION
There is a bug in the current master, that when the restricted_data_cache is enabled, the websocket connection always returns full_data.

Its time we get rid of the CollectionElement...