### PR TITLE
Fixes the initial loading of motions and their states

### DIFF
--- a/client/src/app/site/motions/models/view-motion.ts
+++ b/client/src/app/site/motions/models/view-motion.ts
@@ -405,6 +405,7 @@ export class ViewMotion extends BaseProjectableModel {
     public updateWorkflow(workflow: Workflow): void {
         if (this.motion && workflow.id === this.motion.workflow_id) {
             this._workflow = workflow;
+            this._state = workflow.getStateById(this.state_id);
         }
     }
 


### PR DESCRIPTION
Fixes #4262
- If the workflow is changed, then the state of the motion will be updated, too