### PR TITLE
the redis host needs to be configured for channel layers

### DIFF
--- a/openslides/utils/settings.py.tpl
+++ b/openslides/utils/settings.py.tpl
@@ -82,10 +82,15 @@ if use_redis:
     # Django Channels
 
     # https://channels.readthedocs.io/en/latest/topics/channel_layers.html#configuration
-
-    CHANNEL_LAYERS['default']['BACKEND'] = 'channels_redis.core.RedisChannelLayer'
-    CHANNEL_LAYERS['default']['CONFIG'] = {"capacity": 100000}
-
+    CHANNEL_LAYERS = {
+        "default": {
+            "BACKEND": "channels_redis.core.RedisChannelLayer",
+            "CONFIG": {
+                "hosts": [("localhost", 6379)],
+                "capacity": 100000,
+            },
+        },
+    }
     # Collection Cache
 
     # Can be:


### PR DESCRIPTION
otherwise the post migration signal in django will try to establish an connection to localhost, no matter what redis server ip or adress was entered.

In the current setup, you need to attach it by yourself, if you want to avoid getting an ugly stacktrace. I do this [via sed](https://github.com/OpenSlides/openslides-docker/blob/1cc8dc1558ccc7726380103577d0097a125c85b2/compose-big-mode/server/Dockerfile#L44).

If you don't do this, you will receive the following stacktrace:

```
server_1_c6862eb763f7 |   Applying motions.0014_motionchangerecommendation_internal... OK
server_1_c6862eb763f7 |   Applying motions.0015_metadata_permission... OK
server_1_c6862eb763f7 |   Applying users.0007_superadmin... OK
server_1_c6862eb763f7 | Traceback (most recent call last):
server_1_c6862eb763f7 |   File "manage.py", line 11, in <module>
server_1_c6862eb763f7 |     exit(main())
server_1_c6862eb763f7 |   File "/app/openslides/__main__.py", line 41, in main
server_1_c6862eb763f7 |     execute_from_command_line(sys.argv)
server_1_c6862eb763f7 |   File "/usr/local/lib/python3.7/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
server_1_c6862eb763f7 |     utility.execute()
server_1_c6862eb763f7 |   File "/usr/local/lib/python3.7/site-packages/django/core/management/__init__.py", line 375, in execute
server_1_c6862eb763f7 |     self.fetch_command(subcommand).run_from_argv(self.argv)
server_1_c6862eb763f7 |   File "/usr/local/lib/python3.7/site-packages/django/core/management/base.py", line 316, in run_from_argv
server_1_c6862eb763f7 |     self.execute(*args, **cmd_options)
server_1_c6862eb763f7 |   File "/usr/local/lib/python3.7/site-packages/django/core/management/base.py", line 353, in execute
server_1_c6862eb763f7 |     output = self.handle(*args, **options)
server_1_c6862eb763f7 |   File "/app/openslides/core/management/commands/migrate.py", line 23, in handle
server_1_c6862eb763f7 |     super().handle(*args, **options)
server_1_c6862eb763f7 |   File "/usr/local/lib/python3.7/site-packages/django/core/management/base.py", line 83, in wrapped
server_1_c6862eb763f7 |     res = handle_func(*args, **kwargs)
server_1_c6862eb763f7 |   File "/usr/local/lib/python3.7/site-packages/django/core/management/commands/migrate.py", line 226, in handle
server_1_c6862eb763f7 |     self.verbosity, self.interactive, connection.alias, apps=post_migrate_apps, plan=plan,
server_1_c6862eb763f7 |   File "/usr/local/lib/python3.7/site-packages/django/core/management/sql.py", line 51, in emit_post_migrate_signal
server_1_c6862eb763f7 |     **kwargs
server_1_c6862eb763f7 |   File "/usr/local/lib/python3.7/site-packages/django/dispatch/dispatcher.py", line 175, in send
server_1_c6862eb763f7 |     for receiver in self._live_receivers(sender)
server_1_c6862eb763f7 |   File "/usr/local/lib/python3.7/site-packages/django/dispatch/dispatcher.py", line 175, in <listcomp>
server_1_c6862eb763f7 |     for receiver in self._live_receivers(sender)
server_1_c6862eb763f7 |   File "/app/openslides/motions/signals.py", line 17, in create_builtin_workflows
server_1_c6862eb763f7 |     workflow_1 = Workflow.objects.create(name='Simple Workflow')
server_1_c6862eb763f7 |   File "/usr/local/lib/python3.7/site-packages/django/db/models/manager.py", line 82, in manager_method
server_1_c6862eb763f7 |     return getattr(self.get_queryset(), name)(*args, **kwargs)
server_1_c6862eb763f7 |   File "/usr/local/lib/python3.7/site-packages/django/db/models/query.py", line 413, in create
server_1_c6862eb763f7 |     obj.save(force_insert=True, using=self.db)
server_1_c6862eb763f7 |   File "/app/openslides/motions/models.py", line 1195, in save
server_1_c6862eb763f7 |     super(Workflow, self).save(**kwargs)
server_1_c6862eb763f7 |   File "/app/openslides/utils/models.py", line 83, in save
server_1_c6862eb763f7 |     inform_changed_data(self.get_root_rest_element())
server_1_c6862eb763f7 |   File "/app/openslides/utils/autoupdate.py", line 65, in inform_changed_data
server_1_c6862eb763f7 |     handle_changed_elements(elements.values())
server_1_c6862eb763f7 |   File "/app/openslides/utils/autoupdate.py", line 171, in handle_changed_elements
server_1_c6862eb763f7 |     async_to_sync(async_handle_collection_elements)()
server_1_c6862eb763f7 |   File "/usr/local/lib/python3.7/site-packages/asgiref/sync.py", line 64, in __call__
server_1_c6862eb763f7 |     return call_result.result()
server_1_c6862eb763f7 |   File "/usr/local/lib/python3.7/concurrent/futures/_base.py", line 425, in result
server_1_c6862eb763f7 |     return self.__get_result()
server_1_c6862eb763f7 |   File "/usr/local/lib/python3.7/concurrent/futures/_base.py", line 384, in __get_result
server_1_c6862eb763f7 |     raise self._exception
server_1_c6862eb763f7 |   File "/usr/local/lib/python3.7/site-packages/asgiref/sync.py", line 78, in main_wrap
server_1_c6862eb763f7 |     result = await self.awaitable(*args, **kwargs)
server_1_c6862eb763f7 |   File "/app/openslides/utils/autoupdate.py", line 163, in async_handle_collection_elements
server_1_c6862eb763f7 |     "change_id": change_id,
server_1_c6862eb763f7 |   File "/usr/local/lib/python3.7/site-packages/channels_redis/core.py", line 601, in group_send
server_1_c6862eb763f7 |     async with self.connection(self.consistent_hash(group)) as connection:
server_1_c6862eb763f7 |   File "/usr/local/lib/python3.7/site-packages/channels_redis/core.py", line 813, in __aenter__
server_1_c6862eb763f7 |     self.conn = await self.pool.pop()
server_1_c6862eb763f7 |   File "/usr/local/lib/python3.7/site-packages/channels_redis/core.py", line 70, in pop
server_1_c6862eb763f7 |     conns.append(await aioredis.create_redis(**self.host, loop=loop))
server_1_c6862eb763f7 |   File "/usr/local/lib/python3.7/site-packages/aioredis/commands/__init__.py", line 178, in create_redis
server_1_c6862eb763f7 |     loop=loop)
server_1_c6862eb763f7 |   File "/usr/local/lib/python3.7/site-packages/aioredis/connection.py", line 108, in create_connection
server_1_c6862eb763f7 |     timeout, loop=loop)
server_1_c6862eb763f7 |   File "/usr/local/lib/python3.7/asyncio/tasks.py", line 388, in wait_for
server_1_c6862eb763f7 |     return await fut
server_1_c6862eb763f7 |   File "/usr/local/lib/python3.7/site-packages/aioredis/stream.py", line 19, in open_connection
server_1_c6862eb763f7 |     lambda: protocol, host, port, **kwds)
server_1_c6862eb763f7 |   File "/usr/local/lib/python3.7/asyncio/base_events.py", line 957, in create_connection
server_1_c6862eb763f7 |     ', '.join(str(exc) for exc in exceptions)))
server_1_c6862eb763f7 | OSError: Multiple exceptions: [Errno 111] Connect call failed ('127.0.0.1', 6379), [Errno 99] Cannot assign requested address
```

Note: This is not a docker issue! This willl happen to you, if your `redis`-server is not located on the same machine and reachable via 127.0.0.1 (which it is naturally not in a docker environment, but also if you use `redis` in a PaaS setup). To reproduce this behaviour, you need to install `redis` on a **remote machine**!

Django will try to connect to `redis` in the `post_migration` signal. But it doesn't read the given variables in the `settings.py`, you need to append the `hosts` configuration for the `CHANNEL_LAYER` to get it to work with a remote `redis`-server.