### PR TITLE
fix vulnerable npm dependency angular-devkit

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -51,7 +51,7 @@
         "zone.js": "^0.8.26"
     },
     "devDependencies": {
-        "@angular-devkit/build-angular": "^0.11.4",
+        "@angular-devkit/build-angular": "^0.12.1",
         "@angular/cli": "^7.1.0",
         "@angular/compiler-cli": "^7.1.1",
         "@angular/language-service": "^7.1.1",


### PR DESCRIPTION
Ten minutes after my last fix, a similar npm 'high risk security warning' popped up, which is auto-fixable by now.

I did not test it in depth, yet (I'm not expecting anything, as this is deep down the node dependencies' rabbit hole)