### PR TITLE
wrong translation string

### DIFF
--- a/client/src/app/site/mediafiles/services/mediafile-filter.service.ts
+++ b/client/src/app/site/mediafiles/services/mediafile-filter.service.ts
@@ -27,7 +27,7 @@ export class MediafileFilterListService extends FilterListService<Mediafile, Vie
             options: [
                 {
                     condition: 'application/pdf',
-                    label: 'is PDF file'
+                    label: 'Is PDF file'
                 },
                 {
                     condition: null,

--- a/client/src/app/site/motions/services/motion-sort-list.service.ts
+++ b/client/src/app/site/motions/services/motion-sort-list.service.ts
@@ -10,7 +10,7 @@ export class MotionSortListService extends SortListService<ViewMotion> {
         sortProperty: 'callListWeight',
         sortAscending: true,
         options: [
-            { property: 'callListWeight', label: 'Call List' },
+            { property: 'callListWeight', label: 'Call list' },
             { property: 'supporters' },
             { property: 'identifier' },
             { property: 'title' },


### PR DESCRIPTION
@emanuelschuetze 

generally, some `*-filter.service.ts` may have labels that will be translated later (else, the sorting property will be used as name and translated)