### PR TITLE
simpler csv export option for agenda type

### DIFF
--- a/client/src/app/shared/models/agenda/item.ts
+++ b/client/src/app/shared/models/agenda/item.ts
@@ -15,9 +15,9 @@ interface ContentObject {
  * Coming from "OpenSlidesConfigVariables" property "agenda_hide_internal_items_on_projector"
  */
 export const itemVisibilityChoices = [
-    { key: 1, name: 'Public item' },
-    { key: 2, name: 'Internal item' },
-    { key: 3, name: 'Hidden item' }
+    { key: 1, name: 'Public item', csvName: '' },
+    { key: 2, name: 'Internal item', csvName: 'internal' },
+    { key: 3, name: 'Hidden item', csvName: 'hidden' }
 ];
 
 /**
@@ -71,6 +71,18 @@ export class Item extends ProjectableBaseModel {
         }
         const type = itemVisibilityChoices.find(choice => choice.key === this.type);
         return type ? type.name : '';
+    }
+
+    /**
+     * Gets a shortened string for CSV export
+     * @returns empty string if it is a public item, 'internal' or 'hidden' otherwise
+     */
+    public get verboseCsvType(): string {
+        if (!this.type) {
+            return '';
+        }
+        const type = itemVisibilityChoices.find(choice => choice.key === this.type);
+        return type ? type.csvName : '';
     }
 
     public getTitle(): string {

--- a/client/src/app/site/agenda/models/view-item.ts
+++ b/client/src/app/site/agenda/models/view-item.ts
@@ -51,6 +51,13 @@ export class ViewItem extends BaseViewModel {
         return '';
     }
 
+    public get verboseCsvType() : string {
+        if (this.item) {
+            return this.item.verboseCsvType;
+        }
+        return '';
+    }
+
     public constructor(item: Item, contentObject: AgendaBaseModel) {
         super();
         this._item = item;

--- a/client/src/app/site/agenda/services/agenda-csv-export.service.ts
+++ b/client/src/app/site/agenda/services/agenda-csv-export.service.ts
@@ -33,7 +33,7 @@ export class AgendaCsvExportService {
                 { label: 'Text', map: viewItem => viewItem.contentObject ? viewItem.contentObject.getCSVExportText() : '' },
                 { label: 'Duration', property: 'duration' },
                 { label: 'Comment', property: 'comment' },
-                { label: 'Item type', property: 'verboseType' }
+                { label: 'Item type', property: 'verboseCsvType' }
             ],
             this.translate.instant('Agenda') + '.csv'
         );


### PR DESCRIPTION
( Follow-up from #4056 )

> One remark: I want to use '' || internal || hidden instead of public item || internal item || hidden item for item type export field. (= empty if public item, this would be backward compatible with 2.x)

After further discussion, we will export with `''`, `'internal'`, `'hidden'` instead of full strings.

Ping @FinnStutzenstein @emanuelschuetze if this is as desired