### PR TITLE
fixing Module not found error

### DIFF
--- a/openslides/motions/migrations/0006_submitter_model.py
+++ b/openslides/motions/migrations/0006_submitter_model.py
@@ -24,7 +24,7 @@ def move_submitters_to_own_model(apps, schema_editor):
                 continue  # Skip the anonymous
 
             submitter = Submitter(user=user, motion=motion, weight=weight)
-            submitter.save(force_insert=True)
+            submitter.save(force_insert=True, skip_autoupdate=True)
             weight += 1
 
 


### PR DESCRIPTION
should fix #4069

An Autoupdate is emitted with fake classes, while migrating,when `skip_autoupdate` is not set to `True`, but it skips the autoupdate and prevents the error in [my message in #4069](https://github.com/OpenSlides/OpenSlides/issues/4069#issuecomment-453042854) from happening.