### PR TITLE
offer alternative sortings of list of speakers

### DIFF
--- a/client/src/app/site/agenda/components/speaker-list/speaker-list.component.html
+++ b/client/src/app/site/agenda/components/speaker-list/speaker-list.component.html
@@ -40,8 +40,8 @@
                     <span>{{ number + 1 }}. {{ speaker }}</span>
                 </div>
                 <div class="finished-suffix">
-                    &nbsp;&nbsp; {{ durationString(speaker) }}
-                    ({{ 'Start time' | translate }}: {{ startTimeToString(speaker) }})
+                    &nbsp;&nbsp; {{ durationString(speaker) }} ({{ 'Start time' | translate }}:
+                    {{ startTimeToString(speaker) }})
                 </div>
                 <button
                     mat-stroked-button
@@ -141,10 +141,15 @@
         <span translate>Close list of speakers</span>
     </button>
 
+    <button mat-menu-item *ngIf="!closedList && !emptyList" (click)="sortSpeakersBy()">
+        <mat-icon>sort</mat-icon>
+        <span translate>Sort speakers by...</span>
+    </button>
+
     <mat-divider *ngIf="!emptyList"></mat-divider>
 
     <button mat-menu-item (click)="clearSpeakerList()" *ngIf="!emptyList" class="red-warning-text">
         <mat-icon>delete</mat-icon>
-        <span trabslate>Remove all speakers</span>
+        <span translate>Remove all speakers</span>
     </button>
 </mat-menu>


### PR DESCRIPTION
Some assemblies require their speakers to keep  a certain order. This offer an sorting option for a list of speakers, which sorts the users either by participant number, given name or last name. 

More advanced sorting, such as alternating between two or more categories of users, is not supported by this.