### PR TITLE
multiSelect on listViews

### DIFF
--- a/client/src/app/shared/components/head-bar/head-bar.component.html
+++ b/client/src/app/shared/components/head-bar/head-bar.component.html
@@ -1,13 +1,13 @@
-<mat-toolbar color='primary' *ngIf="!vp.isMobile"></mat-toolbar>
-<mat-toolbar color='primary' class="sticky-toolbar">
+<mat-toolbar color="primary" [ngClass]="multiSelectMode ? 'multi-select' : '' " *ngIf="!vp.isMobile"></mat-toolbar>
+<mat-toolbar color="primary" [ngClass]="multiSelectMode ? 'multi-select' : '' " class="sticky-toolbar">
     <div class="toolbar-left">
         <!-- Nav menu -->
-        <button mat-icon-button class="on-transition-fade" *ngIf="vp.isMobile && nav" (click)='clickHamburgerMenu()'>
+        <button mat-icon-button class="on-transition-fade" *ngIf="vp.isMobile && nav && !multiSelectMode" (click)='clickHamburgerMenu()'>
             <mat-icon>menu</mat-icon>
         </button>
 
         <!-- Exit / Back button -->
-        <button mat-icon-button class="on-transition-fade" *ngIf="!nav && !editMode" (click)="onBackButton()">
+        <button mat-icon-button class="on-transition-fade" *ngIf="!nav && !editMode && !multiSelectMode" (click)="onBackButton()">
             <mat-icon>arrow_back</mat-icon>
         </button>
 
@@ -16,22 +16,28 @@
             <mat-icon>close</mat-icon>
         </button>
 
-        <div class="toolbar-left-text on-transition-fade">
+        <div class="toolbar-left-text on-transition-fade" *ngIf="!multiSelectMode">
             <!-- Title slot -->
             <ng-content select=".title-slot"></ng-content>
         </div>
     </div>
-    <div class=spacer></div>
-    <div class="toolbar-right">
 
+    <!-- centered information slot-->
+    <div *ngIf="multiSelectMode" class=spacer></div>
+    <div class="toolbar-centered on-transition-fade" *ngIf="multiSelectMode">
+        <ng-content select=".central-info-slot"></ng-content>
+    </div>
+    <div class=spacer></div>
+
+    <div class="toolbar-right">
         <!-- Extra controls slot -->
         <div class="extra-controls-wrapper on-transition-fade">
             <ng-content select=".extra-controls-slot"></ng-content>
         </div>
 
         <!-- Main action button - desktop -->
-        <button mat-mini-fab color="accent" class="on-transition-fade" *ngIf="mainButton && !editMode && !vp.isMobile"
-            (click)="sendMainEvent()">
+        <button mat-mini-fab color="accent" class="on-transition-fade"
+            *ngIf="mainButton && !editMode && !vp.isMobile && !multiSelectMode" (click)="sendMainEvent()">
             <mat-icon>{{ mainButtonIcon }}</mat-icon>
         </button>
 
@@ -46,6 +52,8 @@
 </mat-toolbar>
 
 <!-- Main action button - mobile-->
-<button mat-fab class="head-button on-transition-fade" *ngIf="mainButton && !editMode && vp.isMobile" (click)=sendMainEvent()>
+
+<button mat-fab class="head-button on-transition-fade"
+    *ngIf="mainButton && !editMode && vp.isMobile && !multiSelectMode" (click)=sendMainEvent()>
     <mat-icon>{{ mainButtonIcon }}</mat-icon>
 </button>

--- a/client/src/app/shared/components/head-bar/head-bar.component.scss
+++ b/client/src/app/shared/components/head-bar/head-bar.component.scss
@@ -18,6 +18,10 @@
         margin-left: 10px;
     }
 }
+.toolbar-centered {
+    margin: auto;
+    vertical-align: baseline;
+}
 
 .toolbar-right {
     display: contents;
@@ -28,4 +32,8 @@
     ::ng-deep .extra-controls-slot {
         display: flex;
     }
+}
+
+mat-toolbar.multi-select {
+    background-color: #757575;
 }

--- a/client/src/app/shared/components/head-bar/head-bar.component.ts
+++ b/client/src/app/shared/components/head-bar/head-bar.component.ts
@@ -20,6 +20,7 @@ import { MainMenuService } from '../../../core/services/main-menu.service';
  *   [mainButton]="opCanEdit()"
  *   [mainButtonIcon]="edit"
  *   [editMode]="editMotion"
+ *   [multiSelectMode]="isMultiSelect"
  *   (mainEvent)="setEditMode(!editMotion)"
  *   (saveEvent)="saveMotion()">
  *
@@ -34,6 +35,13 @@ import { MainMenuService } from '../../../core/services/main-menu.service';
  *             <mat-icon>more_vert</mat-icon>
  *         </button>
  *     </div>
+ *     <!-- MultiSelect info -->
+ *     <div class="central-info-slot">
+ *     <button mat-icon-button (click)="toggleMultiSelect()">
+ *         <mat-icon>arrow_back</mat-icon>
+ *     </button>
+ *         <span>{{ selectedRows.length }}&nbsp;</span><span translate>selected</span>
+ * </div>
  * </os-head-bar>
  * ```
  */
@@ -60,6 +68,12 @@ export class HeadBarComponent {
      */
     @Input()
     public editMode = false;
+
+    /**
+     * Determine multiSelect mode: changed interactions and head bar
+     */
+    @Input()
+    public multiSelectMode = false;
 
     /**
      * Determine if there should be the main action button

--- a/client/src/app/site/agenda/components/agenda-list/agenda-list.component.html
+++ b/client/src/app/site/agenda/components/agenda-list/agenda-list.component.html
@@ -1,21 +1,50 @@
-<os-head-bar [mainButton]="true" (mainEvent)=onPlusButton()>
+<os-head-bar [mainButton]="true" (mainEvent)=onPlusButton() [multiSelectMode]="isMultiSelect">
     <!-- Title -->
     <div class="title-slot">
         <h2 translate>Agenda</h2>
     </div>
+    <!-- Menu -->
+    <div class="menu-slot">
+        <button type="button" mat-icon-button [matMenuTriggerFor]="agendaMenu">
+            <mat-icon>more_vert</mat-icon>
+        </button>
+    </div>
+
+    <!-- Multiselect info -->
+    <div class="central-info-slot">
+        <button mat-icon-button (click)="toggleMultiSelect()">
+            <mat-icon>arrow_back</mat-icon>
+        </button>
+        <span>{{ selectedRows.length }}&nbsp;</span><span translate>selected</span>
+    </div>
+
+    <div class="extra-controls-slot on-transition-fade" *ngIf="isMultiSelect">
+        <button mat-icon-button (click)="deleteSelected()">
+            <mat-icon>delete</mat-icon>
+        </button>
+    </div>
+
 </os-head-bar>
 
+
 <mat-table class="os-listview-table on-transition-fade" [dataSource]="dataSource" matSort>
+    <ng-container matColumnDef="selector">
+        <mat-header-cell *matHeaderCellDef mat-sort-header class="checkbox-cell"></mat-header-cell>
+        <mat-cell *matCellDef="let item" class="checkbox-cell">
+            <mat-icon>{{ isSelected(item) ? 'check_circle' : '' }}</mat-icon>
+        </mat-cell>
+    </ng-container>
+
     <!-- title column -->
     <ng-container matColumnDef="title">
         <mat-header-cell *matHeaderCellDef mat-sort-header>Topic</mat-header-cell>
-        <mat-cell *matCellDef="let item" (click)="selectAgendaItem(item)">{{ item.getListTitle() }}</mat-cell>
+        <mat-cell *matCellDef="let item">{{ item.getListTitle() }}</mat-cell>
     </ng-container>
 
     <!-- Duration column -->
     <ng-container matColumnDef="duration">
         <mat-header-cell *matHeaderCellDef mat-sort-header>Duration</mat-header-cell>
-        <mat-cell *matCellDef="let item" (click)="selectAgendaItem(item)">{{ item.duration }}</mat-cell>
+        <mat-cell *matCellDef="let item">{{ item.duration }}</mat-cell>
     </ng-container>
 
     <!-- Speakers column -->
@@ -32,7 +61,45 @@
         </mat-cell>
     </ng-container>
 
-    <mat-header-row *matHeaderRowDef="['title', 'duration', 'speakers']"></mat-header-row>
-    <mat-row *matRowDef="let row; columns: ['title', 'duration', 'speakers']"></mat-row>
+    <mat-header-row *matHeaderRowDef="getColumnDefinition()"></mat-header-row>
+    <mat-row [ngClass]="selectedRows.indexOf(row) >= 0 ? 'selected': ''" (click)='selectItem(row, $event)'
+        *matRowDef="let row; columns: getColumnDefinition()"></mat-row>
 </mat-table>
 <mat-paginator class="on-transition-fade" [pageSizeOptions]="[25, 50, 75, 100, 125]"></mat-paginator>
+
+<mat-menu #agendaMenu="matMenu">
+    <div *ngIf="!isMultiSelect">
+        <button mat-menu-item *osPerms="'agenda.can_manage'" (click)="toggleMultiSelect()">
+            <mat-icon>library_add</mat-icon>
+            <span translate>MultiSelect</span>
+        </button>
+    </div>
+
+    <div *ngIf="isMultiSelect" >
+        <div *osPerms="'agenda.can_manage'">
+            <button mat-menu-item (click)="deleteSelected()">
+                <mat-icon>delete</mat-icon>
+                <span translate>Delete selected</span>
+            </button>
+            <mat-divider></mat-divider>
+            <button mat-menu-item (click)="setClosedSelected(true)">
+                <mat-icon>done</mat-icon>
+                <span translate>Close selected</span>
+            </button>
+            <button mat-menu-item (click)="setClosedSelected(false)">
+                <mat-icon>redo</mat-icon>
+                <span translate>Open selected</span>
+            </button>
+
+            <mat-divider></mat-divider>
+            <button mat-menu-item (click)="setVisibilitySelected(true)">
+                <mat-icon>visibility</mat-icon>
+                <span translate>Set visible</span>
+            </button>
+            <button mat-menu-item (click)="setVisibilitySelected(false)">
+                <mat-icon>visibility_off</mat-icon>
+                <span translate>Set invisible</span>
+            </button>
+        </div>
+    </div>
+</mat-menu>

--- a/client/src/app/site/assignments/assignment-list/assignment-list.component.html
+++ b/client/src/app/site/assignments/assignment-list/assignment-list.component.html
@@ -1,18 +1,40 @@
-<os-head-bar plusButton=true (plusButtonClicked)=onPlusButton()>
+<os-head-bar plusButton=true (plusButtonClicked)=onPlusButton() [multiSelectMode]="isMultiSelect">
     <!-- Title -->
     <div class="title-slot">
+
         <h2 translate>Elections</h2>
     </div>
-
     <!-- Menu -->
     <div class="menu-slot">
         <button type="button" mat-icon-button [matMenuTriggerFor]="assignmentMenu">
             <mat-icon>more_vert</mat-icon>
         </button>
     </div>
+
+    <!-- Multiselect info -->
+    <div class="central-info-slot">
+        <button mat-icon-button (click)="toggleMultiSelect()">
+            <mat-icon>arrow_back</mat-icon>
+        </button>
+        <span>{{ selectedRows.length }}&nbsp;</span><span translate>selected</span>
+    </div>
+
+    <div class="extra-controls-slot on-transition-fade" *ngIf="isMultiSelect">
+        <button mat-icon-button (click)="deleteSelected()">
+            <mat-icon>delete</mat-icon>
+        </button>
+    </div>
+
 </os-head-bar>
 
+
 <mat-table class="os-listview-table on-transition-fade" [dataSource]="dataSource" matSort>
+    <ng-container matColumnDef="selector">
+        <mat-header-cell *matHeaderCellDef mat-sort-header class="checkbox-cell" ></mat-header-cell>
+        <mat-cell *matCellDef="let assignment" class="checkbox-cell" >
+            <mat-icon>{{ isSelected(assignment) ? 'check_circle' : '' }}</mat-icon>
+        </mat-cell>
+    </ng-container>
     <!-- name column -->
     <ng-container matColumnDef="title">
         <mat-header-cell *matHeaderCellDef mat-sort-header>Title</mat-header-cell>
@@ -35,15 +57,30 @@
         </mat-cell>
     </ng-container>
 
-    <mat-header-row *matHeaderRowDef="['title', 'phase', 'candidates']"></mat-header-row>
-    <mat-row (click)="selectAssignment(row)" *matRowDef="let row; columns: ['title', 'phase', 'candidates']"></mat-row>
+    <mat-header-row *matHeaderRowDef="getColumnDefintion()"></mat-header-row>
+    <mat-row [ngClass]="selectedRows.indexOf(row) >= 0 ? 'selected': ''" (click)='selectItem(row, $event)'
+        *matRowDef="let row; columns: getColumnDefintion()">
+    </mat-row>
 </mat-table>
 
 <mat-paginator class="on-transition-fade" [pageSizeOptions]="[25, 50, 75, 100, 125]"></mat-paginator>
 
 <mat-menu #assignmentMenu="matMenu">
-    <button mat-menu-item (click)="downloadAssignmentButton()">
-        <mat-icon>archive</mat-icon>
-        <span translate>Export ...</span>
-    </button>
+    <div *ngIf="!isMultiSelect">
+        <button mat-menu-item *osPerms="'assignment.can_manage'" (click)="toggleMultiSelect()">
+            <mat-icon>library_add</mat-icon>
+            <span translate>MultiSelect</span>
+        </button>
+        <button mat-menu-item (click)="downloadAssignmentButton()">
+            <mat-icon>archive</mat-icon>
+            <span translate>Export ...</span>
+        </button>
+    </div>
+
+    <div *ngIf="isMultiSelect">
+        <button mat-menu-item *osPerms="'assignment.can_manage'" (click)="deleteSelected()">
+            <mat-icon>delete</mat-icon>
+            <span translate>Delete assignments</span>
+        </button>
+    </div>
 </mat-menu>

--- a/client/src/app/site/base/list-view-base.ts
+++ b/client/src/app/site/base/list-view-base.ts
@@ -12,6 +12,22 @@ export abstract class ListViewBaseComponent<V extends BaseViewModel> extends Bas
     public dataSource: MatTableDataSource<V>;
 
     /**
+     * Toggle for enabling the multiSelect mode. Defaults to false (inactive)
+     */
+    protected canMultiSelect = false;
+
+    /**
+     * Current state of the multiSelect mode. TODO Could be merged with edit mode?
+     */
+    private _multiSelectModus = false;
+
+    /**
+     * An array of currently selected items, upon which multiselect actions can be performed
+     * see {@link selectItem}.
+     */
+    public selectedRows: V[];
+
+    /**
      * The table itself
      */
     @ViewChild(MatTable)
@@ -37,6 +53,7 @@ export abstract class ListViewBaseComponent<V extends BaseViewModel> extends Bas
      */
     public constructor(titleService: Title, translate: TranslateService, matSnackBar: MatSnackBar) {
         super(titleService, translate, matSnackBar);
+        this.selectedRows = [];
     }
 
     /**
@@ -48,5 +65,89 @@ export abstract class ListViewBaseComponent<V extends BaseViewModel> extends Bas
         this.dataSource = new MatTableDataSource();
         this.dataSource.paginator = this.paginator;
         this.dataSource.sort = this.sort;
+    }
+
+    /**
+     * Default click action on selecting an item. In multiselect modus,
+     * this just adds/removes from a selection, else it performs a {@link singleSelectAction}
+     * @param row The clicked row's {@link ViewModel}
+     * @param event The Mouse event
+     */
+    public selectItem(row: V, event: MouseEvent): void {
+        event.stopPropagation();
+        if (!this._multiSelectModus) {
+            this.singleSelectAction(row);
+        } else {
+            const idx = this.selectedRows.indexOf(row);
+            if ( idx < 0){
+                this.selectedRows.push(row);
+            } else {
+                this.selectedRows.splice(idx, 1);
+            }
+        }
+    }
+
+    /**
+     * Method to perform an action on click on a row, if not in MultiSelect Modus.
+     * Should be overridden by implementations. Currently there is no default action.
+     * @param row a ViewModel
+     */
+    public singleSelectAction(row: V) : void {
+    }
+
+    /**
+     * enables/disables the multiSelect Mode
+     */
+    public toggleMultiSelect() : void {
+        if (!this.canMultiSelect || this.isMultiSelect) {
+            this._multiSelectModus = false;
+            this.clearSelection();
+        } else {
+            this._multiSelectModus = true;
+        }
+    }
+
+    /**
+     * Returns the current state of the multiSelect modus
+     */
+    public get isMultiSelect(): boolean {
+        return this._multiSelectModus;
+    }
+
+    /**
+     * checks if a row is currently selected in the multiSelect modus.
+     * @param item The row's entry
+     */
+    public isSelected(item: V): boolean {
+        if (!this._multiSelectModus) {
+            return false;
+        }
+        return this.selectedRows.indexOf(item) >= 0;
+    }
+
+    /**
+     * Handler to quickly unselect all items.
+     */
+    public clearSelection(): void {
+        this.selectedRows = [];
+    }
+
+    /**
+     * Checks the array of selected items against the datastore data. This is
+     * meant to reselect items by their id even if some of their data changed,
+     * and to remove selected data that don't exist anymore.
+     * To be called after an update of data. Checks if updated selected items
+     * are still present in the dataSource, and (re-)selects them. This should
+     * be called as the observed datasource updates.
+     */
+    protected checkSelection(): void {
+        const newSelection = [];
+        this.selectedRows.forEach(selectedrow => {
+            const newrow = this.dataSource.data.find(item => item.id === selectedrow.id);
+            if (newrow) {
+                newSelection.push(newrow);
+            }
+        });
+        this.selectedRows = newSelection;
     }
 }

--- a/client/src/app/site/mediafiles/components/mediafile-list/mediafile-list.component.html
+++ b/client/src/app/site/mediafiles/components/mediafile-list/mediafile-list.component.html
@@ -1,4 +1,11 @@
-<os-head-bar [mainButton]="true" (mainEvent)="onMainEvent()" [editMode]="editFile" (saveEvent)="onSaveEditedFile()">
+<os-head-bar
+    [mainButton]="true"
+    [editMode]="editFile"
+    [multiSelectMode]="isMultiSelect"
+    (mainEvent)="onMainEvent()"
+    (saveEvent)="onSaveEditedFile()"
+>
+
     <!-- Title -->
     <div class="title-slot">
         <h2 *ngIf="!editFile" translate>Files</h2>
@@ -37,19 +44,48 @@
             <mat-icon>more_vert</mat-icon>
         </button>
     </div>
+
+    <!-- Multiselect menu -->
+    <div class="multiselect-menu-slot">
+        <button type="button" mat-icon-button [matMenuTriggerFor]="mediafilesMultiSelectMenu">
+            <mat-icon>more_vert</mat-icon>
+        </button>
+    </div>
+
+    <!-- Multiselect info -->
+    <div *ngIf="this.isMultiSelect" class="central-info-slot">
+        <button mat-icon-button (click)="toggleMultiSelect()">
+            <mat-icon >arrow_back</mat-icon>
+        </button>
+        <span>{{ selectedRows.length }}&nbsp;</span><span translate>selected</span>
+    </div>
+
+    <div class="extra-controls-slot on-transition-fade" *ngIf="isMultiSelect">
+        <button mat-icon-button (click)="deleteSelected()">
+            <mat-icon>delete</mat-icon>
+        </button>
+    </div>
 </os-head-bar>
 
 <mat-table class="os-listview-table on-transition-fade" [dataSource]="dataSource" matSort>
+
+    <ng-container matColumnDef="selector">
+        <mat-header-cell *matHeaderCellDef mat-sort-header class="checkbox-cell"></mat-header-cell>
+        <mat-cell *matCellDef="let item" class="checkbox-cell">
+            <mat-icon>{{ isSelected(item) ? 'check_circle' : '' }}</mat-icon>
+        </mat-cell>
+    </ng-container>
+
     <!-- Filename -->
     <ng-container matColumnDef="title">
         <mat-header-cell *matHeaderCellDef mat-sort-header>Name</mat-header-cell>
-        <mat-cell *matCellDef="let file" (click)="download(file)">{{ file.title }}</mat-cell>
+        <mat-cell *matCellDef="let file">{{ file.title }}</mat-cell>
     </ng-container>
 
     <!-- Info -->
     <ng-container matColumnDef="info">
         <mat-header-cell *matHeaderCellDef mat-sort-header>Group</mat-header-cell>
-        <mat-cell *matCellDef="let file" (click)="download(file)">
+        <mat-cell *matCellDef="let file">
             <div class="file-info-cell">
                 <span> <mat-icon [inline]="true">insert_drive_file</mat-icon> {{ file.type }} </span>
                 <span> <mat-icon [inline]="true">data_usage</mat-icon> {{ file.size }} </span>
@@ -86,7 +122,8 @@
     </ng-container>
 
     <mat-header-row *matHeaderRowDef="getColumnDefinition()"></mat-header-row>
-    <mat-row *matRowDef="let row; columns: getColumnDefinition()"></mat-row>
+    <mat-row *matRowDef="let row; columns: getColumnDefinition()"
+        [ngClass]="selectedRows.indexOf(row) >= 0 ? 'selected': ''" (click)='selectItem(row, $event)'></mat-row>
 </mat-table>
 
 <mat-paginator class="on-transition-fade" [pageSizeOptions]="[25, 50, 75, 100, 125]"></mat-paginator>
@@ -130,9 +167,14 @@
 
 <!-- Menu for Mediafiles -->
 <mat-menu #mediafilesMenu="matMenu">
-    <!-- Delete all files - later replaced with multi-select function -->
-    <button mat-menu-item class="red-warning-text" (click)="onDeleteAllFiles()">
+    <button mat-menu-item *osPerms="'mediafiles.can_manage'" (click)="toggleMultiSelect()">
+            <mat-icon>library_add</mat-icon>
+            <span translate>MultiSelect</span>
+    </button>
+</mat-menu>
+<mat-menu #mediafilesMultiSelectMenu="matMenu">
+    <button mat-menu-item *osPerms="'mediafiles.can_manage'" (click)="deleteSelected()">
         <mat-icon>delete</mat-icon>
-        <span translate>Delete all files</span>
+        <span translate>Delete selected</span>
     </button>
 </mat-menu>

--- a/client/src/app/site/motions/components/motion-list/motion-list.component.html
+++ b/client/src/app/site/motions/components/motion-list/motion-list.component.html
@@ -1,4 +1,4 @@
-<os-head-bar [mainButton]="true" (mainEvent)=onPlusButton()>
+<os-head-bar [mainButton]="true" (mainEvent)=onPlusButton() [multiSelectMode]="isMultiSelect">
     <!-- Title -->
     <div class="title-slot">
         <h2 translate>Motions</h2>
@@ -10,6 +10,21 @@
             <mat-icon>more_vert</mat-icon>
         </button>
     </div>
+
+    <!-- Multiselect info -->
+    <div class="central-info-slot">
+        <button mat-icon-button (click)="toggleMultiSelect()">
+            <mat-icon>arrow_back</mat-icon>
+        </button>
+        <span>{{ selectedRows.length }}&nbsp;</span><span translate>selected</span>
+    </div>
+
+    <div class="extra-controls-slot on-transition-fade" *ngIf="isMultiSelect">
+        <button mat-icon-button (click)="deleteSelected()">
+            <mat-icon>delete</mat-icon>
+        </button>
+    </div>
+
 </os-head-bar>
 
 <div class="custom-table-header on-transition-fade">
@@ -22,10 +37,17 @@
 </div>
 
 <mat-table class="os-listview-table on-transition-fade" [dataSource]="dataSource" matSort>
+    <ng-container matColumnDef="selector" >
+        <mat-header-cell *matHeaderCellDef mat-sort-header class="checkbox-cell"></mat-header-cell>
+        <mat-cell *matCellDef="let motion" class="checkbox-cell">
+            <mat-icon>{{ isSelected(motion) ? 'check_circle' : '' }}</mat-icon>
+        </mat-cell>
+    </ng-container>
+
     <!-- identifier column -->
     <ng-container matColumnDef="identifier">
         <mat-header-cell *matHeaderCellDef mat-sort-header>Identifier</mat-header-cell>
-        <mat-cell *matCellDef="let motion" (click)="selectMotion(motion)">
+        <mat-cell *matCellDef="let motion">
             <div class="innerTable">
                 {{ motion.identifier }}
             </div>
@@ -35,7 +57,7 @@
     <!-- title column -->
     <ng-container matColumnDef="title">
         <mat-header-cell *matHeaderCellDef mat-sort-header>Title</mat-header-cell>
-        <mat-cell *matCellDef="let motion" (click)="selectMotion(motion)">
+        <mat-cell *matCellDef="let motion">
             <div class="innerTable">
                 <span class="motion-list-title">{{ motion.title }}</span>
                 <br>
@@ -50,7 +72,7 @@
     <!-- state column -->
     <ng-container matColumnDef="state">
         <mat-header-cell *matHeaderCellDef mat-sort-header>State</mat-header-cell>
-        <mat-cell *matCellDef="let motion" (click)="selectMotion(motion)">
+        <mat-cell *matCellDef="let motion">
             <!--div *ngIf='isDisplayIcon(motion.state) && motion.state' class='innerTable'>
                 <mat-icon>{{ getStateIcon(motion.state) }}</mat-icon>
             </div>-->
@@ -64,7 +86,7 @@
     <ng-container matColumnDef="speakers">
         <mat-header-cell *matHeaderCellDef mat-sort-header>Speakers</mat-header-cell>
         <mat-cell *matCellDef="let motion">
-            <button mat-icon-button (click)="onSpeakerIcon(motion)">
+            <button mat-icon-button (click)="onSpeakerIcon(motion, $event)">
                 <mat-icon
                     [matBadge]="motion.agendaSpeakerAmount > 0 ? motion.agendaSpeakerAmount : null"
                     matBadgeColor="accent">
@@ -74,34 +96,55 @@
         </mat-cell>
     </ng-container>
 
-    <mat-header-row *matHeaderRowDef="columnsToDisplayMinWidth"></mat-header-row>
-    <mat-row *matRowDef="let row; columns: columnsToDisplayMinWidth"></mat-row>
+    <mat-header-row *matHeaderRowDef="getColumnDefinition()"></mat-header-row>
+    <mat-row [ngClass]="selectedRows.indexOf(row) >= 0 ? 'selected': ''" (click)='selectItem(row, $event)'
+        *matRowDef="let row; columns: getColumnDefinition()">
+    </mat-row>
 </mat-table>
 
 <mat-paginator class="on-transition-fade" [pageSizeOptions]="[25, 50, 75, 100, 125]"></mat-paginator>
 
 <mat-menu #motionListMenu="matMenu">
-    <button mat-menu-item routerLink="category">
-        <mat-icon>device_hub</mat-icon>
-        <span translate>Categories</span>
-    </button>
+    <div *ngIf="!isMultiSelect">
+        <button mat-menu-item *osPerms="'motions.can_manage'" (click)="toggleMultiSelect()">
+            <mat-icon>library_add</mat-icon>
+            <span translate>MultiSelect</span>
+        </button>
+        <button mat-menu-item routerLink="category">
+            <mat-icon>device_hub</mat-icon>
+            <span translate>Categories</span>
+        </button>
 
-    <button mat-menu-item routerLink="comment-section">
-        <mat-icon>speaker_notes</mat-icon>
-        <span translate>Comment sections</span>
-    </button>
+        <button mat-menu-item routerLink="comment-section">
+            <mat-icon>speaker_notes</mat-icon>
+            <span translate>Comment sections</span>
+        </button>
 
-    <button mat-menu-item routerLink="statute-paragraphs" *ngIf="statutesEnabled">
-        <mat-icon>account_balance</mat-icon>
-        <span translate>Statute paragraphs</span>
-    </button>
-
-    <button mat-menu-item *osPerms="'motions.can_manage'" routerLink="call-list">
-        <mat-icon>sort</mat-icon>
-        <span translate>Call list</span>
-    </button>
-    <button mat-menu-item (click)="csvExportMotionList()">
-        <mat-icon>archive</mat-icon>
-        <span translate>Export as CSV</span>
-    </button>
+        <button mat-menu-item routerLink="statute-paragraphs" *ngIf="statutesEnabled">
+            <mat-icon>account_balance</mat-icon>
+            <span translate>Statute paragraphs</span>
+        </button>
+    </div>
+    <div *ngIf="isMultiSelect">
+        <div *osPerms="'motions.can_manage'">
+            <button mat-menu-item  (click)="deleteSelected()">
+                <mat-icon>delete</mat-icon>
+                <span translate>Delete selected</span>
+            </button>
+            <button mat-menu-item (click)="openSetStatusMenu()">
+                <mat-icon>sentiment_satisfied</mat-icon>
+                <!-- TODO: icon -->
+                <span translate>Set status</span>
+            </button>
+            <button mat-menu-item (click)="openSetCategoryMenu()">
+                <mat-icon>sentiment_satisfied</mat-icon>
+                <!-- TODO: icon -->
+                <span translate>Set categories</span>
+            </button>
+        </div>
+        <button mat-menu-item (click)="csvExportMotionList()">
+            <mat-icon>archive</mat-icon>
+            <span translate>Export as CSV</span>
+        </button>
+    </div>
 </mat-menu>

--- a/client/src/app/site/motions/services/motion-repository.service.ts
+++ b/client/src/app/site/motions/services/motion-repository.service.ts
@@ -123,7 +123,7 @@ export class MotionRepositoryService extends BaseRepository<ViewMotion, Motion> 
     public async update(update: Partial<Motion>, viewMotion: ViewMotion): Promise<void> {
         const motion = viewMotion.motion;
         motion.patchValues(update);
-        await this.dataSend.partialUpdateModel(motion);
+        return await this.dataSend.partialUpdateModel(motion);
     }
 
     /**
@@ -134,7 +134,7 @@ export class MotionRepositoryService extends BaseRepository<ViewMotion, Motion> 
      * @param viewMotion
      */
     public async delete(viewMotion: ViewMotion): Promise<void> {
-        await this.dataSend.deleteModel(viewMotion.motion);
+        return await this.dataSend.deleteModel(viewMotion.motion);
     }
 
     /**

--- a/client/src/app/site/tags/components/tag-list/tag-list.component.html
+++ b/client/src/app/site/tags/components/tag-list/tag-list.component.html
@@ -1,5 +1,5 @@
 <os-head-bar [mainButton]="true" [nav]="true" [editMode]="editTag"
-    (mainEvent)="setEditMode(!editTag)" (saveEvent)="saveTag()">
+    (mainEvent)="setEditMode(!editTag)" (saveEvent)="saveTag()" [multiSelectMode]="isMultiSelect">>
     <!-- Title -->
     <div class="title-slot">
         <h2 *ngIf="!editTag && !newTag" translate>Tags</h2>
@@ -14,11 +14,12 @@
 
     <!-- remove button -->
     <div class="extra-controls-slot on-transition-fade">
-        <button *ngIf="editTag && !newTag" type="button" mat-button (click)="deleteSelectedTag()">
+        <button *ngIf="!isMultiSelect && editTag && !newTag" type="button" mat-button (click)="deleteSelectedTag()">
             <mat-icon>delete</mat-icon>
             <span translate>Delete</span>
         </button>
     </div>
+
 </os-head-bar>
 
 <mat-table class="os-listview-table on-transition-fade" [dataSource]="dataSource" matSort>
@@ -27,7 +28,7 @@
         <mat-cell *matCellDef="let tag">{{ tag.getTitle() }}</mat-cell>
     </ng-container>
     <mat-header-row *matHeaderRowDef="['name']"></mat-header-row>
-    <mat-row (click)="selectTag(row)" *matRowDef="let row; columns: ['name']"></mat-row>
+    <mat-row (click)='selectItem(row, $event)' *matRowDef="let row; columns: ['name']"></mat-row>
 </mat-table>
 
 <mat-paginator class="on-transition-fade" [pageSizeOptions]="[25, 50, 75, 100, 125]"></mat-paginator>

--- a/client/src/app/site/tags/components/tag-list/tag-list.component.ts
+++ b/client/src/app/site/tags/components/tag-list/tag-list.component.ts
@@ -116,10 +116,10 @@ export class TagListComponent extends ListViewBaseComponent<ViewTag> implements 
     }
 
     /**
-     * Select a row in the table
+     * Handler for a click on a row in the table
      * @param viewTag
      */
-    public selectTag(viewTag: ViewTag): void {
+    public singleSelectAction(viewTag: ViewTag): void {
         this.selectedTag = viewTag;
         this.setEditMode(true, false);
         this.tagForm.setValue({ name: this.selectedTag.name });

--- a/client/src/app/site/users/components/user-list/user-list.component.html
+++ b/client/src/app/site/users/components/user-list/user-list.component.html
@@ -1,4 +1,4 @@
-<os-head-bar mainButton=true (mainEvent)=onPlusButton()>
+<os-head-bar mainButton=true (mainEvent)=onPlusButton() [multiSelectMode]="isMultiSelect">
     <!-- Title -->
     <div class="title-slot">
         <h2 translate>Participants</h2>
@@ -10,6 +10,21 @@
             <mat-icon>more_vert</mat-icon>
         </button>
     </div>
+
+    <!-- Multiselect info -->
+    <div class="central-info-slot">
+        <button mat-icon-button (click)="toggleMultiSelect()">
+            <mat-icon>arrow_back</mat-icon>
+        </button>
+        <span>{{ selectedRows.length }}&nbsp;</span><span translate>selected</span>
+    </div>
+
+    <div class="extra-controls-slot on-transition-fade" *ngIf="isMultiSelect">
+        <button mat-icon-button (click)="deleteSelected()">
+            <mat-icon>delete</mat-icon>
+        </button>
+    </div>
+
 </os-head-bar>
 
 <div class="custom-table-header on-transition-fade">
@@ -22,6 +37,12 @@
 </div>
 
 <mat-table class="os-listview-table on-transition-fade" [dataSource]="dataSource" matSort>
+    <ng-container matColumnDef="selector">
+        <mat-header-cell *matHeaderCellDef mat-sort-header class="checkbox-cell"></mat-header-cell>
+        <mat-cell *matCellDef="let user" class="checkbox-cell">
+            <mat-icon>{{ isSelected(user) ? 'check_circle' : '' }}</mat-icon>
+        </mat-cell>
+    </ng-container>
 
     <!-- name column -->
     <ng-container matColumnDef="name">
@@ -58,25 +79,91 @@
         </mat-cell>
     </ng-container>
 
-    <mat-header-row *matHeaderRowDef="['name', 'group', 'presence']"></mat-header-row>
-    <mat-row (click)="selectUser(row)" *matRowDef="let row; columns: ['name', 'group', 'presence']"></mat-row>
+    <mat-header-row *matHeaderRowDef="getColumnDefinition()"></mat-header-row>
+    <mat-row [ngClass]="selectedRows.indexOf(row) >= 0 ? 'selected': ''" (click)='selectItem(row, $event)'
+        *matRowDef="let row; columns: getColumnDefinition()">
+    </mat-row>
 </mat-table>
 
 <mat-paginator class="on-transition-fade" [pageSizeOptions]="[25, 50, 75, 100, 125]"></mat-paginator>
 
 <mat-menu #userMenu="matMenu">
-    <button mat-menu-item *osPerms="'users.can_manage'" routerLink="groups">
-        <mat-icon>people</mat-icon>
-        <span translate>Groups</span>
-    </button>
+    <div *ngIf="!isMultiSelect">
+        <button mat-menu-item *osPerms="'users.can_manage'" (click)="toggleMultiSelect()">
+            <mat-icon>library_add</mat-icon>
+            <span translate>MultiSelect</span>
+        </button>
 
-    <button mat-menu-item>
-        <mat-icon>save_alt</mat-icon>
-        <span translate>Import ...</span>
-    </button>
+        <button mat-menu-item *osPerms="'users.can_manage'" routerLink="groups">
+            <mat-icon>people</mat-icon>
+            <span translate>Groups</span>
+        </button>
 
-    <button mat-menu-item (click)="csvExportUserList()">
-        <mat-icon>archive</mat-icon>
-        <span translate>Export as CSV</span>
-    </button>
+        <button mat-menu-item>
+            <mat-icon>save_alt</mat-icon>
+            <span translate>Import ...</span>
+        </button>
+
+        <button mat-menu-item (click)="csvExportUserList()">
+            <mat-icon>archive</mat-icon>
+            <span translate>Export as CSV</span>
+        </button>
+    </div>
+    <div *ngIf="isMultiSelect">
+        <div *osPerms="'users.can_manage'">
+            <button mat-menu-item (click)="setGroupSelected(null)">
+                <mat-icon>archive</mat-icon>
+                <span translate>Set groups</span>
+                <!-- TODO bottomsheet/menu? -->
+            </button>
+
+            <mat-divider></mat-divider>
+
+            <button mat-menu-item (click)="setActiveSelected(true)">
+                <mat-icon>add_circle</mat-icon>
+                <span translate>Set active</span>
+            </button>
+
+            <button mat-menu-item (click)="setActiveSelected(false)">
+                <mat-icon>remove_circle</mat-icon>
+                <span translate>Set inactive</span>
+            </button>
+
+            <mat-divider></mat-divider>
+
+            <button mat-menu-item (click)="setPresentSelected(true)">
+                <mat-icon>add_circle</mat-icon>
+                <span translate>Set as present</span>
+            </button>
+
+            <button mat-menu-item (click)="setPresentSelected(false)">
+                <mat-icon>remove_circle</mat-icon>
+                <span translate>Set as not present</span>
+            </button>
+
+            <mat-divider></mat-divider>
+
+            <button mat-menu-item (click)="setCommitteeSelected(true)">
+                <mat-icon>add_circle</mat-icon>
+                <span translate>Set as committee</span>
+            </button>
+
+            <button mat-menu-item (click)="setCommitteeSelected(false)">
+                <mat-icon>remove_circle</mat-icon>
+                <span translate>Unset committee</span>
+            </button>
+
+            <mat-divider></mat-divider>
+
+            <button mat-menu-item (click)="sendInvitationSelected()">
+                <mat-icon>mail</mat-icon>
+                <span translate>Send invitations</span>
+            </button>
+
+            <button mat-menu-item (click)="deleteSelected()">
+                <mat-icon>delete</mat-icon>
+                <span translate>Delete selected</span>
+            </button>
+        </div>
+    </div>
 </mat-menu>

--- a/client/src/app/site/users/services/user-repository.service.ts
+++ b/client/src/app/site/users/services/user-repository.service.ts
@@ -47,14 +47,14 @@ export class UserRepositoryService extends BaseRepository<ViewUser, User> {
             updateUser.username = viewUser.username;
         }
 
-        await this.dataSend.updateModel(updateUser);
+        return await this.dataSend.updateModel(updateUser);
     }
 
     /**
      * Deletes a given user
      */
     public async delete(viewUser: ViewUser): Promise<void> {
-        await this.dataSend.deleteModel(viewUser.user);
+        return await this.dataSend.deleteModel(viewUser.user);
     }
 
     /**

--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -2,7 +2,7 @@
 @include mat-core();
 
 /** Import brand theme and (new) component themes */
-@import './assets/styles/openslides-theme';
+@import './assets/styles/openslides-theme.scss';
 @import './app/site/site.component.scss-theme';
 @import '../node_modules/roboto-fontface/css/roboto/roboto-fontface.css';
 @import '../node_modules/roboto-fontface/css/roboto-condensed/roboto-condensed-fontface.css';
@@ -110,6 +110,10 @@ body {
         cursor: pointer;
         background-color: rgba(0, 0, 0, 0.025);
     }
+    mat-row.selected {
+        cursor: pointer;
+        background-color: rgba(0, 0, 0, 0.055);
+    }
 }
 
 .card-plus-distance {
@@ -151,6 +155,18 @@ mat-expansion-panel {
 
 mat-panel-title mat-icon {
     padding-right: 30px;
+}
+
+
+.hidden-cell {
+    flex: 0;
+    width: 0;
+    display: none;
+}
+
+.checkbox-cell {
+    flex: 1;
+    max-width: 30px;
 }
 
 // ngx-file-drop requires the custom style in the global css file


### PR DESCRIPTION
TODO:
- [x] check all linked functionality if they do what they're supposed to do
- [x] robustness against changing data
- [ ] disable filtering/sorting while in multiSelect state ( #3963 )
- [x] discussing/fixing my layout crimes
- [ ] better/more generic html templating, still too much copypasta


**TL;DR** ListViews can switch into a 'multiSelect' mode. In this mode, the head-bar changes to show the amount of selected items; the menu changes to multi-select related functions (bulk delete, setting status, etc.)

Major changes: Every listView has now an optional boolean `canMultiSelect`. If this is set to true (default isn't yet, as I don't know if every listView should be able to do it), the multiselect modus can be switched on, 

In this mode, a click on an item will not do the default `singleClickAction` anymore, but add/remove this item from a list (this.selectedRows), and a replacement menu (still todo, because yet untested) will change the menu on the upper left, offering functions for several methods at once

