### PR TITLE
Prevent dialogs to close easily

### DIFF
--- a/client/src/app/core/ui-services/choice.service.ts
+++ b/client/src/app/core/ui-services/choice.service.ts
@@ -46,6 +46,7 @@ export class ChoiceService extends OpenSlidesComponent {
         const dialogRef = this.dialog.open(ChoiceDialogComponent, {
             minWidth: '250px',
             maxHeight: '90vh',
+            disableClose: true,
             data: {
                 title: title,
                 choices: choices,

--- a/client/src/app/shared/components/copyright-sign/copyright-sign.component.ts
+++ b/client/src/app/shared/components/copyright-sign/copyright-sign.component.ts
@@ -600,7 +600,10 @@ export class CopyrightSignComponent {
 
         if (this.clickCounter === 5) {
             this.clickCounter = 0;
-            this.dialog.open(C4DialogComponent, { width: '550px' });
+            this.dialog.open(C4DialogComponent, {
+                width: '550px',
+                disableClose: true
+            });
         } else {
             this.clickTimeout = <any>setTimeout(() => {
                 this.clickCounter = 0;

--- a/client/src/app/site/agenda/components/agenda-list/agenda-list.component.ts
+++ b/client/src/app/site/agenda/components/agenda-list/agenda-list.component.ts
@@ -118,7 +118,8 @@ export class AgendaListComponent extends ListViewBaseComponent<ViewItem> impleme
     public openEditInfo(item: ViewItem): void {
         const dialogRef = this.dialog.open(ItemInfoDialogComponent, {
             width: '400px',
-            data: item
+            data: item,
+            disableClose: true
         });
 
         dialogRef.afterClosed().subscribe(result => {

--- a/client/src/app/site/motions/components/motion-detail-diff/motion-detail-diff.component.ts
+++ b/client/src/app/site/motions/components/motion-detail-diff/motion-detail-diff.component.ts
@@ -319,7 +319,8 @@ export class MotionDetailDiffComponent extends BaseViewComponent implements Afte
         this.dialogService.open(MotionChangeRecommendationComponent, {
             height: '400px',
             width: '600px',
-            data: data
+            data: data,
+            disableClose: true
         });
     }
 

--- a/client/src/app/site/motions/components/motion-poll/motion-poll.component.ts
+++ b/client/src/app/site/motions/components/motion-poll/motion-poll.component.ts
@@ -203,7 +203,8 @@ export class MotionPollComponent implements OnInit {
         const dialogRef = this.dialog.open(MotionPollDialogComponent, {
             data: { ...this.poll },
             maxHeight: '90vh',
-            minWidth: '250px'
+            minWidth: '250px',
+            disableClose: true
         });
         dialogRef.afterClosed().subscribe(result => {
             if (result) {


### PR DESCRIPTION
Fixes #4116
- Every dialog (created by MatDialog) should only close if the user explicit clicks 'x' or 'cancel' now.