### PR TITLE
fix #4065

### DIFF
--- a/openslides/topics/serializers.py
+++ b/openslides/topics/serializers.py
@@ -1,3 +1,4 @@
+from openslides.utils.autoupdate import inform_changed_data
 from openslides.utils.rest_api import CharField, IntegerField, ModelSerializer
 from openslides.utils.validate import validate_html
 
@@ -54,6 +55,7 @@ class TopicSerializer(ModelSerializer):
         topic.agenda_item_update_information["comment"] = agenda_comment
         topic.agenda_item_update_information["duration"] = agenda_duration
         topic.agenda_item_update_information["weight"] = agenda_weight
-        topic.save()
+        topic.save(skip_autoupdate=True)
         topic.attachments.add(*attachments)
+        inform_changed_data(topic)
         return topic


### PR DESCRIPTION
Topic must exist before adding attachment (first `topic.save()`), but also must be saved again after adding attachments, too, else the attachment info will disappear into the void. Only topic creation was affected by this.

maybe there's a more elegant way, but I'm sure the referenced bug is here