### PR TITLE
pinning typescript to <3.3 - fixes #4249

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -82,7 +82,7 @@
         "ts-node": "~8.0.2",
         "tslint": "~5.12.1",
         "tsutils": "^3.7.0",
-        "typescript": "^3.2",
+        "typescript": "~3.2.0",
         "webpack-bundle-analyzer": "^3.0.3",
         "terser": "3.14.1"
     }


### PR DESCRIPTION
According to the [`pacakge.json`-documentatation](https://docs.npmjs.com/files/package.json)

The caret "`^`" matches only to "compatible" versions. Which [means](https://stackoverflow.com/a/22345808), that if you define `^3.2` as version, that it will match on all versions `3.x.x`. The tilde "`~`" only matches to minor versions, so if you define `~3.2` as version, it will match only to version `3.2.x`.

It seems that typescript sees itself as compatible, but in reality, isn't. Therefore it will be pinned to minor versions in 3.2.

The definition of "Compatible to version" (caret) and "Approximately that version" (tilde) is done via `semver`. There seems to be a subtle difference across machines and used and via dependencies installed `semver`-versions, that causes some machines to resolve the `^3.2` correctly to not install typescript `3.3.0` and others to think, that `3.3.0` is compatible to `3.2`.