### PR TITLE
Projector V

### DIFF
--- a/openslides/agenda/apps.py
+++ b/openslides/agenda/apps.py
@@ -13,7 +13,7 @@ class AgendaAppConfig(AppConfig):
         from django.db.models.signals import pre_delete, post_save
         from ..core.signals import permission_change
         from ..utils.rest_api import router
-        from .projector import register_projector_elements
+        from .projector import register_projector_slides
         from .signals import (
             get_permission_change_data,
             listen_to_related_object_post_delete,
@@ -24,7 +24,7 @@ class AgendaAppConfig(AppConfig):
         from ..utils.access_permissions import required_user
 
         # Define projector elements.
-        register_projector_elements()
+        register_projector_slides()
 
         # Connect signals.
         post_save.connect(

--- a/openslides/agenda/projector.py
+++ b/openslides/agenda/projector.py
@@ -1,7 +1,11 @@
 from collections import defaultdict
 from typing import Any, Dict, List, Tuple
 
-from ..utils.projector import AllData, register_projector_element
+from ..utils.projector import (
+    AllData,
+    ProjectorElementException,
+    register_projector_slide,
+)
 
 
 # Important: All functions have to be prune. This means, that thay can only
@@ -41,7 +45,7 @@ def get_tree(
     return get_children(children[parent_id])
 
 
-def items(element: Dict[str, Any], all_data: AllData) -> Dict[str, Any]:
+def items_slide(all_data: AllData, element: Dict[str, Any]) -> Dict[str, Any]:
     """
     Item list slide.
 
@@ -63,7 +67,9 @@ def items(element: Dict[str, Any], all_data: AllData) -> Dict[str, Any]:
     return {"items": agenda_items}
 
 
-def list_of_speakers(element: Dict[str, Any], all_data: AllData) -> Dict[str, Any]:
+def list_of_speakers_slide(
+    all_data: AllData, element: Dict[str, Any]
+) -> Dict[str, Any]:
     """
     List of speakers slide.
 
@@ -76,7 +82,7 @@ def list_of_speakers(element: Dict[str, Any], all_data: AllData) -> Dict[str, An
     try:
         item = all_data["agenda/item"][item_id]
     except KeyError:
-        return {"error": f"Item {item_id} does not exist"}
+        raise ProjectorElementException(f"Item {item_id} does not exist")
 
     user_ids = []
     for speaker in item["speakers"]:
@@ -84,6 +90,6 @@ def list_of_speakers(element: Dict[str, Any], all_data: AllData) -> Dict[str, An
     return {"user_ids": user_ids}
 
 
-def register_projector_elements() -> None:
-    register_projector_element("agenda/item-list", items)
-    register_projector_element("agenda/list-of-speakers", list_of_speakers)
+def register_projector_slides() -> None:
+    register_projector_slide("agenda/item-list", items_slide)
+    register_projector_slide("agenda/list-of-speakers", list_of_speakers_slide)

--- a/openslides/assignments/apps.py
+++ b/openslides/assignments/apps.py
@@ -15,12 +15,12 @@ class AssignmentsAppConfig(AppConfig):
         from ..utils.access_permissions import required_user
         from ..utils.rest_api import router
         from . import serializers  # noqa
-        from .projector import register_projector_elements
+        from .projector import register_projector_slides
         from .signals import get_permission_change_data
         from .views import AssignmentViewSet, AssignmentPollViewSet
 
         # Define projector elements.
-        register_projector_elements()
+        register_projector_slides()
 
         # Connect signals.
         permission_change.connect(

--- a/openslides/assignments/projector.py
+++ b/openslides/assignments/projector.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict
 
-from ..utils.projector import register_projector_element
+from ..utils.projector import AllData, register_projector_slide
 
 
 # Important: All functions have to be prune. This means, that thay can only
@@ -9,9 +9,7 @@ from ..utils.projector import register_projector_element
 #            to be fast!
 
 
-def assignment(
-    element: Dict[str, Any], all_data: Dict[str, Dict[int, Dict[str, Any]]]
-) -> Dict[str, Any]:
+def assignment_slide(all_data: AllData, element: Dict[str, Any]) -> Dict[str, Any]:
     """
     Assignment slide.
     """
@@ -19,5 +17,5 @@ def assignment(
     return {"error": "TODO"}
 
 
-def register_projector_elements() -> None:
-    register_projector_element("assignments/assignment", assignment)
+def register_projector_slides() -> None:
+    register_projector_slide("assignments/assignment", assignment_slide)

--- a/openslides/core/apps.py
+++ b/openslides/core/apps.py
@@ -17,7 +17,7 @@ class CoreAppConfig(AppConfig):
     def ready(self):
         # Import all required stuff.
         from .config import config
-        from .projector import register_projector_elements
+        from .projector import register_projector_slides
         from . import serializers  # noqa
         from .signals import (
             delete_django_app_permissions,
@@ -49,7 +49,7 @@ class CoreAppConfig(AppConfig):
         config.collect_config_variables_from_apps()
 
         # Define projector elements.
-        register_projector_elements()
+        register_projector_slides()
 
         # Connect signals.
         post_permission_creation.connect(

--- a/openslides/core/projector.py
+++ b/openslides/core/projector.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict
 
-from ..utils.projector import register_projector_element
+from ..utils.projector import AllData, register_projector_slide
 
 
 # Important: All functions have to be prune. This means, that thay can only
@@ -9,9 +9,7 @@ from ..utils.projector import register_projector_element
 #            to be fast!
 
 
-def countdown(
-    element: Dict[str, Any], all_data: Dict[str, Dict[int, Dict[str, Any]]]
-) -> Dict[str, Any]:
+def countdown_slide(all_data: AllData, element: Dict[str, Any]) -> Dict[str, Any]:
     """
     Countdown slide.
 
@@ -30,9 +28,7 @@ def countdown(
         return {"error": f"Countdown {countdown_id} does not exist"}
 
 
-def message(
-    element: Dict[str, Any], all_data: Dict[str, Dict[int, Dict[str, Any]]]
-) -> Dict[str, Any]:
+def message_slide(all_data: AllData, element: Dict[str, Any]) -> Dict[str, Any]:
     """
     Message slide.
 
@@ -51,7 +47,7 @@ def message(
         return {"error": f"Message {message_id} does not exist"}
 
 
-def register_projector_elements() -> None:
-    register_projector_element("core/countdown", countdown)
-    register_projector_element("core/projector-message", message)
+def register_projector_slides() -> None:
+    register_projector_slide("core/countdown", countdown_slide)
+    register_projector_slide("core/projector-message", message_slide)
     # TODO: Add clock slide

--- a/openslides/core/serializers.py
+++ b/openslides/core/serializers.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from ..utils.projector import projector_elements
+from ..utils.projector import projector_slides
 from ..utils.rest_api import Field, IntegerField, ModelSerializer, ValidationError
 from ..utils.validate import validate_html
 from .models import (
@@ -56,7 +56,7 @@ def elements_validator(value: Any) -> None:
             raise ValidationError(
                 {"detail": "Every dictionary must have a key 'name'."}
             )
-        if element["name"] not in projector_elements:
+        if element["name"] not in projector_slides:
             raise ValidationError(
                 {"detail": f"Unknown projector element {element['name']},"}
             )

--- a/openslides/mediafiles/apps.py
+++ b/openslides/mediafiles/apps.py
@@ -12,14 +12,14 @@ class MediafilesAppConfig(AppConfig):
         # Import all required stuff.
         from openslides.core.signals import permission_change
         from openslides.utils.rest_api import router
-        from .projector import register_projector_elements
+        from .projector import register_projector_slides
         from .signals import get_permission_change_data
         from .views import MediafileViewSet
         from . import serializers  # noqa
         from ..utils.access_permissions import required_user
 
         # Define projector elements.
-        register_projector_elements()
+        register_projector_slides()
 
         # Connect signals.
         permission_change.connect(

--- a/openslides/mediafiles/projector.py
+++ b/openslides/mediafiles/projector.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict
 
-from ..utils.projector import register_projector_element
+from ..utils.projector import AllData, register_projector_slide
 
 
 # Important: All functions have to be prune. This means, that thay can only
@@ -9,14 +9,12 @@ from ..utils.projector import register_projector_element
 #            to be fast!
 
 
-def mediafile(
-    element: Dict[str, Any], all_data: Dict[str, Dict[int, Dict[str, Any]]]
-) -> Dict[str, Any]:
+def mediafile_slide(all_data: AllData, element: Dict[str, Any]) -> Dict[str, Any]:
     """
     Slide for Mediafile.
     """
     return {"error": "TODO"}
 
 
-def register_projector_elements() -> None:
-    register_projector_element("mediafiles/mediafile", mediafile)
+def register_projector_slides() -> None:
+    register_projector_slide("mediafiles/mediafile", mediafile_slide)

--- a/openslides/motions/apps.py
+++ b/openslides/motions/apps.py
@@ -13,7 +13,7 @@ class MotionsAppConfig(AppConfig):
         # Import all required stuff.
         from openslides.core.signals import permission_change
         from openslides.utils.rest_api import router
-        from .projector import register_projector_elements
+        from .projector import register_projector_slides
         from .signals import create_builtin_workflows, get_permission_change_data
         from . import serializers  # noqa
         from .views import (
@@ -30,7 +30,7 @@ class MotionsAppConfig(AppConfig):
         from ..utils.access_permissions import required_user
 
         # Define projector elements.
-        register_projector_elements()
+        register_projector_slides()
 
         # Connect signals.
         post_migrate.connect(

--- a/openslides/motions/models.py
+++ b/openslides/motions/models.py
@@ -87,6 +87,7 @@ class MotionManager(models.Manager):
                 "tags",
                 "submitters",
                 "supporters",
+                "change_recommendations",
             )
         )
 

--- a/openslides/motions/serializers.py
+++ b/openslides/motions/serializers.py
@@ -400,6 +400,9 @@ class MotionSerializer(ModelSerializer):
     )
     agenda_parent_id = IntegerField(write_only=True, required=False, min_value=1)
     submitters = SubmitterSerializer(many=True, read_only=True)
+    change_recommendations = MotionChangeRecommendationSerializer(
+        many=True, read_only=True
+    )
 
     class Meta:
         model = Motion
@@ -436,6 +439,7 @@ class MotionSerializer(ModelSerializer):
             "weight",
             "created",
             "last_modified",
+            "change_recommendations",
         )
         read_only_fields = (
             "state",

--- a/openslides/topics/apps.py
+++ b/openslides/topics/apps.py
@@ -10,13 +10,13 @@ class TopicsAppConfig(AppConfig):
         # Import all required stuff.
         from openslides.core.signals import permission_change
         from ..utils.rest_api import router
-        from .projector import register_projector_elements
+        from .projector import register_projector_slides
         from .signals import get_permission_change_data
         from .views import TopicViewSet
         from . import serializers  # noqa
 
         # Define projector elements.
-        register_projector_elements()
+        register_projector_slides()
 
         # Connect signals.
         permission_change.connect(

--- a/openslides/topics/projector.py
+++ b/openslides/topics/projector.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict
 
-from ..utils.projector import register_projector_element
+from ..utils.projector import AllData, register_projector_slide
 
 
 # Important: All functions have to be prune. This means, that thay can only
@@ -9,14 +9,12 @@ from ..utils.projector import register_projector_element
 #            to be fast!
 
 
-def topic(
-    element: Dict[str, Any], all_data: Dict[str, Dict[int, Dict[str, Any]]]
-) -> Dict[str, Any]:
+def topic_slide(all_data: AllData, element: Dict[str, Any]) -> Dict[str, Any]:
     """
     Topic slide.
     """
     return {"error": "TODO"}
 
 
-def register_projector_elements() -> None:
-    register_projector_element("topics/topic", topic)
+def register_projector_slides() -> None:
+    register_projector_slide("topics/topic", topic_slide)

--- a/openslides/users/apps.py
+++ b/openslides/users/apps.py
@@ -13,12 +13,12 @@ class UsersAppConfig(AppConfig):
         from . import serializers  # noqa
         from ..core.signals import post_permission_creation, permission_change
         from ..utils.rest_api import router
-        from .projector import register_projector_elements
+        from .projector import register_projector_slides
         from .signals import create_builtin_groups_and_admin, get_permission_change_data
         from .views import GroupViewSet, PersonalNoteViewSet, UserViewSet
 
         # Define projector elements.
-        register_projector_elements()
+        register_projector_slides()
 
         # Connect signals.
         post_permission_creation.connect(

--- a/openslides/users/projector.py
+++ b/openslides/users/projector.py
@@ -1,6 +1,6 @@
-from typing import Any, Dict
+from typing import Any, Dict, List
 
-from ..utils.projector import register_projector_element
+from ..utils.projector import AllData, register_projector_slide
 
 
 # Important: All functions have to be prune. This means, that thay can only
@@ -9,14 +9,28 @@ from ..utils.projector import register_projector_element
 #            to be fast!
 
 
-def user(
-    element: Dict[str, Any], all_data: Dict[str, Dict[int, Dict[str, Any]]]
-) -> Dict[str, Any]:
+def user_slide(all_data: AllData, element: Dict[str, Any]) -> Dict[str, Any]:
     """
     User slide.
     """
     return {"error": "TODO"}
 
 
-def register_projector_elements() -> None:
-    register_projector_element("users/user", user)
+def get_user_name(all_data: AllData, user_id: int) -> str:
+    """
+    Returns the short name for an user_id.
+    """
+    user = all_data["users/user"][user_id]
+    name_parts: List[str] = []
+    for name_part in ("title", "first_name", "last_name"):
+        if user[name_part]:
+            name_parts.append(user[name_part])
+    if not name_part:
+        name_parts.append(user["username"])
+    if user["structure_level"]:
+        name_parts.append(f"({user['structure_level']})")
+    return " ".join(name_parts)
+
+
+def register_projector_slides() -> None:
+    register_projector_slide("users/user", user_slide)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -6,7 +6,7 @@ from django.test.utils import CaptureQueriesContext
 from openslides.core.config import config
 from openslides.core.models import Projector
 from openslides.users.models import User
-from openslides.utils.projector import AllData, get_config, register_projector_element
+from openslides.utils.projector import AllData, get_config, register_projector_slide
 
 
 class TConfig:
@@ -90,19 +90,19 @@ class TProjector:
         return elements
 
 
-def slide1(element: Dict[str, Any], all_data: AllData) -> Dict[str, Any]:
+def slide1(all_data: AllData, element: Dict[str, Any]) -> Dict[str, Any]:
     """
     Slide that shows the general_event_name.
     """
     return {"name": "slide1", "event_name": get_config(all_data, "general_event_name")}
 
 
-def slide2(element: Dict[str, Any], all_data: AllData) -> Dict[str, Any]:
+def slide2(all_data: AllData, element: Dict[str, Any]) -> Dict[str, Any]:
     return {"name": "slide2"}
 
 
-register_projector_element("test/slide1", slide1)
-register_projector_element("test/slide2", slide2)
+register_projector_slide("test/slide1", slide1)
+register_projector_slide("test/slide2", slide2)
 
 
 def count_queries(func, *args, **kwargs) -> int:

--- a/tests/integration/motions/test_viewset.py
+++ b/tests/integration/motions/test_viewset.py
@@ -48,7 +48,8 @@ def test_motion_db_queries():
     * 1 request to get the polls,
     * 1 request to get the attachments,
     * 1 request to get the tags,
-    * 2 requests to get the submitters and supporters.
+    * 2 requests to get the submitters and supporters,
+    * 1 request for change_recommendations.
 
     Two comment sections are created and for each motions two comments.
     """
@@ -70,7 +71,7 @@ def test_motion_db_queries():
         )
     # TODO: Create some polls etc.
 
-    assert count_queries(Motion.get_elements) == 12
+    assert count_queries(Motion.get_elements) == 13
 
 
 @pytest.mark.django_db(transaction=False)

--- a/tests/unit/agenda/test_projector.py
+++ b/tests/unit/agenda/test_projector.py
@@ -86,32 +86,32 @@ def all_data():
 
 
 def test_items(all_data):
-    config: Dict[str, Any] = {}
+    element: Dict[str, Any] = {}
 
-    data = projector.items(config, all_data)
+    data = projector.items_slide(all_data, element)
 
     assert data == {"items": ["Item1", "item2"]}
 
 
 def test_items_parent(all_data):
-    config: Dict[str, Any] = {"id": 1}
+    element: Dict[str, Any] = {"id": 1}
 
-    data = projector.items(config, all_data)
+    data = projector.items_slide(all_data, element)
 
     assert data == {"items": ["item4"]}
 
 
 def test_items_tree(all_data):
-    config: Dict[str, Any] = {"tree": True}
+    element: Dict[str, Any] = {"tree": True}
 
-    data = projector.items(config, all_data)
+    data = projector.items_slide(all_data, element)
 
     assert data == {"items": [("Item1", [("item4", [])]), ("item2", [])]}
 
 
 def test_items_tree_parent(all_data):
-    config: Dict[str, Any] = {"tree": True, "id": 1}
+    element: Dict[str, Any] = {"tree": True, "id": 1}
 
-    data = projector.items(config, all_data)
+    data = projector.items_slide(all_data, element)
 
     assert data == {"items": [("item4", [])]}

--- a/tests/unit/motions/test_projector.py
+++ b/tests/unit/motions/test_projector.py
@@ -156,7 +156,7 @@ def all_data():
 def test_motion_slide(all_data):
     element: Dict[str, Any] = {"id": 1}
 
-    data = projector.motion_slide(element, all_data)
+    data = projector.motion_slide(all_data, element)
 
     assert data == {
         "identifier": "4",
@@ -167,7 +167,6 @@ def test_motion_slide(all_data):
         "show_meta_box": True,
         "reason": "",
         "state": "submitted",
-        "state_extension": None,
-        "submitter": [{"first_name": "", "last_name": "Administrator", "title": ""}],
+        "submitter": ["Administrator"],
         "poll": {"yes": "10.000000", "no": "-1.000000", "abstain": "20.000000"},
     }


### PR DESCRIPTION
Changes to the motion slide and other parts of the prjector system.

I changed the wording of "slide" and "element", changed the order of argument of slide functions and added an projector exception.

This PR has one big change. It adds the change_recommendation into the full_data of each motion. It does not remove the change_recommendation as own root_rest_model, so this change should not be a problem. An alternative would be to add only the ids of the change_recommendations to the motion-full-data. See also #4193
