### PR TITLE
Fixes #4174

### DIFF
--- a/client/src/app/shared/components/os-sort-filter-bar/os-sort-filter-bar.component.html
+++ b/client/src/app/shared/components/os-sort-filter-bar/os-sort-filter-bar.component.html
@@ -35,6 +35,7 @@
         </button>
         <mat-form-field *ngIf="isSearchBar">
             <input
+                osAutofocus
                 matInput
                 (keyup)="applySearch($event, $event.target.value)"
                 placeholder="{{ translate.instant('Search') }}"

--- a/client/src/app/site/common/components/search/search.component.html
+++ b/client/src/app/site/common/components/search/search.component.html
@@ -11,7 +11,7 @@
 <div class="search-field">
     <form [formGroup]="quickSearchform">
         <mat-form-field>
-            <input matInput formControlName="query" (keyup)="quickSearch()" />
+            <input matInput osAutofocus formControlName="query" (keyup)="quickSearch()" />
             <mat-icon matSuffix>search</mat-icon>
         </mat-form-field>
     </form>


### PR DESCRIPTION
Fixed the non-autofocus search-input-element on the search-page.
Added directive 'osAutofocus' to the input-element, so it will be autofocussed when the user enters the search-component.