### PR TITLE
fix login not responding to errors

### DIFF
--- a/client/src/app/site/login/components/login-mask/login-mask.component.ts
+++ b/client/src/app/site/login/components/login-mask/login-mask.component.ts
@@ -7,7 +7,6 @@ import { OperatorService } from 'app/core/services/operator.service';
 import { MatSnackBar, MatSnackBarRef, SimpleSnackBar } from '@angular/material';
 import { FormGroup, Validators, FormBuilder } from '@angular/forms';
 import { TranslateService } from '@ngx-translate/core';
-import { HttpErrorResponse } from '@angular/common/http';
 import { environment } from 'environments/environment';
 import { OpenSlidesService } from '../../../../core/services/openslides.service';
 import { LoginDataService } from '../../../../core/services/login-data.service';
@@ -141,13 +140,11 @@ export class LoginMaskComponent extends BaseComponent implements OnInit, OnDestr
             }
             this.router.navigate([redirect]);
         } catch (e) {
-            if (e instanceof HttpErrorResponse) {
-                this.loginForm.setErrors({
-                    notFound: true
-                });
-                this.loginErrorMsg = e.error.detail;
-                this.inProcess = false;
-            }
+            this.loginForm.setErrors({
+                notFound: true
+            });
+            this.loginErrorMsg = e;
+            this.inProcess = false;
         }
     }
 


### PR DESCRIPTION
Solves the issue of login errors not arriving at the login mask. As the error is converted into a string early on (http.service), I'm juggling this message down to the login mask, always keeping it a string.

This hurts a bit, because I like Error objects, but I don't want to break stuff *somewhere* that may already rely on it being a string.

The easier way was to have the login mask rely on 'if there is an error arriving, something is wrong, but I just need to display it'.

@FinnStutzenstein, because I was told the errorHandling is yours.