### PR TITLE
Fix Headless Browser Start with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,8 +82,9 @@ matrix:
       cache:
         directories:
           - node_modules
+      services:
+        - xvfb
       before_install:
-        - sh -e /etc/init.d/xvfb start
         - export CHROME_BIN=/usr/bin/google-chrome
         - export DISPLAY=:99.0
         - npm install -g @angular/cli


### PR DESCRIPTION
Even though the documentation of travis still states, that xvfb can be
initialized via init.d, it seems that all images are updated to use
systemd, therefore it was switched to the travis service syntax.