### PR TITLE
shorten Motion title (wip)

### DIFF
--- a/client/src/app/site/motions/components/motion-list/motion-list.component.html
+++ b/client/src/app/site/motions/components/motion-list/motion-list.component.html
@@ -51,9 +51,10 @@
             <mat-header-cell *matHeaderCellDef mat-sort-header>Title</mat-header-cell>
             <mat-cell *matCellDef="let motion">
                 <div class="innerTable">
-                    <span class="motion-list-title">{{ motion.title }}
+                    <span class="motion-list-title" matTooltip="{{ motion.title }}">
+                        {{ shortenTitle(motion) }}
                         <span>
-                            <mat-icon inline>{{ motion.star ? 'star' : 'star_border' }}</mat-icon>
+                            <mat-icon inline>{{ motion.star ? 'star' : '' }}</mat-icon>
                         </span>
                     </span>
 

--- a/client/src/app/site/motions/components/motion-list/motion-list.component.ts
+++ b/client/src/app/site/motions/components/motion-list/motion-list.component.ts
@@ -212,4 +212,22 @@ export class MotionListComponent extends ListViewBaseComponent<ViewMotion> imple
             this.raiseError(e);
         }
     }
+
+    /**
+     * Shortens a motion title according to the current size of the 'title' column
+     * (TODO: Still not functioning with zoomed page)
+     *
+     * @param row
+     * @returns a shortened title if the title is too long
+     */
+    public shortenTitle(row: ViewMotion): string {
+        const pixelsPerChar = 10; // TODO: make this depend on current font size
+        const defi: HTMLElement[] = this.table._getRenderedRows(this.table._rowOutlet);
+        const element: HTMLCollectionOf<Element> = defi[1].getElementsByClassName('cdk-column-title');
+        const maxChars = Math.floor(element[0].clientWidth / pixelsPerChar);
+        if (row.title.length < maxChars) {
+            return row.title;
+        }
+        return row.title.substr(0, maxChars - 2) + '..';
+    }
 }


### PR DESCRIPTION
Idea is to have a motion title stripped down to one line in the list view.

This approach is a bit ugly, but maybe we can use it.

- hard coded 'max pixels per char' is not a good idea, I guess.
- digging in the entrails of the rendered stuff is not the most elegant solution
- It does not work flawlessly in all instances the browser's size/zoom changes.

If we end up using it, long user names and other list views may want to use it, too.

(Some ninja fix: the 'favorite' star should only show if it is a favorite)

