### PR TITLE
Fixed user migrations

### DIFF
--- a/openslides/users/migrations/0007_superadmin.py
+++ b/openslides/users/migrations/0007_superadmin.py
@@ -22,10 +22,18 @@ def create_superadmin_group(apps, schema_editor):
         return
 
     # Get the new superadmin group (or the old delegates)
-    superadmin, created_superadmin_group = Group.objects.get_or_create(pk=2, defaults={'name': '__temp__'})
+    # we cannot use Group.objects.get_or_create here, because this would trigger an autoupdate
+    try:
+        superadmin = Group.objects.get(pk=2)
+        created_superadmin_group = False
+    except Group.DoesNotExist:
+        superadmin = Group(pk=2, name='__temp__')
+        superadmin.save(skip_autoupdate=True)
+        created_superadmin_group = True
 
     if not created_superadmin_group:
-        new_delegate = Group.objects.create(name='Delegates2')
+        new_delegate = Group(name='Delegates2')
+        new_delegate.save(skip_autoupdate=True)
         new_delegate.permissions.set(superadmin.permissions.all())
         superadmin.permissions.set([])
 


### PR DESCRIPTION
I got an error trying to migrate an older database:
```
File "/home/finn/OpenSlides/OpenSlides/openslides/users/migrations/0007_superadmin.py", line 28, in create_superadmin_group
    new_delegate = Group.objects.create(name='Delegates2')
  File "/home/finn/OpenSlides/.venv/lib/python3.7/site-packages/django/db/models/manager.py", line 82, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/home/finn/OpenSlides/.venv/lib/python3.7/site-packages/django/db/models/query.py", line 413, in create
    obj.save(force_insert=True, using=self.db)
  File "/home/finn/OpenSlides/OpenSlides/openslides/utils/models.py", line 83, in save
    inform_changed_data(self.get_root_rest_element())
  File "/home/finn/OpenSlides/OpenSlides/openslides/utils/autoupdate.py", line 57, in inform_changed_data
    full_data=root_instance.get_full_data())
  File "/home/finn/OpenSlides/OpenSlides/openslides/utils/models.py", line 137, in get_full_data
    return self.get_access_permissions().get_full_data(self)
  File "/home/finn/OpenSlides/OpenSlides/openslides/utils/models.py", line 47, in get_access_permissions
    raise ImproperlyConfigured("A RESTModel needs to have an access_permission.")
django.core.exceptions.ImproperlyConfigured: A RESTModel needs to have an access_permission.
```
This fixes the error.