### PR TITLE
prevent accidental self- lockout in multiSelect

### DIFF
--- a/client/src/app/site/users/components/user-list/user-list.component.ts
+++ b/client/src/app/site/users/components/user-list/user-list.component.ts
@@ -370,7 +370,14 @@ export class UserListComponent extends ListViewBaseComponent<ViewUser, User> imp
      * Handler for bulk setting new passwords. Needs multiSelect mode.
      */
     public async resetPasswordsSelected(): Promise<void> {
-        for (const user of this.selectedRows) {
+        if (this.selectedRows.find(row => row.user.id === this.operator.user.id)) {
+            this.raiseError(
+                this.translate.instant(
+                    'Note: Your own password will not be changed. Please use the password change dialog instead.'
+                )
+            );
+        }
+        for (const user of this.selectedRows.filter(u => u.user.id !== this.operator.user.id)) {
             const password = this.repo.getRandomPassword();
             this.repo.resetPassword(user, password, true);
         }


### PR DESCRIPTION
With admin rights you can semi-accidentally send a request to set a random new+default password for yourself; which can cause you not to be able to login again.

This only displays a confirmation if you selected yourself; you can still do it.

Should there be warnings for locking yourself out of groups (which ones?) too?

(Deleting yourself is not possible, so no warning there, yet)