### PR TITLE
Several bug fixes for 2.3.x

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,11 @@ Bugfixes:
    html tags for old and new text) [#3942].
  - Fixed motion/amendment diff bug [#3943, #3946, #4020].
  - Allow to hide internal items in agenda sort view [#3992].
+ - Several minor bug fixes [#4023], especially:
+
+   - Fixed motion slide: project diff mode by default (if selected in config)
+   - PDF export: Added missing alignment for pdf header logo (right).
+   - Fixed set motion block multi action.
 
 
 Version 2.3 (2018-09-20)

--- a/openslides/core/static/js/core/pdf.js
+++ b/openslides/core/static/js/core/pdf.js
@@ -197,15 +197,20 @@ angular.module('OpenSlidesApp.core.pdf', [])
                     });
                 }
 
-                var line1 = [
-                    Config.translate(Config.get('general_event_name').value),
-                    Config.translate(Config.get('general_event_description').value)
-                ].filter(Boolean).join(' – ');
-                var line2 = [
-                    Config.get('general_event_location').value,
-                    Config.get('general_event_date').value
-                ].filter(Boolean).join(', ');
-                var text = [line1, line2].join('\n');
+                var text;
+                if (logoHeaderLeftUrl && logoHeaderRightUrl) {
+                    text = '';
+                } else {
+                    var line1 = [
+                        Config.translate(Config.get('general_event_name').value),
+                        Config.translate(Config.get('general_event_description').value)
+                    ].filter(Boolean).join(' – ');
+                    var line2 = [
+                        Config.get('general_event_location').value,
+                        Config.get('general_event_date').value
+                    ].filter(Boolean).join(', ');
+                    text = [line1, line2].join('\n');
+                }
                 columns.push({
                     text: text,
                     fontSize: 10,
@@ -220,6 +225,7 @@ angular.module('OpenSlidesApp.core.pdf', [])
                     columns.push({
                         image: logoHeaderRightUrl,
                         fit: [180, 40],
+                        alignment: 'right',
                         width: '20%'
                     });
                 }

--- a/openslides/motions/static/js/motions/motion-services.js
+++ b/openslides/motions/static/js/motions/motion-services.js
@@ -609,17 +609,19 @@ angular.module('OpenSlidesApp.motions.motionservices', ['OpenSlidesApp.motions',
             }, function () {
                 $scope.change_recommendations = [];
                 $scope.title_change_recommendation = null;
-                MotionChangeRecommendation.filter({
-                    'where': {'motion_version_id': {'==': motion.active_version}}
-                }).forEach(function (change) {
-                    if (change.isTextRecommendation()) {
-                        $scope.change_recommendations.push(change);
-                    }
-                    if (change.isTitleRecommendation()) {
-                        $scope.title_change_recommendation = change;
-                    }
-                });
-                rebuild_amendments_crs();
+                if (motion) {
+                    MotionChangeRecommendation.filter({
+                        'where': {'motion_version_id': {'==': motion.active_version}}
+                    }).forEach(function (change) {
+                        if (change.isTextRecommendation()) {
+                            $scope.change_recommendations.push(change);
+                        }
+                        if (change.isTitleRecommendation()) {
+                            $scope.title_change_recommendation = change;
+                        }
+                    });
+                    rebuild_amendments_crs();
+                }
             });
 
             $scope.$watch(function () {

--- a/openslides/motions/static/js/motions/projector.js
+++ b/openslides/motions/static/js/motions/projector.js
@@ -72,13 +72,16 @@ angular.module('OpenSlidesApp.motions.projector', [
             return Motion.lastModified(motionId);
         }, function () {
             $scope.motion = Motion.get(motionId);
-            $scope.amendment_diff_paragraphs = $scope.motion.getAmendmentParagraphsLinesDiff();
-            $scope.viewChangeRecommendations.setVersion($scope.motion, $scope.motion.active_version);
-            _.forEach($scope.motion.polls, function (poll) {
-                MotionPollDecimalPlaces.getPlaces(poll, true).then(function (decimalPlaces) {
-                    precisionCache[poll.id] = decimalPlaces;
+            if ($scope.motion) {
+                $scope.amendment_diff_paragraphs = $scope.motion.getAmendmentParagraphsLinesDiff();
+                $scope.viewChangeRecommendations.setVersion($scope.motion, $scope.motion.active_version);
+                _.forEach($scope.motion.polls, function (poll) {
+                    MotionPollDecimalPlaces.getPlaces(poll, true).then(function (decimalPlaces) {
+                        precisionCache[poll.id] = decimalPlaces;
+                    });
                 });
-            });
+                $scope.viewChangeRecommendations.initProjector($scope, $scope.motion, $scope.mode);
+            }
         });
 
         var precisionCache = {};

--- a/openslides/motions/static/templates/motions/motion-detail.html
+++ b/openslides/motions/static/templates/motions/motion-detail.html
@@ -234,7 +234,7 @@
                   <i class="fa fa-cog"></i>
                 </span>
                 <ul uib-dropdown-menu class="dropdown-menu" aria-labelledby="recommendation-dropdown">
-                  <li ng-repeat="recommendation in motion.state.getRecommendations()">
+                  <li ng-repeat="recommendation in motion.state.getRecommendations() | orderBy:'id'">
                     <a href ng-click="motion.setRecommendation(recommendation.id)">
                       {{ recommendation.recommendation_label | translate }}
                       <span ng-if="recommendation.show_recommendation_extension_field">...</span>

--- a/openslides/motions/static/templates/motions/motion-list.html
+++ b/openslides/motions/static/templates/motions/motion-list.html
@@ -116,7 +116,7 @@
       </select>
       <!-- set motion block button -->
       <a ng-show="selectedAction == 'setMotionBlock' && selectedMotionBlock"
-         ng-click="setMotionBlockMultiple(motionsFilterd, selectedMotionBlock)" class="btn btn-default btn-sm">
+         ng-click="setMotionBlockMultiple(motionsFiltered, selectedMotionBlock)" class="btn btn-default btn-sm">
         <translate>Set motion block</translate>
       </a>
       <!-- delete button -->


### PR DESCRIPTION
- PDF export: Added missing alignment for pdf header logo (right).
  Hide event data if heder logo left _and_ right is set.
- Fixed typo in set motion block multi action.
- Fixed motion slide: project diff mode by default (if selected in config)
- Catched some JS errors (for undefined motion objects).
- Order recommendations by id in motion detail view.