### PR TITLE
Motion Attachments + Restructure

### DIFF
--- a/client/src/app/shared/models/mediafiles/mediafile.ts
+++ b/client/src/app/shared/models/mediafiles/mediafile.ts
@@ -24,6 +24,15 @@ export class Mediafile extends ProjectableBaseModel {
         this.mediafile = new File(input.mediafile);
     }
 
+    /**
+     * Determine the downloadURL
+     *
+     * @returns the download URL for the specific file as string
+     */
+    public getDownloadUrl(): string {
+        return `${this.media_url_prefix}${this.mediafile.name}`;
+    }
+
     public getTitle(): string {
         return this.title;
     }

--- a/client/src/app/site/agenda/services/agenda-repository.service.ts
+++ b/client/src/app/site/agenda/services/agenda-repository.service.ts
@@ -1,4 +1,6 @@
 import { Injectable } from '@angular/core';
+import { map } from 'rxjs/operators';
+import { Observable } from 'rxjs';
 
 import { BaseRepository } from '../../base/base-repository';
 import { DataStoreService } from '../../../core/services/data-store.service';
@@ -12,6 +14,7 @@ import { ViewSpeaker } from '../models/view-speaker';
 import { Speaker } from 'app/shared/models/agenda/speaker';
 import { User } from 'app/shared/models/users/user';
 import { HttpService } from 'app/core/services/http.service';
+import { ConfigService } from 'app/core/services/config.service';
 
 /**
  * Repository service for users
@@ -27,11 +30,13 @@ export class AgendaRepositoryService extends BaseRepository<ViewItem, Item> {
      * @param DS The DataStore
      * @param httpService OpenSlides own HttpService
      * @param mapperService OpenSlides mapping service for collection strings
+     * @param config Read config variables
      */
     public constructor(
         protected DS: DataStoreService,
         private httpService: HttpService,
-        mapperService: CollectionStringModelMapperService
+        mapperService: CollectionStringModelMapperService,
+        private config: ConfigService
     ) {
         super(DS, mapperService, Item);
     }
@@ -178,5 +183,14 @@ export class AgendaRepositoryService extends BaseRepository<ViewItem, Item> {
     public createViewModel(item: Item): ViewItem {
         const contentObject = this.getContentObject(item);
         return new ViewItem(item, contentObject);
+    }
+
+    /**
+     * Get agenda visibility from the config
+     *
+     * @return An observable to the default agenda visibility
+     */
+    public getDefaultAgendaVisibility(): Observable<number> {
+        return this.config.get('agenda_new_items_default_visibility').pipe(map(key => +key));
     }
 }

--- a/client/src/app/site/base/list-view-base.ts
+++ b/client/src/app/site/base/list-view-base.ts
@@ -79,7 +79,7 @@ export abstract class ListViewBaseComponent<V extends BaseViewModel> extends Bas
             this.singleSelectAction(row);
         } else {
             const idx = this.selectedRows.indexOf(row);
-            if ( idx < 0){
+            if (idx < 0) {
                 this.selectedRows.push(row);
             } else {
                 this.selectedRows.splice(idx, 1);
@@ -92,19 +92,25 @@ export abstract class ListViewBaseComponent<V extends BaseViewModel> extends Bas
      * Should be overridden by implementations. Currently there is no default action.
      * @param row a ViewModel
      */
-    public singleSelectAction(row: V) : void {
-    }
+    public singleSelectAction(row: V): void {}
 
     /**
      * enables/disables the multiSelect Mode
      */
-    public toggleMultiSelect() : void {
+    public toggleMultiSelect(): void {
         if (!this.canMultiSelect || this.isMultiSelect) {
             this._multiSelectModus = false;
             this.clearSelection();
         } else {
             this._multiSelectModus = true;
         }
+    }
+
+    /**
+     * Select all files in the current data source
+     */
+    public selectAll(): void {
+        this.selectedRows = this.dataSource.data;
     }
 
     /**

--- a/client/src/app/site/mediafiles/components/mediafile-list/mediafile-list.component.html
+++ b/client/src/app/site/mediafiles/components/mediafile-list/mediafile-list.component.html
@@ -168,6 +168,10 @@
             <mat-icon>library_add</mat-icon>
             <span translate>Exit multiselect</span>
         </button>
+        <button mat-menu-item (click)="selectAll()">
+            <mat-icon>done_all</mat-icon>
+            <span translate>Select all</span>
+        </button>
         <mat-divider></mat-divider>
         <button mat-menu-item *osPerms="'mediafiles.can_manage'" (click)="deleteSelected()">
             <mat-icon>delete</mat-icon>

--- a/client/src/app/site/mediafiles/models/view-mediafile.ts
+++ b/client/src/app/site/mediafiles/models/view-mediafile.ts
@@ -43,7 +43,7 @@ export class ViewMediafile extends BaseViewModel {
     }
 
     public get downloadUrl(): string {
-        return this.mediafile && this.mediafile.mediafile ? `${this.prefix}${this.fileName}` : null;
+        return this.mediafile ? this.mediafile.getDownloadUrl() : null;
     }
 
     public constructor(mediafile?: Mediafile, uploader?: User) {
@@ -100,7 +100,7 @@ export class ViewMediafile extends BaseViewModel {
             'video/3gpp',
             'video/x-msvideo',
             'video/x-ms-wmv',
-            'video/x-matroska',
+            'video/x-matroska'
         ].includes(this.type);
     }
 

--- a/client/src/app/site/motions/components/manage-submitters/manage-submitters.component.html
+++ b/client/src/app/site/motions/components/manage-submitters/manage-submitters.component.html
@@ -3,14 +3,6 @@
     <button class="small-button" type="button" mat-icon-button disableRipple *ngIf="!isEditMode" (click)="onEdit()">
         <mat-icon>edit</mat-icon>
     </button>
-    <span *ngIf="isEditMode">
-        <button class="small-button" type="button" mat-icon-button disableRipple (click)="onSave()">
-            <mat-icon>save</mat-icon>
-        </button>
-        <button class="small-button" type="button" mat-icon-button disableRipple (click)="onCancel()">
-            <mat-icon>close</mat-icon>
-        </button>
-    </span>
 </h4>
 
 <div *ngIf="!isEditMode">
@@ -32,7 +24,13 @@
             ></os-search-value-selector>
         </form>
 
-        <os-sorting-list class="testclass" [input]="editSubmitterObservable" [live]="true" [count]="true" (sortEvent)="onSortingChange($event)">
+        <os-sorting-list
+            class="testclass"
+            [input]="editSubmitterObservable"
+            [live]="true"
+            [count]="true"
+            (sortEvent)="onSortingChange($event)"
+        >
             <!-- implicit user references into the component using ng-template slot -->
             <ng-template let-user>
                 <button type="button" mat-icon-button matTooltip="{{ 'Remove' | translate }}" (click)="onRemove(user)">
@@ -40,6 +38,9 @@
                 </button>
             </ng-template>
         </os-sorting-list>
+        <mat-card-actions>
+            <button type="button" mat-button (click)="onSave()"><span translate>Save</span></button>
+            <button type="button" mat-button (click)="onCancel()"><span translate>Cancel</span></button>
+        </mat-card-actions>
     </mat-card>
 </div>
-

--- a/client/src/app/site/motions/components/motion-block-list/motion-block-list.component.ts
+++ b/client/src/app/site/motions/components/motion-block-list/motion-block-list.component.ts
@@ -13,6 +13,7 @@ import { Item, itemVisibilityChoices } from 'app/shared/models/agenda/item';
 import { DataStoreService } from 'app/core/services/data-store.service';
 import { MotionBlockRepositoryService } from '../../services/motion-block-repository.service';
 import { ViewMotionBlock } from '../../models/view-motion-block';
+import { AgendaRepositoryService } from 'app/site/agenda/services/agenda-repository.service';
 
 /**
  * Table for the motion blocks
@@ -57,6 +58,7 @@ export class MotionBlockListComponent extends ListViewBaseComponent<ViewMotionBl
      * @param router routing to children
      * @param route determine the local route
      * @param repo the motion block repository
+     * @param agendaRepo the agenda repository service
      * @param DS the dataStore
      * @param formBuilder creates forms
      */
@@ -67,6 +69,7 @@ export class MotionBlockListComponent extends ListViewBaseComponent<ViewMotionBl
         private router: Router,
         private route: ActivatedRoute,
         private repo: MotionBlockRepositoryService,
+        private agendaRepo: AgendaRepositoryService,
         private DS: DataStoreService,
         private formBuilder: FormBuilder
     ) {
@@ -98,7 +101,7 @@ export class MotionBlockListComponent extends ListViewBaseComponent<ViewMotionBl
             this.dataSource.data = newMotionblocks;
         });
 
-        this.repo.getDefaultAgendaVisibility().subscribe(visibility => (this.defaultVisibility = visibility));
+        this.agendaRepo.getDefaultAgendaVisibility().subscribe(visibility => (this.defaultVisibility = visibility));
     }
 
     /**

--- a/client/src/app/site/motions/components/motion-detail/motion-detail.component.html
+++ b/client/src/app/site/motions/components/motion-detail/motion-detail.component.html
@@ -12,7 +12,7 @@
             <span translate>Motion</span>
             <!-- Whitespace between "Motion" and identifier -->
             <span>&nbsp;</span> <span *ngIf="!editMotion">{{ motion.identifier }}</span>
-            <span *ngIf="editMotion">{{ metaInfoForm.get('identifier').value }}</span>
+            <span *ngIf="editMotion">{{ contentForm.get('identifier').value }}</span>
         </h2>
         <h2 *ngIf="newMotion" translate>New motion</h2>
     </div>
@@ -21,14 +21,32 @@
     <div *ngIf="!editMotion" class="extra-controls-slot on-transition-fade">
         <div *ngIf="previousMotion">
             <button mat-button (click)="navigateToMotion(previousMotion)">
-                <mat-icon>navigate_before</mat-icon>
+                <!-- possible icons:
+                    arrow_left
+                    chevron_left
+                    first_page
+                    arrow_back
+                    arrow_back_ios
+                    navigate_before
+                    fast_rewind
+                -->
+                <mat-icon>chevron_left</mat-icon>
                 <span>{{ previousMotion.identifier }}</span>
             </button>
         </div>
         <div *ngIf="nextMotion">
             <button mat-button (click)="navigateToMotion(nextMotion)">
                 <span>{{ nextMotion.identifier }}</span>
-                <mat-icon>navigate_next</mat-icon>
+                <!-- possible icons:
+                    arrow_right
+                    chevron_right
+                    last_page
+                    arrow_forward
+                    arrow_forward_ios
+                    navigate_next
+                    fast_forward
+                -->
+                <mat-icon>chevron_right</mat-icon>
             </button>
         </div>
     </div>
@@ -87,18 +105,16 @@
 </os-head-bar>
 
 <!-- Title -->
-<div *ngIf="motion" class="motion-title on-transition-fade">
-    <h2 *ngIf="!editMotion">{{ motion.title }}</h2>
-    <h2 *ngIf="editMotion">{{ contentForm.get('title').value }}</h2>
+<div class="motion-title on-transition-fade" *ngIf="motion && !editMotion">
+    <h2>{{ motion.title }}</h2>
 </div>
 
-<ng-container *ngIf="vp.isMobile; then: mobileView; else: desktopView"></ng-container>
+<ng-container *ngIf="vp.isMobile; then mobileView; else desktopView"></ng-container>
 
 <ng-template #mobileView>
-    <mat-accordion multi='true' class='on-transition-fade'>
-
+    <mat-accordion multi="true" class="on-transition-fade">
         <!-- MetaInfo Panel-->
-        <mat-expansion-panel #metaInfoPanel [expanded]="true" class='meta-info-block meta-info-panel'>
+        <mat-expansion-panel #metaInfoPanel [expanded]="true" class="meta-info-block meta-info-panel">
             <mat-expansion-panel-header>
                 <mat-panel-title>
                     <mat-icon>info</mat-icon>
@@ -126,8 +142,8 @@
             </div>
         </mat-expansion-panel>
 
-        <os-motion-comments *ngIf="!newMotion" [motion]="motion"></os-motion-comments>
-        <os-personal-note *ngIf="!newMotion" [motion]="motion"></os-personal-note>
+        <os-motion-comments *ngIf="!editMotion" [motion]="motion"></os-motion-comments>
+        <os-personal-note *ngIf="!editMotion" [motion]="motion"></os-personal-note>
     </mat-accordion>
 </ng-template>
 
@@ -139,8 +155,8 @@
                 <ng-container *ngTemplateOutlet="metaInfoTemplate"></ng-container>
             </div>
 
-            <os-motion-comments *ngIf="!newMotion" [motion]="motion"></os-motion-comments>
-            <os-personal-note *ngIf="!newMotion" [motion]="motion"></os-personal-note>
+            <os-motion-comments *ngIf="!editMotion" [motion]="motion"></os-motion-comments>
+            <os-personal-note *ngIf="!editMotion" [motion]="motion"></os-personal-note>
         </div>
         <div class="desktop-right ">
             <!-- Content -->
@@ -150,99 +166,72 @@
 </ng-template>
 
 <ng-template #metaInfoTemplate>
-    <form [formGroup]="metaInfoForm" (keydown)="onKeyDown($event)" (ngSubmit)="saveMotion()">
-        <!-- Identifier -->
-        <div *ngIf="editMotion && !newMotion">
-            <!-- <div *ngIf="editMotion"> -->
-            <div *ngIf="!editMotion">
-                <h4 translate>Identifier</h4>
-                {{ motion.identifier }}
-            </div>
-            <mat-form-field *ngIf="editMotion">
-                <input
-                    matInput
-                    placeholder="{{ &quot;Identifier&quot; | translate }}"
-                    formControlName="identifier"
-                    [value]="motionCopy.identifier"
-                />
-            </mat-form-field>
-        </div>
-
+    <div *ngIf="motion">
         <!-- Submitters -->
-        <div *ngIf="motion && motion.submitters || newMotion">
-            <div *ngIf="newMotion">
-                <div *osPerms="['motions.can_manage', 'motions.can_manage_metadata']">
-                    <os-search-value-selector
-                        ngDefaultControl
-                        [form]="metaInfoForm"
-                        [formControl]="metaInfoForm.get('submitters_id')"
-                        [multiple]="true"
-                        listname="{{ 'Submitters' | translate }}"
-                        [InputListValues]="submitterObserver"
-                    ></os-search-value-selector>
-                </div>
-            </div>
-            <div *ngIf="!editMotion && !newMotion">
-                <os-manage-submitters [motion]="motion"></os-manage-submitters>
-            </div>
+        <div *ngIf="motion.submitters || newMotion">
+            <div *ngIf="!editMotion"><os-manage-submitters [motion]="motion"></os-manage-submitters></div>
         </div>
 
-        <!-- Supporters -->
-        <div *ngIf='motion && minSupporters'>
-            <div *ngIf="editMotion">
-                <div *osPerms="['motions.can_manage', 'motions.can_manage_metadata']">
-                    <os-search-value-selector
-                        ngDefaultControl
-                        [form]="metaInfoForm"
-                        [formControl]="metaInfoForm.get('supporters_id')"
-                        [multiple]="true"
-                        listname="{{ 'Supporters' | translate }}"
-                        [InputListValues]="supporterObserver"
-                    ></os-search-value-selector>
-                </div>
-            </div>
-            <div *ngIf="!editMotion">
-                <h4 *ngIf="perms.isAllowed('support', motion) || motion.hasSupporters()" translate>Supporters</h4>
-                <!-- support button -->
-                <button type="button" *ngIf="perms.isAllowed('support', motion)" (click)=support() mat-raised-button color="primary">
-                    <mat-icon>thumb_up</mat-icon>
-                    {{ 'Support' | translate }}
-                </button>
-                <!-- unsupport button -->
-                <button type="button" *ngIf="perms.isAllowed('unsupport', motion)" (click)=unsupport() mat-raised-button color="primary">
-                    <mat-icon>thumb_down</mat-icon>
-                    {{ 'Unsupport' | translate }}
-                </button>
-                <!-- show supporters (TODO: open in dialog) -->
-                <button type="button" *ngIf="motion.hasSupporters()" (click)=openSupportersDialog() mat-button>
-                    {{ motion.supporters.length }} {{ 'supporters' | translate }}
-                </button>
-                <p *ngIf="showSupporters">
-                    <mat-chip-list *ngFor="let supporter of motion.supporters">
-                        <mat-chip>{{ supporter.full_name }}</mat-chip>
-                    </mat-chip-list>
-                </p>
-            </div>
+        <!-- do Support -->
+        <div *ngIf="minSupporters && !editMotion">
+            <h4 *ngIf="perms.isAllowed('support', motion) || motion.hasSupporters()" translate>Supporters</h4>
 
+            <!-- support button -->
+            <button
+                type="button"
+                mat-raised-button
+                color="primary"
+                (click)="support()"
+                *ngIf="perms.isAllowed('support', motion)"
+            >
+                <mat-icon>thumb_up</mat-icon>
+                {{ 'Support' | translate }}
+            </button>
+
+            <!-- unsupport button -->
+            <button
+                type="button"
+                *ngIf="perms.isAllowed('unsupport', motion)"
+                (click)="unsupport()"
+                mat-raised-button
+                color="primary"
+            >
+                <mat-icon>thumb_down</mat-icon>
+                {{ 'Unsupport' | translate }}
+            </button>
+            <!-- show supporters (TODO: open in dialog) -->
+            <button type="button" *ngIf="motion.hasSupporters()" (click)="openSupportersDialog()" mat-button>
+                {{ motion.supporters.length }} {{ 'supporters' | translate }}
+            </button>
+            <p *ngIf="showSupporters">
+                <mat-chip-list *ngFor="let supporter of motion.supporters">
+                    <mat-chip>{{ supporter.full_name }}</mat-chip>
+                </mat-chip-list>
+            </p>
         </div>
 
-        <!-- State -->
-        <div *ngIf='motion && !editMotion'>
+        <!-- Set State -->
+        <div *ngIf="!editMotion">
             <h4 translate>State</h4>
-            <mat-menu #stateMenu='matMenu'>
-                <button *ngFor='let state of motion.nextStates' mat-menu-item
-                    (click)=setState(state.id)>{{ state.name | translate }}
+            <mat-menu #stateMenu="matMenu">
+                <button *ngFor="let state of motion.nextStates" mat-menu-item (click)="setState(state.id)">
+                    {{ state.name | translate }}
                 </button>
                 <mat-divider></mat-divider>
-                <button mat-menu-item (click)=setState(null)>
+                <button mat-menu-item (click)="setState(null)">
                     <mat-icon>replay</mat-icon> {{ 'Reset state' | translate }}
                 </button>
             </mat-menu>
-            <mat-basic-chip [matMenuTriggerFor]='stateMenu' [ngClass]="{
-                    'green': motion.state.css_class === 'success',
-                    'red': motion.state.css_class === 'danger',
-                    'grey': motion.state.css_class === 'default',
-                    'lightblue': motion.state.css_class === 'primary' }">
+            <mat-basic-chip
+                *ngIf="motion.state"
+                [matMenuTriggerFor]="stateMenu"
+                [ngClass]="{
+                    green: motion.state.css_class === 'success',
+                    red: motion.state.css_class === 'danger',
+                    grey: motion.state.css_class === 'default',
+                    lightblue: motion.state.css_class === 'primary'
+                }"
+            >
                 {{ motion.state.name | translate }}
             </mat-basic-chip>
 
@@ -250,27 +239,35 @@
         </div>
 
         <!-- Recommendation -->
-        <div *ngIf='motion && recommender && !editMotion'>
+        <div *ngIf="recommender && !editMotion">
             <h4>{{ recommender }}</h4>
-            <mat-menu #recommendationMenu='matMenu'>
-                <button *ngFor='let recommendation of motion.possibleRecommendations' mat-menu-item
-                    (click)=setRecommendation(recommendation.id)>{{ recommendation.recommendation_label | translate }}
+            <mat-menu #recommendationMenu="matMenu">
+                <button
+                    *ngFor="let recommendation of motion.possibleRecommendations"
+                    mat-menu-item
+                    (click)="setRecommendation(recommendation.id)"
+                >
+                    {{ recommendation.recommendation_label | translate }}
                 </button>
                 <mat-divider></mat-divider>
-                <button mat-menu-item (click)=setRecommendation(null)>
+                <button mat-menu-item (click)="setRecommendation(null)">
                     <mat-icon>replay</mat-icon> {{ 'Reset recommendation' | translate }}
                 </button>
             </mat-menu>
-            <mat-basic-chip [matMenuTriggerFor]='recommendationMenu' class="bluegrey">
-                {{ motion.recommendation ? (motion.recommendation.recommendation_label | translate) : ('not set' | translate) }}
+            <mat-basic-chip [matMenuTriggerFor]="recommendationMenu" class="bluegrey">
+                {{
+                    motion.recommendation
+                        ? (motion.recommendation.recommendation_label | translate)
+                        : ('not set' | translate)
+                }}
             </mat-basic-chip>
         </div>
 
         <!-- Category -->
         <!-- Disabled during "new motion" since changing has no effect -->
-        <div *ngIf="motion && !editMotion">
+        <div *ngIf="!editMotion">
             <h4 translate>Category</h4>
-            <mat-menu #categoryMenu='matMenu'>
+            <mat-menu #categoryMenu="matMenu">
                 <button
                     mat-menu-item
                     *ngFor="let category of categoryObserver.value"
@@ -278,75 +275,34 @@
                 >
                     {{ category }}
                 </button>
-                <button mat-menu-item (click)=setCategory(null)>
-                    ---
-                </button>
+                <button mat-menu-item (click)="setCategory(null)">---</button>
             </mat-menu>
-            <mat-basic-chip [matMenuTriggerFor]='categoryMenu' class="grey">
+            <mat-basic-chip [matMenuTriggerFor]="categoryMenu" class="grey">
                 {{ motion.category ? motion.category : ('not set' | translate) }}
             </mat-basic-chip>
         </div>
 
         <!-- Block -->
-        <div *ngIf="motion && !editMotion">
+        <div *ngIf="!editMotion">
             <h4 translate>Motion block</h4>
 
-            <mat-menu #blockMenu='matMenu'>
-                <button
-                    mat-menu-item
-                    *ngFor="let block of blockObserver.value"
-                    (click)="setBlock(block.id)"
-                >
+            <mat-menu #blockMenu="matMenu">
+                <button mat-menu-item *ngFor="let block of blockObserver.value" (click)="setBlock(block.id)">
                     {{ block }}
                 </button>
-                <button mat-menu-item (click)="setBlock(null)">
-                    ---
-                </button>
+                <button mat-menu-item (click)="setBlock(null)">---</button>
             </mat-menu>
-            <mat-basic-chip [matMenuTriggerFor]='blockMenu' class="grey">
-                 {{ motion.motion_block ? motion.motion_block : ('not set' | translate) }}
+            <mat-basic-chip [matMenuTriggerFor]="blockMenu" class="grey">
+                {{ motion.motion_block ? motion.motion_block : ('not set' | translate) }}
             </mat-basic-chip>
         </div>
 
-        <!-- Workflow -->
-        <div *ngIf="editMotion">
-            <div *osPerms="['motions.can_manage', 'motions.can_manage_metadata']">
-                <os-search-value-selector
-                    ngDefaultControl
-                    [form]="metaInfoForm"
-                    [formControl]="metaInfoForm.get('workflow_id')"
-                    [multiple]="false"
-                    listname="{{ 'Workflow' | translate }}"
-                    [InputListValues]="workflowObserver"
-                ></os-search-value-selector>
-            </div>
+        <!-- Origin - display only -->
+        <div *ngIf="!editMotion && motion.origin">
+            <h4 translate>Origin</h4>
+            {{ motion.origin }}
         </div>
-
-        <!-- Origin -->
-        <div *ngIf="(motion && motion.origin) || editMotion">
-            <div *ngIf="!editMotion">
-                <h4 translate>Origin</h4>
-                {{ motion.origin }}
-            </div>
-            <div *osPerms="['motions.can_manage', 'motions.can_manage_metadata']">
-                <mat-form-field *ngIf="editMotion">
-                    <input
-                        matInput
-                        placeholder="{{ 'Origin' | translate}}"
-                        formControlName="origin"
-                        [value]="motionCopy.origin"
-                    />
-                </mat-form-field>
-            </div>
-        </div>
-
-        <!-- Voting -->
-        <!--
-            <div *ngIf='motion.polls && motion.polls.length > 0 || editMotion'>
-                <h4 translate>Voting</h4>
-            </div>
-        -->
-    </form>
+    </div>
 </ng-template>
 
 <ng-template #contentTemplate>
@@ -356,9 +312,10 @@
         (clickdown)="onKeyDown($event)"
         (keydown)="onKeyDown($event)"
         (ngSubmit)="saveMotion()"
+        *ngIf="motion"
     >
         <!-- Line Number and Diff buttons -->
-        <div *ngIf="motion && !editMotion && !motion.isStatuteAmendment()" class="motion-text-controls">
+        <div *ngIf="!editMotion && !motion.isStatuteAmendment()" class="motion-text-controls">
             <button
                 type="button"
                 mat-icon-button
@@ -397,31 +354,53 @@
             </mat-form-field>
         </div>
 
-        <!-- Title -->
-        <div *ngIf="(motion && motion.title) || editMotion">
-            <div *ngIf="!editMotion">
-                <h4>{{ motion.title }}</h4>
+        <!-- Submitter -->
+        <div *ngIf="newMotion" class="content-field form100">
+            <div *osPerms="['motions.can_manage', 'motions.can_manage_metadata']">
+                <os-search-value-selector
+                    ngDefaultControl
+                    [form]="contentForm"
+                    [formControl]="contentForm.get('submitters_id')"
+                    [multiple]="true"
+                    listname="{{ 'Submitters' | translate }}"
+                    [InputListValues]="submitterObserver"
+                ></os-search-value-selector>
+            </div>
+        </div>
+
+        <div class="form-id-title">
+            <!-- Identifier -->
+            <div *ngIf="editMotion && !newMotion" class="content-field form-identifier">
+                <mat-form-field *ngIf="editMotion">
+                    <input
+                        matInput
+                        placeholder="{{ 'Identifier' | translate }}"
+                        formControlName="identifier"
+                        [value]="motionCopy.identifier"
+                    />
+                </mat-form-field>
             </div>
 
-            <mat-form-field *ngIf="editMotion" class="wide-form">
-                <input
-                    matInput
-                    osAutofocus
-                    placeholder="{{ 'Title' | translate }}"
-                    formControlName="title"
-                    [value]="motionCopy.title"
-                    required
-                />
-            </mat-form-field>
+            <!-- Title -->
+            <div *ngIf="editMotion" class="content-field form-title">
+                <mat-form-field *ngIf="editMotion">
+                    <input
+                        matInput
+                        osAutofocus
+                        placeholder="{{ 'Title' | translate }}"
+                        formControlName="title"
+                        [value]="motionCopy.title"
+                        required
+                    />
+                </mat-form-field>
+            </div>
         </div>
 
         <!-- Text -->
         <span class="text-prefix-label">{{ preamble | translate }}</span>
 
         <!-- Regular motions or traditional amendments -->
-        <ng-container
-            *ngIf="motion && !editMotion && !motion.isStatuteAmendment() && !motion.isParagraphBasedAmendment()"
-        >
+        <ng-container *ngIf="!editMotion && !motion.isStatuteAmendment() && !motion.isParagraphBasedAmendment()">
             <div
                 *ngIf="!isRecoModeDiff()"
                 class="motion-text"
@@ -451,7 +430,7 @@
         </ng-container>
         <div
             class="motion-text line-numbers-none"
-            *ngIf="motion && !editMotion && motion.isStatuteAmendment()"
+            *ngIf="!editMotion && motion.isStatuteAmendment()"
             [innerHTML]="getFormattedStatuteAmendment()"
         ></div>
 
@@ -459,21 +438,120 @@
         <editor formControlName="text" [init]="tinyMceSettings" *ngIf="motion && editMotion"></editor>
 
         <!-- Paragraph-based amendments -->
-        <ng-container *ngIf="motion && !editMotion && motion.isParagraphBasedAmendment()">
+        <ng-container *ngIf="!editMotion && motion.isParagraphBasedAmendment()">
             <ng-container *ngTemplateOutlet="paragraphBasedAmendment"></ng-container>
         </ng-container>
 
         <!-- Reason -->
-        <div *ngIf="motion || editMotion">
-            <h5 *ngIf="motion.reason || editMotion" translate>Reason</h5>
+        <div *ngIf="motion.reason || editMotion">
+            <h3 translate>Reason</h3>
             <div class="motion-text" *ngIf="!editMotion"><div [innerHtml]="motion.reason"></div></div>
 
             <!-- The HTML Editor -->
-            <editor
-                formControlName='reason'
-                [init]="tinyMceSettings"
-                *ngIf="editMotion"
-            ></editor>
+            <editor formControlName="reason" [init]="tinyMceSettings" *ngIf="editMotion"></editor>
+        </div>
+
+        <div class="extra-data">
+            <!-- Attachments -->
+            <div *ngIf="motion.hasAttachments() || editMotion" class="content-field form100">
+                <div *ngIf="!editMotion">
+                    <h4 translate>Attachments</h4>
+                    <mat-list dense>
+                        <mat-list-item *ngFor="let file of motion.attachments">
+                            <a [routerLink]="" (click)="onClickAttacment(file)">{{ file.title }}</a>
+                        </mat-list-item>
+                    </mat-list>
+                </div>
+                <div *ngIf="editMotion">
+                    <os-search-value-selector
+                        ngDefaultControl
+                        [form]="contentForm"
+                        [formControl]="contentForm.get('attachments_id')"
+                        [multiple]="true"
+                        listname="{{ 'Attachments' | translate }}"
+                        [InputListValues]="mediafilesObserver"
+                    ></os-search-value-selector>
+                </div>
+            </div>
+
+            <!-- Category form -->
+            <div class="content-field form100" *ngIf="newMotion && categoryObserver.value.length > 0">
+                <os-search-value-selector
+                    ngDefaultControl
+                    [form]="contentForm"
+                    [formControl]="contentForm.get('category_id')"
+                    [multiple]="false"
+                    [includeNone]="true"
+                    listname="{{ 'Category' | translate }}"
+                    [InputListValues]="categoryObserver"
+                ></os-search-value-selector>
+            </div>
+
+            <!-- Parent item -->
+            <div class="content-field form100" *ngIf="newMotion && agendaItemObserver.value.length > 0">
+                <os-search-value-selector
+                    ngDefaultControl
+                    [form]="contentForm"
+                    [formControl]="contentForm.get('parent_id')"
+                    [multiple]="false"
+                    [includeNone]="true"
+                    listname="{{ 'Parent Item' | translate }}"
+                    [InputListValues]="agendaItemObserver"
+                ></os-search-value-selector>
+            </div>
+
+            <!-- Visibility -->
+            <div class="content-field form100" *ngIf="newMotion">
+                <mat-form-field>
+                    <mat-select formControlName="agenda_type" placeholder="{{ 'Agenda visibility' | translate }}">
+                        <mat-option *ngFor="let type of itemVisibility" [value]="type.key">
+                            <span>{{ type.name | translate }}</span>
+                        </mat-option>
+                    </mat-select>
+                </mat-form-field>
+            </div>
+
+            <!-- Supporter form -->
+            <div class="content-field form100" *ngIf="editMotion && minSupporters">
+                <div *osPerms="['motions.can_manage', 'motions.can_manage_metadata']">
+                    <os-search-value-selector
+                        ngDefaultControl
+                        [form]="contentForm"
+                        [formControl]="contentForm.get('supporters_id')"
+                        [multiple]="true"
+                        listname="{{ 'Supporters' | translate }}"
+                        [InputListValues]="supporterObserver"
+                    ></os-search-value-selector>
+                </div>
+            </div>
+
+            <!-- Workflow -->
+            <div class="content-field form100" *ngIf="editMotion && workflowObserver.value.length > 1">
+                <div *osPerms="['motions.can_manage', 'motions.can_manage_metadata']">
+                    <os-search-value-selector
+                        ngDefaultControl
+                        [form]="contentForm"
+                        [formControl]="contentForm.get('workflow_id')"
+                        [multiple]="false"
+                        listname="{{ 'Workflow' | translate }}"
+                        [InputListValues]="workflowObserver"
+                    ></os-search-value-selector>
+                </div>
+            </div>
+
+            <!-- Origin form -->
+            <div class="content-field form100" *ngIf="editMotion">
+                <div *osPerms="['motions.can_manage', 'motions.can_manage_metadata']">
+                    <mat-form-field>
+                        <input
+                            matInput
+                            placeholder="{{ 'Origin' | translate }}"
+                            formControlName="origin"
+                            [value]="motionCopy.origin"
+                        />
+                    </mat-form-field>
+                </div>
+            </div>
         </div>
     </form>
 </ng-template>
@@ -522,9 +600,15 @@
 <!-- Line number Menu -->
 <mat-menu #lineNumberingMenu="matMenu">
     <div *ngIf="motion">
-        <button mat-menu-item translate (click)=setLineNumberingMode(0) [ngClass]="{ 'selected': motion.lnMode === 0 }">none</button>
-        <button mat-menu-item translate (click)=setLineNumberingMode(1) [ngClass]="{ 'selected': motion.lnMode === 1 }">inline</button>
-        <button mat-menu-item translate (click)=setLineNumberingMode(2) [ngClass]="{ 'selected': motion.lnMode === 2 }">outside</button>
+        <button mat-menu-item translate (click)="setLineNumberingMode(0)" [ngClass]="{ selected: motion.lnMode === 0 }">
+            none
+        </button>
+        <button mat-menu-item translate (click)="setLineNumberingMode(1)" [ngClass]="{ selected: motion.lnMode === 1 }">
+            inline
+        </button>
+        <button mat-menu-item translate (click)="setLineNumberingMode(2)" [ngClass]="{ selected: motion.lnMode === 2 }">
+            outside
+        </button>
     </div>
 </mat-menu>
 

--- a/client/src/app/site/motions/components/motion-detail/motion-detail.component.scss
+++ b/client/src/app/site/motions/components/motion-detail/motion-detail.component.scss
@@ -23,7 +23,6 @@ span {
     line-height: 180%;
     font-size: 120%;
     color: #317796; // TODO: put in theme as $primary
-
     h2 {
         margin: 0;
         font-weight: normal;
@@ -38,58 +37,6 @@ span {
     float: right;
     button {
         font-size: 115%;
-    }
-}
-
-.motion-submitter {
-    display: inline;
-    font-weight: bold;
-    font-size: 70%;
-}
-
-.meta-info-block {
-    form {
-        div + div {
-            margin-top: 15px;
-        }
-
-        ul {
-            margin: 5px;
-        }
-    }
-
-    h3 {
-        display: block;
-        // padding-top: 0;
-        margin-top: 0px; //distance between heading and text
-        margin-bottom: 3px; //distance between heading and text
-        font-size: 80%;
-        color: gray;
-
-        mat-icon {
-            margin-left: 5px;
-        }
-    }
-
-    .mat-form-field-label {
-        font-size: 12pt;
-        color: gray;
-    }
-
-    .mat-form-field-label-wrapper {
-        mat-icon {
-            margin-left: 5px;
-        }
-    }
-}
-
-.wide-form {
-    textarea {
-        height: 25vh;
-    }
-
-    ::ng-deep {
-        width: 100%;
     }
 }
 
@@ -142,6 +89,45 @@ span {
     .text-prefix-label {
         display: block;
         margin: 0 10px 7px 0px;
+    }
+
+    .extra-data {
+        margin-top: 1em;
+    }
+
+    .content-field {
+        display: inline-block;
+        ::ng-deep {
+            .mat-form-field {
+                width: 100%;
+            }
+        }
+    }
+
+    .form100 {
+        width: 100%;
+    }
+
+    .form70 {
+        width: 70%;
+    }
+
+    .form30 {
+        width: 30%;
+    }
+
+    .form-id-title {
+        display: flex;
+
+        .form-identifier {
+            flex: 0 0 95px;
+            max-width: 95px;
+            margin-right: 1em;
+        }
+
+        .form-title {
+            flex: 1 1 auto;
+        }
     }
 }
 

--- a/client/src/app/site/motions/components/motion-list/motion-list.component.html
+++ b/client/src/app/site/motions/components/motion-list/motion-list.component.html
@@ -41,13 +41,21 @@
         <mat-header-cell *matHeaderCellDef mat-sort-header>Title</mat-header-cell>
         <mat-cell *matCellDef="let motion">
             <div class="innerTable">
-                <span class="motion-list-title">{{ motion.title }}</span> <br />
+                <span class="motion-list-title">{{ motion.title }}</span>
+                <!-- attachments -->
+                <span class="attached-files" *ngIf="motion.hasAttachments()">
+                    <!-- <mat-basic-chip class="bluegrey"> <mat-icon>attach_file</mat-icon> </mat-basic-chip> -->
+                    <mat-icon>attach_file</mat-icon>
+                </span>
+
+                <br />
                 <span class="motion-list-from" *ngIf="motion.submitters.length">
                     <span translate>by</span> {{ motion.submitters }}
                 </span>
                 <br *ngIf="motion.submitters.length" />
                 <!-- state -->
                 <mat-basic-chip
+                    *ngIf="motion.state"
                     [ngClass]="{
                         green: motion.state.css_class === 'success',
                         red: motion.state.css_class === 'danger',

--- a/client/src/app/site/motions/components/motion-list/motion-list.component.scss
+++ b/client/src/app/site/motions/components/motion-list/motion-list.component.scss
@@ -30,6 +30,17 @@
             color: rgba(0, 0, 0, 0.5);
             font-size: 90%;
         }
+
+        .attached-files {
+            .mat-icon {
+                display: inline-flex;
+                vertical-align: middle;
+                $icon-size: 16px;
+                font-size: $icon-size;
+                height: $icon-size;
+                width: $icon-size;
+            }
+        }
     }
 
     /** State */

--- a/client/src/app/site/motions/services/motion-block-repository.service.ts
+++ b/client/src/app/site/motions/services/motion-block-repository.service.ts
@@ -12,7 +12,6 @@ import { ViewMotion } from '../models/view-motion';
 import { Observable } from 'rxjs';
 import { MotionRepositoryService } from './motion-repository.service';
 import { map } from 'rxjs/operators';
-import { ConfigService } from 'app/core/services/config.service';
 
 /**
  * Repository service for motion blocks
@@ -28,14 +27,12 @@ export class MotionBlockRepositoryService extends BaseRepository<ViewMotionBlock
      * @param mapperService Mapping collection strings to classes
      * @param dataSend Send models to the server
      * @param motionRepo Accessing the motion repository
-     * @param config To access config variables
      */
     public constructor(
         DS: DataStoreService,
         mapperService: CollectionStringModelMapperService,
         private dataSend: DataSendService,
         private motionRepo: MotionRepositoryService,
-        private config: ConfigService
     ) {
         super(DS, mapperService, MotionBlock);
     }
@@ -101,15 +98,6 @@ export class MotionBlockRepositoryService extends BaseRepository<ViewMotionBlock
      */
     public getMotionAmountByBlock(block: MotionBlock): number {
         return this.DS.filter(Motion, motion => motion.motion_block_id === block.id).length;
-    }
-
-    /**
-     * Get agenda visibility from the config
-     *
-     * @return An observable to the default agenda visibility
-     */
-    public getDefaultAgendaVisibility(): Observable<number> {
-        return this.config.get('agenda_new_items_default_visibility').pipe(map(key => +key));
     }
 
     /**

--- a/client/src/app/site/motions/services/motion-repository.service.ts
+++ b/client/src/app/site/motions/services/motion-repository.service.ts
@@ -27,6 +27,7 @@ import { TreeService } from 'app/core/services/tree.service';
 import { ViewMotionAmendedParagraph } from '../models/view-motion-amended-paragraph';
 import { CreateMotion } from '../models/create-motion';
 import { MotionBlock } from 'app/shared/models/motions/motion-block';
+import { Mediafile } from 'app/shared/models/mediafiles/mediafile';
 
 /**
  * Repository Services for motions (and potentially categories)
@@ -64,7 +65,7 @@ export class MotionRepositoryService extends BaseRepository<ViewMotion, Motion> 
         private readonly diff: DiffService,
         private treeService: TreeService
     ) {
-        super(DS, mapperService, Motion, [Category, User, Workflow, Item, MotionBlock]);
+        super(DS, mapperService, Motion, [Category, User, Workflow, Item, MotionBlock, Mediafile]);
     }
 
     /**
@@ -82,11 +83,12 @@ export class MotionRepositoryService extends BaseRepository<ViewMotion, Motion> 
         const workflow = this.DS.get(Workflow, motion.workflow_id);
         const item = this.DS.get(Item, motion.agenda_item_id);
         const block = this.DS.get(MotionBlock, motion.motion_block_id);
+        const attachments = this.DS.getMany(Mediafile, motion.attachments_id);
         let state: WorkflowState = null;
         if (workflow) {
             state = workflow.getStateById(motion.state_id);
         }
-        return new ViewMotion(motion, category, submitters, supporters, workflow, state, item, block);
+        return new ViewMotion(motion, category, submitters, supporters, workflow, state, item, block, attachments);
     }
 
     /**


### PR DESCRIPTION
Biggest change: Mediafiles in motions via Attachments.

I restructured Motion Details "a little".

- Removed MetaDataForm (since we use Chips for everything now, it did not do anything anymore)
- put all input fields logically under reason
- hide left side during edit/creation
- identifier is defined left of title (in edit only, not during creation)
- hide personal note and comments during edit
- hide the big-blue title during creation
- submitter can be defined under the reason during creation, add-sort-submitter is available in normal view mode
- restructure motion details code base
- add missing comments

Creating and updating should look a little more relaxed now.