### PR TITLE
separate abstract functions from motion-csv-import

### DIFF
--- a/client/src/app/core/services/text-import.service.ts
+++ b/client/src/app/core/services/text-import.service.ts
@@ -1,0 +1,368 @@
+import { BehaviorSubject, Observable } from 'rxjs';
+import { Injectable, EventEmitter } from '@angular/core';
+import { MatSnackBar } from '@angular/material';
+import { Papa, PapaParseConfig } from 'ngx-papaparse';
+import { TranslateService } from '@ngx-translate/core';
+import { BaseViewModel } from 'app/site/base/base-view-model';
+
+/**
+ * Interface for value- Label combinations.
+ * Map objects didn't work, TODO: Use map objects (needs iterating through all objects of a map)
+ */
+export interface ValueLabelCombination {
+    value: string;
+    label: string;
+}
+
+/**
+ * Interface matching a newly created entry with their duplicates and an import status
+ */
+export interface NewEntry<V> {
+    newEntry: V;
+    status: CsvImportStatus;
+    errors: string[];
+    duplicates: V[];
+}
+
+/**
+ * interface for a preview summary
+ */
+export interface ImportCSVPreview {
+    total: number;
+    duplicates: number;
+    errors: number;
+    new: number;
+    done: number;
+}
+
+/**
+ * The permitted states of a new entry. Only a 'new' entry should be imported
+ * and then be set to 'done'.
+ */
+type CsvImportStatus = 'new' | 'error' | 'done';
+
+/**
+ * Abstract service for imports
+ */
+@Injectable({
+    providedIn: 'root'
+})
+export abstract class TextImportService<V extends BaseViewModel> {
+    public abstract errorList: Object;
+
+    /**
+     * The headers expected in the CSV matching import model's properties (in order)
+     */
+    public expectedHeader: (keyof V)[];
+
+    /**
+     * The minimimal number of header entries needed to successfully create an entry
+     */
+    public requiredHeaderLength: number;
+
+    /**
+     * The last parsed file object (may be reparsed with new encoding, thus kept in memory)
+     */
+    private _rawFile: File;
+
+    /**
+     * The used column separator. If left on an empty string (default),
+     * the papaparse parser will automatically decide on separators.
+     */
+    public columnSeparator = '';
+
+    /**
+     * The used text separator.
+     */
+    public textSeparator = '"';
+
+    /**
+     * The encoding used by the FileReader object.
+     */
+    public encoding = 'utf-8';
+
+    /**
+     * List of possible encodings and their label. values should be values accepted
+     * by the FileReader API
+     */
+    public encodings: ValueLabelCombination[] = [
+        { value: 'utf-8', label: 'UTF 8 - Unicode' },
+        { value: 'iso-8859-1', label: 'ISO 8859-1 - West European' },
+        { value: 'iso-8859-15', label: 'ISO 8859-15 - West European (with €)' }
+    ];
+
+    /**
+     * List of possible column separators to pass on to papaParse
+     */
+    public columnSeparators: ValueLabelCombination[] = [
+        { label: 'Comma', value: ',' },
+        { label: 'Semicolon', value: ';' },
+        // {label: 'Tabulator', value: '\t'},
+        { label: 'Automatic', value: '' }
+    ];
+
+    /**
+     * List of possible text separators to pass on to papaParse. Note that
+     * it cannot automatically detect textseparators (value must not be an empty string)
+     */
+    public textSeparators: ValueLabelCombination[] = [
+        { label: 'Double quotes (")', value: '"' },
+        { label: "Single quotes (')", value: "'" }
+    ];
+
+    /**
+     * FileReader object for file import
+     */
+    private reader = new FileReader();
+
+    /**
+     * the list of parsed models that have been extracted from the opened file
+     */
+    private _entries: NewEntry<V>[] = [];
+
+    /**
+     * BehaviorSubject for displaying a preview for the currently selected entries
+     */
+    public newEntries = new BehaviorSubject<NewEntry<V>[]>([]);
+
+    /**
+     * Emits an error string to display if a file import cannot be done
+     */
+    public errorEvent = new EventEmitter<string>();
+
+    /**
+     * storing the summary preview for the import, to avoid recalculating it
+     * at each display change.
+     */
+    protected _preview: ImportCSVPreview;
+
+    /**
+     * Returns a summary on actions that will be taken/not taken.
+     */
+    public get summary(): ImportCSVPreview {
+        if (!this._preview) {
+            this.updatePreview();
+        }
+        return this._preview;
+    }
+
+    /**
+     * Returns the current entries. For internal use in extending classes, as it
+     * might not be filled with data at all times (see {@link newEntries} for a BehaviorSubject)
+     */
+    protected get entries(): NewEntry<V>[] {
+        return this._entries;
+    }
+
+    /**
+     * Constructor. Creates a fileReader to subscribe to it for incoming parsed
+     * strings
+     * @param categoryRepo Repository to fetch pre-existing categories
+     * @param motionBlockRepo Repository to fetch pre-existing motionBlocks
+     * @param userRepo Repository to query/ create users
+     * @param translate Translation service
+     * @param papa External csv parser (ngx-papaparser)
+     * @param matSnackBar snackBar to display import errors
+     */
+    public constructor(protected translate: TranslateService, private papa: Papa, protected matSnackbar: MatSnackBar) {
+        this.reader.onload = (event: any) => {
+            // TODO type: event is a progressEvent,
+            // but has a property target.result, which typescript doesn't recognize
+            this.parseInput(event.target.result);
+        };
+    }
+
+    /**
+     * Clears all stored secondary data
+     * TODO: Merge with clearPreview()
+     */
+    public abstract clearData(): void;
+
+    /**
+     * Parses the data input. Expects a string as returned by via a
+     * File.readAsText() operation
+     *
+     * @param file
+     */
+    public parseInput(file: string): void {
+        this.clearData();
+        this.clearPreview();
+        const papaConfig: PapaParseConfig = {
+            header: false,
+            skipEmptyLines: true,
+            quoteChar: this.textSeparator
+        };
+        if (this.columnSeparator) {
+            papaConfig.delimiter = this.columnSeparator;
+        }
+        const entryLines = this.papa.parse(file, papaConfig).data;
+        const valid = this.checkHeader(entryLines.shift());
+        if (!valid) {
+            return;
+        }
+        entryLines.forEach(line => {
+            this._entries.push(this.mapData(line));
+        });
+        this.newEntries.next(this._entries);
+        this.updatePreview();
+    }
+
+    /**
+     * Parsing an e string representing an entry, extracting secondary data, returning a new entry object
+     * @param line a line extracted by the CSV (without the header)
+     */
+    public abstract mapData(line: string): NewEntry<V>;
+
+    /**
+     * Trigger for executing the import.
+     */
+    public abstract async doImport(): Promise<void>;
+
+    /**
+     * counts the amount of duplicates that have no decision on the action to
+     * be taken
+     */
+    public updatePreview(): void {
+        const summary = {
+            total: 0,
+            new: 0,
+            duplicates: 0,
+            errors: 0,
+            done: 0
+        };
+        this._entries.forEach(entry => {
+            summary.total += 1;
+            if (entry.status === 'done') {
+                summary.done += 1;
+                return;
+            } else if (entry.status === 'error' && !entry.duplicates.length) {
+                // errors that are not due to duplicates
+                summary.errors += 1;
+                return;
+            } else if (entry.duplicates.length) {
+                summary.duplicates += 1;
+                return;
+            } else if (entry.status === 'new') {
+                summary.new += 1;
+            }
+        });
+        this._preview = summary;
+    }
+
+    /**
+     * returns a subscribable representation of the new items to be imported
+     */
+    public getNewEntries(): Observable<NewEntry<V>[]> {
+        return this.newEntries.asObservable();
+    }
+
+    /**
+     * Handler after a file was selected. Basic checking for type, then hand
+     * over to parsing
+     *
+     * @param event type is Event, but has target.files, which typescript doesn't seem to recognize
+     */
+    public onSelectFile(event: any): void {
+        // TODO type
+        if (event.target.files && event.target.files.length === 1) {
+            if (event.target.files[0].type === 'text/csv') {
+                this._rawFile = event.target.files[0];
+                this.readFile(event.target.files[0]);
+            } else {
+                this.matSnackbar.open(this.translate.instant('Wrong file type detected. Import failed.'), '', {
+                    duration: 3000
+                });
+                this.clearPreview();
+                this._rawFile = null;
+            }
+        }
+    }
+
+    /**
+     * Rereads the (previously selected) file, if present. Thought to be triggered
+     * by parameter changes on encoding, column, text separators
+     */
+    public refreshFile(): void {
+        if (this._rawFile) {
+            this.readFile(this._rawFile);
+        }
+    }
+
+    /**
+     * (re)-reads a given file with the current parameter
+     */
+    private readFile(file: File): void {
+        this.reader.readAsText(file, this.encoding);
+    }
+
+    /**
+     * Checks the first line of the csv (the header) for consistency (length)
+     *
+     * @param row expected to be an array parsed from the first line of a csv file
+     */
+    private checkHeader(row: string[]): boolean {
+        const snackbarDuration = 3000;
+        if (row.length < this.requiredHeaderLength) {
+            this.matSnackbar.open(this.translate.instant('The file has too few columns to be parsed properly.'), '', {
+                duration: snackbarDuration
+            });
+
+            this.clearPreview();
+            return false;
+        } else if (row.length < this.expectedHeader.length) {
+            this.matSnackbar.open(
+                this.translate.instant('The file seems to have some ommitted columns. They will be considered empty.'),
+                '',
+                { duration: snackbarDuration }
+            );
+        } else if (row.length > this.expectedHeader.length) {
+            this.matSnackbar.open(
+                this.translate.instant('The file seems to have additional columns. They will be ignored.'),
+                '',
+                { duration: snackbarDuration }
+            );
+        }
+        return true;
+    }
+
+    /**
+     * Resets the data and preview (triggered upon selecting an invalid file)
+     */
+    public clearPreview(): void {
+        this._entries = [];
+        this.newEntries.next([]);
+        this._preview = null;
+    }
+
+    /**
+     * set a list of short names for error, indicating which column failed
+     */
+    public setError(entry: NewEntry<V>, error: string): void {
+        if (this.errorList.hasOwnProperty(error)) {
+            if (!entry.errors) {
+                entry.errors = [error];
+            } else if (!entry.errors.includes(error)) {
+                entry.errors.push(error);
+                entry.status = 'error';
+            }
+        }
+    }
+
+    /**
+     * Get an extended error description.
+     * @param error
+     */
+    public verbose(error: string): string {
+        return this.errorList[error];
+    }
+
+    /**
+     * Queries if a given error is present in the given entry
+     *
+     * @param entry
+     * @param error
+     */
+    public hasError(entry: NewEntry<V>, error: string): boolean {
+        return entry.errors.includes(error);
+    }
+}

--- a/client/src/app/core/services/text-import.service.ts
+++ b/client/src/app/core/services/text-import.service.ts
@@ -155,11 +155,7 @@ export abstract class TextImportService<V extends BaseViewModel> {
     }
 
     /**
-     * Constructor. Creates a fileReader to subscribe to it for incoming parsed
-     * strings
-     * @param categoryRepo Repository to fetch pre-existing categories
-     * @param motionBlockRepo Repository to fetch pre-existing motionBlocks
-     * @param userRepo Repository to query/ create users
+     * Constructor. Creates a fileReader to subscribe to it for incoming parsed strings
      * @param translate Translation service
      * @param papa External csv parser (ngx-papaparser)
      * @param matSnackBar snackBar to display import errors

--- a/client/src/app/site/motions/components/motion-import-list/motion-import-list.component.html
+++ b/client/src/app/site/motions/components/motion-import-list/motion-import-list.component.html
@@ -23,7 +23,6 @@
             Identifier, reason, submitter, category, origin and motion block are optional and may be empty.
         </li>
         <li translate>Additional columns after the required ones may be present and won't affect the import.</li>
-        <li translate>Only double quotes are accepted as text delimiter (no single quotes).</li>
     </ul>
     <button mat-button color="accent" (click)="downloadCsvExample()" translate>Download CSV example file</button>
     <div class="wrapper">
@@ -112,20 +111,20 @@
             <ng-container matColumnDef="status" sticky>
                 <mat-header-cell *matHeaderCellDef></mat-header-cell>
                 <mat-cell *matCellDef="let entry">
-                    <div *ngIf="entry.newMotion.status === 'error'">
+                    <div *ngIf="entry.status === 'error'">
                         <mat-icon
                             class="red-warning-text"
-                            matTooltip="{{ entry.newMotion.errors.length }} + {{ 'errors' | translate }}"
+                            matTooltip="{{ entry.errors.length }} {{ 'errors' | translate }}"
                         >
                             {{ getActionIcon(entry) }}
                         </mat-icon>
                     </div>
-                    <div *ngIf="entry.newMotion.status === 'new'">
+                    <div *ngIf="entry.status === 'new'">
                         <mat-icon matTooltip="{{ 'Motion will be imported' | translate }}">
                             {{ getActionIcon(entry) }}
                         </mat-icon>
                     </div>
-                    <div *ngIf="entry.newMotion.status === 'done'">
+                    <div *ngIf="entry.status === 'done'">
                         <mat-icon matTooltip="{{ 'Motion has been imported' | translate }}">
                             {{ getActionIcon(entry) }}
                         </mat-icon>
@@ -140,12 +139,12 @@
                     <mat-icon
                         color="warn"
                         inline
-                        *ngIf="entry.newMotion.hasError('Duplicates')"
+                        *ngIf="hasError(entry, 'Duplicates')"
                         matTooltip="{{ getVerboseError('Duplicates') | translate }}"
                     >
                         warning
                     </mat-icon>
-                    &nbsp;{{ entry.newMotion.identifier }}
+                    &nbsp;{{ entry.newEntry.identifier }}
                 </mat-cell>
             </ng-container>
 
@@ -155,35 +154,35 @@
                 <mat-cell *matCellDef="let entry">
                     <mat-icon
                         color="warn"
-                        *ngIf="entry.newMotion.hasError('Title')"
+                        *ngIf="hasError(entry, 'Title')"
                         matTooltip="{{ getVerboseError('Title') | translate }}"
                     >
                         warning
                     </mat-icon>
-                    &nbsp;{{ entry.newMotion.title }}
+                    &nbsp;{{ entry.newEntry.title }}
                 </mat-cell>
             </ng-container>
 
             <!-- tect column TODO: Bigger-->
             <ng-container matColumnDef="text">
                 <mat-header-cell *matHeaderCellDef translate>Motion text</mat-header-cell>
-                <mat-cell *matCellDef="let entry" matTooltip="{{ getLongPreview(entry.newMotion.text) }}">
+                <mat-cell *matCellDef="let entry" matTooltip="{{ getLongPreview(entry.newEntry.text) }}">
                     <mat-icon
                         color="warn"
-                        *ngIf="entry.newMotion.hasError('Text')"
+                        *ngIf="hasError(entry, 'Text')"
                         matTooltip="{{ getVerboseError('Text') | translate }}"
                     >
                         warning
                     </mat-icon>
-                    &nbsp;{{ getShortPreview(entry.newMotion.text) }}
+                    &nbsp;{{ getShortPreview(entry.newEntry.text) }}
                 </mat-cell>
             </ng-container>
 
             <!-- reason column -->
             <ng-container matColumnDef="reason">
                 <mat-header-cell *matHeaderCellDef translate>Reason</mat-header-cell>
-                <mat-cell *matCellDef="let entry" matTooltip="{{ getLongPreview(entry.newMotion.reason) }}">
-                    {{ getShortPreview(entry.newMotion.reason) }}
+                <mat-cell *matCellDef="let entry" matTooltip="{{ getLongPreview(entry.newEntry.reason) }}">
+                    {{ getShortPreview(entry.newEntry.reason) }}
                 </mat-cell>
             </ng-container>
 
@@ -191,15 +190,15 @@
             <ng-container matColumnDef="submitters">
                 <mat-header-cell *matHeaderCellDef translate>Submitters</mat-header-cell>
                 <mat-cell *matCellDef="let entry">
-                    <div *ngIf="entry.newMotion.csvSubmitters.length">
+                    <div *ngIf="entry.newEntry.csvSubmitters.length">
                         <mat-icon
                             color="warn"
-                            *ngIf="entry.newMotion.hasError('Submitters')"
+                            *ngIf="hasError(entry, 'Submitters')"
                             matTooltip="{{ getVerboseError('Submitters') | translate }}"
                         >
                             warning
                         </mat-icon>
-                        <span *ngFor="let submitter of entry.newMotion.csvSubmitters">
+                        <span *ngFor="let submitter of entry.newEntry.csvSubmitters">
                             {{ submitter.name }}
                             <mat-icon class="newBadge" color="accent" inline *ngIf="!submitter.id">add</mat-icon>
                             &nbsp;
@@ -212,16 +211,16 @@
             <ng-container matColumnDef="category">
                 <mat-header-cell *matHeaderCellDef translate>Category</mat-header-cell>
                 <mat-cell *matCellDef="let entry">
-                    <div *ngIf="entry.newMotion.csvCategory">
+                    <div *ngIf="entry.newEntry.csvCategory">
                         <mat-icon
                             color="warn"
-                            *ngIf="entry.newMotion.hasError('Category')"
+                            *ngIf="hasError(entry, 'Category')"
                             matTooltip="{{ getVerboseError('Category') | translate }}"
                         >
                             warning
                         </mat-icon>
-                        {{ entry.newMotion.csvCategory.name }}
-                        <mat-icon class="newBadge" color="accent" inline *ngIf="!entry.newMotion.csvCategory.id"
+                        {{ entry.newEntry.csvCategory.name }}
+                        <mat-icon class="newBadge" color="accent" inline *ngIf="!entry.newEntry.csvCategory.id"
                             >add</mat-icon
                         >&nbsp;
                     </div>
@@ -231,23 +230,23 @@
             <!-- origin column -->
             <ng-container matColumnDef="origin">
                 <mat-header-cell *matHeaderCellDef translate>Origin</mat-header-cell>
-                <mat-cell *matCellDef="let entry">{{ entry.newMotion.origin }}</mat-cell>
+                <mat-cell *matCellDef="let entry">{{ entry.newEntry.origin }}</mat-cell>
             </ng-container>
 
             <!-- motion block column -->
-            <ng-container matColumnDef="motion block">
+            <ng-container matColumnDef="motion_block">
                 <mat-header-cell *matHeaderCellDef translate>Motion block</mat-header-cell>
                 <mat-cell *matCellDef="let entry">
-                    <div *ngIf="entry.newMotion.csvMotionblock">
+                    <div *ngIf="entry.newEntry.csvMotionblock">
                         <mat-icon
                             color="warn"
-                            *ngIf="entry.newMotion.hasError('MotionBlock')"
+                            *ngIf="hasError(entry, 'MotionBlock')"
                             matTooltip="{{ getVerboseError('MotionBlock') | translate }}"
                         >
                             warning
                         </mat-icon>
-                        {{ entry.newMotion.csvMotionblock.name }}
-                        <mat-icon class="newBadge" color="accent" inline *ngIf="!entry.newMotion.csvMotionblock.id">
+                        {{ entry.newEntry.csvMotionblock.name }}
+                        <mat-icon class="newBadge" color="accent" inline *ngIf="!entry.newEntry.csvMotionblock.id">
                             add
                         </mat-icon>
                         &nbsp;

--- a/client/src/app/site/motions/components/motion-import-list/motion-import-list.component.ts
+++ b/client/src/app/site/motions/components/motion-import-list/motion-import-list.component.ts
@@ -5,7 +5,9 @@ import { ViewChild, Component, OnInit } from '@angular/core';
 
 import { BaseViewComponent } from 'app/site/base/base-view';
 import { MotionCsvExportService } from '../../services/motion-csv-export.service';
-import { MotionImportService, NewMotionEntry, ValueLabelCombination } from '../../services/motion-import.service';
+import { MotionImportService } from '../../services/motion-import.service';
+import { NewEntry, ValueLabelCombination } from 'app/core/services/text-import.service';
+import { ViewMotion } from '../../models/view-motion';
 
 /**
  * Component for the motion import list view.
@@ -19,7 +21,7 @@ export class MotionImportListComponent extends BaseViewComponent implements OnIn
     /**
      * The data source for a table. Requires to be initialised with a BaseViewModel
      */
-    public dataSource: MatTableDataSource<NewMotionEntry>;
+    public dataSource: MatTableDataSource<NewEntry<ViewMotion>>;
 
     /**
      * Switch that turns true if a file has been selected in the input
@@ -41,7 +43,7 @@ export class MotionImportListComponent extends BaseViewComponent implements OnIn
      * The table itself
      */
     @ViewChild(MatTable)
-    protected table: MatTable<NewMotionEntry>;
+    protected table: MatTable<NewEntry<ViewMotion>>;
 
     /**
      * Returns the amount of total item successfully parsed
@@ -171,15 +173,15 @@ export class MotionImportListComponent extends BaseViewComponent implements OnIn
             };
         } else if (this.shown === 'noerror') {
             this.dataSource.filterPredicate = (data, filter) => {
-                if (data.newMotion.status === 'done') {
+                if (data.status === 'done') {
                     return true;
-                } else if (!(data.newMotion.status !== 'error') && !data.duplicates.length) {
+                } else if (!(data.status !== 'error') && !data.duplicates.length) {
                     return true;
                 }
             };
         } else if (this.shown === 'error') {
             this.dataSource.filterPredicate = (data, filter) => {
-                if (data.newMotion.errors.length || data.duplicates.length) {
+                if (data.errors.length || data.duplicates.length) {
                     return true;
                 }
                 return false;
@@ -193,8 +195,8 @@ export class MotionImportListComponent extends BaseViewComponent implements OnIn
      *
      * @param row
      */
-    public getStateClass(row: NewMotionEntry): string {
-        switch (row.newMotion.status) {
+    public getStateClass(row: NewEntry<ViewMotion>): string {
+        switch (row.status) {
             case 'done':
                 return 'import-done import-decided';
             case 'error':
@@ -237,8 +239,8 @@ export class MotionImportListComponent extends BaseViewComponent implements OnIn
      * Return the icon for the action of the item
      * @param entry
      */
-    public getActionIcon(entry: NewMotionEntry): string {
-        switch (entry.newMotion.status) {
+    public getActionIcon(entry: NewEntry<ViewMotion>): string {
+        switch (entry.status) {
             case 'error': // no import possible
                 return 'block';
             case 'new': // new item, will be imported
@@ -304,5 +306,14 @@ export class MotionImportListComponent extends BaseViewComponent implements OnIn
      */
     public getVerboseError(error: string): string {
         return this.importer.verbose(error);
+    }
+
+    /**
+     * Checks if an error is present in a new entry
+     * @param row
+     * @param error
+     */
+    public hasError(row: NewEntry<ViewMotion>, error: string): boolean {
+        return this.importer.hasError(row, error);
     }
 }

--- a/client/src/app/site/motions/models/view-csv-create-motion.ts
+++ b/client/src/app/site/motions/models/view-csv-create-motion.ts
@@ -2,17 +2,14 @@ import { ViewCreateMotion } from './view-create-motion';
 import { CreateMotion } from './create-motion';
 
 /**
- * Interface for imported secondary data. A name can be matched to an existing
- * model instance by the solve... functions.
- * TODO MultiId will be filled if there is more than one match (to be used in case of 'I want to select one of these matches)
+ * Interface for correlating between strings representing BaseModels and existing
+ * BaseModels.
  */
 export interface CsvMapping {
     name: string;
     id?: number;
     multiId?: number[];
 }
-
-type CsvImportStatus = 'new' | 'error' | 'done';
 
 /**
  * Create motion class for the View. Its different to ViewMotion in fact that the submitter handling is different
@@ -38,66 +35,8 @@ export class ViewCsvCreateMotion extends ViewCreateMotion {
      */
     public csvSubmitters: CsvMapping[];
 
-    /**
-     * The current import status of this motion.
-     * Starts as 'new', if set to 'done', a proper {@link Motion} model will
-     * probably exist in the dataStore. error status will be set if the import
-     * cannot be done
-     */
-    private _status: CsvImportStatus = 'new';
-
-    /**
-     * list of import errors See {@link MotionImportService}
-     */
-    public errors: string[] = [];
-
-    /**
-     * Returns the current status.
-     */
-    public get status(): CsvImportStatus {
-        return this._status;
-    }
-
-    public set status(status: CsvImportStatus) {
-        this._status = status;
-    }
-
-    public get motion(): CreateMotion {
-        return this._motion;
-    }
-
     public constructor(motion?: CreateMotion) {
         super(motion);
-    }
-
-    /**
-     * Duplicate this motion into a copy of itself
-     */
-    public copy(): ViewCreateMotion {
-        return new ViewCreateMotion(
-            this._motion,
-            this._category,
-            this._submitters,
-            this._supporters,
-            this._workflow,
-            this._state
-        );
-    }
-
-    /**
-     * Checks if a given error is present. TODO: Is more a ViewModel option
-     *
-     * @param error
-     */
-    public hasError(error: string): boolean {
-        return this.errors.includes(error);
-    }
-
-    /**
-     * Toggle to set a CreateMotion to a 'successfully parsed' status
-     */
-    public done(): void {
-        this._status = 'done';
     }
 
     /**

--- a/client/src/app/site/motions/services/motion-repository.service.ts
+++ b/client/src/app/site/motions/services/motion-repository.service.ts
@@ -621,10 +621,9 @@ export class MotionRepositoryService extends BaseRepository<ViewMotion, Motion> 
     }
 
     /**
-     * Returns all Motion duplicates (sharing specific values given in input)
+     * Returns motion duplicates (sharing the identifier)
      * @param viewMotion the ViewMotion to compare against the list of Motions
      * in the data
-     * @param sharedValues properties that must be equal to consider it a duplicate
      */
     public getMotionDuplicates(motion: Motion): ViewMotion[] {
         const duplicates = this.DS.filter(Motion, item => motion.identifier === item.identifier);


### PR DESCRIPTION
This doesn't add functionality, it separates the motion csv import from generic import stuff which can be reused for other imports (I'm working on branches for user and agenda, on top of this pr).

Some ninja fixes where I found outdated docs.