### PR TITLE
Fix pytest to a version lower 4.1 until a bug in pytest-asyncio is fixed

### DIFF
--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -2,7 +2,7 @@ coverage
 flake8
 isort
 mypy
-pytest
+pytest<4.1  # See https://github.com/pytest-dev/pytest-asyncio/issues/104
 pytest-django
 pytest-asyncio
 pytest-cov


### PR DESCRIPTION
The is a bug in pytest-asyncio. Until it is fixed, we have to use a lower version of pytest.

I merge this immediately, because this issue lets travis fail and all other pull requests would be blocked. 