### PR TITLE
bulk move motions in call list

### DIFF
--- a/client/src/app/core/repositories/motions/motion-repository.service.ts
+++ b/client/src/app/core/repositories/motions/motion-repository.service.ts
@@ -320,6 +320,19 @@ export class MotionRepositoryService extends BaseRepository<ViewMotion, Motion> 
     }
 
     /**
+     * Sends the changed nodes to the server, with only the top nodes being submitted.
+     *
+     * @param data The reordered data from the sorting, as list of ViewMotions
+     * @param parent a parent id
+     */
+    public async sortMotionBranches(data: ViewMotion[], parent?: number): Promise<void> {
+        const url = '/rest/motions/motion/sort/';
+        const nodes = data.map(motion => ({ id: motion.id }));
+        const params = parent ? { nodes: nodes, parent_id: parent } : { nodes: nodes };
+        await this.httpService.post(url, params);
+    }
+
+    /**
      * Supports the motion
      *
      * @param viewMotion target motion

--- a/client/src/app/site/motions/components/motion-list/motion-list.component.html
+++ b/client/src/app/site/motions/components/motion-list/motion-list.component.html
@@ -248,10 +248,13 @@
                 <span translate>Add/remove tags</span>
             </button>
             <button mat-menu-item (click)="multiselectWrapper(multiselectService.moveToItem(selectedRows))">
-                <!-- TODO: Not implemented yet -->
                 <mat-icon>sort</mat-icon>
                 <span translate>Move to agenda item</span>
             </button>
+            <button mat-menu-item (click)="multiselectWrapper(multiselectService.bulkMoveItems(selectedRows))">
+                    <mat-icon>format_indent_increase</mat-icon>
+                    <span translate>Move in call list</span>
+                </button>
         </div>
         <div *ngIf="perms.isAllowed('manage')">
             <mat-divider></mat-divider>


### PR DESCRIPTION
An attempt for moving around many call list items at once.

This treats the selected items as a tree; keeping the internal hierarchy of the selected items, and inserts them either as sort_parent child of another item, or rearranges the weight(s).
