### PR TITLE
travis check for createsettings and migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,25 @@ matrix:
         - python -m mypy openslides/ tests/
         - python -W ignore -m pytest --cov --cov-fail-under=70
 
+    - language: python
+      name: "Server: Tests Startup Routine Python 3.7"
+      cache:
+        pip: true
+      python:
+        - "3.7"
+      install:
+        - python --version
+        - pip install --upgrade setuptools pip
+        - pip install --upgrade --requirement requirements/development.txt
+        - pip install --upgrade .[big_mode]
+        - pip freeze
+      script:
+        - set -e
+        - python manage.py createsettings
+        - python manage.py migrate
+        - python manage.py runserver --noreload & (sleep 15 && kill $(ps aux | grep 'manage.py runserver' | head -n -1 | awk '{print $2}'))
+        - set +e
+
     - language: node_js
       name: "Client: Linting"
       node_js:

--- a/DEVELOPMENT.rst
+++ b/DEVELOPMENT.rst
@@ -70,6 +70,25 @@ When debugging something email related change the email backend to console::
 
     $ python manage.py start --debug-email
 
+
+d.a Debugging the Server
+''''''''''''''''''''''''
+
+If you wish to have even further debugging, enable `django-extensions
+<https://django-extensions.readthedocs.io/>`_,
+in the ``settings.py``  by adding ``django_extensions`` to the list of
+``INSTALLED_PLLUGINS``. Make sure, you add the following lines to your
+``requirements/development.txt``::
+
+    Werkzeug
+    pyparsing
+    pydot
+    django-extensions
+
+and install them via pip. You can start the enhanced debugging-server via::
+
+    $ python manage.py runserver_plus
+
 e. Setup and start the client
 '''''''''''''''''''''''''''''
 
@@ -124,6 +143,10 @@ a. Running server tests
 
 To run some server tests see `.travis.yml
 <https://github.com/OpenSlides/OpenSlides/blob/master/.travis.yml>`_.
+
+You can generate an class-structure image, when having `django_extensions` enabled (see above)
+
+    $ python manage.py graph_models -a -g -o my_project_visualized.png
 
 
 b. Client tests and commands


### PR DESCRIPTION
In reaction of #4069 the ticket #4070 was created.

Currently this version can sanely check if `createsettings` and `migrations` wents through. The `runserver` command is more or less for readability and for checking the logs, since it always returns `0`. A flag for the `runserver` command would be nice, that returns `-1` when it hits failure state.