### PR TITLE
full text search for media file, some permission checks

### DIFF
--- a/client/src/app/site/mediafiles/components/mediafile-list/mediafile-list.component.html
+++ b/client/src/app/site/mediafiles/components/mediafile-list/mediafile-list.component.html
@@ -1,5 +1,5 @@
 <os-head-bar
-    [mainButton]="true"
+    [mainButton]="canEdit"
     [editMode]="editFile"
     [multiSelectMode]="isMultiSelect"
     (mainEvent)="onMainEvent()"
@@ -35,7 +35,7 @@
     </div>
 
     <!-- Menu -->
-    <div class="menu-slot">
+    <div class="menu-slot" *ngIf="canEdit">
         <button type="button" mat-icon-button [matMenuTriggerFor]="mediafilesMenu">
             <mat-icon>more_vert</mat-icon>
         </button>
@@ -170,7 +170,7 @@
             <span translate>Deselect all</span>
         </button>
         <mat-divider></mat-divider>
-        <button mat-menu-item *osPerms="'mediafiles.can_manage'" (click)="deleteSelected()">
+        <button mat-menu-item *ngIf="canEdit" (click)="deleteSelected()">
             <mat-icon>delete</mat-icon>
             <span translate>Delete</span>
         </button>

--- a/client/src/app/site/mediafiles/services/mediafile-filter.service.ts
+++ b/client/src/app/site/mediafiles/services/mediafile-filter.service.ts
@@ -5,6 +5,7 @@ import { Mediafile } from 'app/shared/models/mediafiles/mediafile';
 import { ViewMediafile } from '../models/view-mediafile';
 import { StorageService } from 'app/core/core-services/storage.service';
 import { MediafileRepositoryService } from 'app/core/repositories/mediafiles/mediafile-repository.service';
+import { OperatorService } from 'app/core/core-services/operator.service';
 
 @Injectable({
     providedIn: 'root'
@@ -12,33 +13,44 @@ import { MediafileRepositoryService } from 'app/core/repositories/mediafiles/med
 export class MediafileFilterListService extends BaseFilterListService<Mediafile, ViewMediafile> {
     protected name = 'Mediafile';
 
-    public filterOptions: OsFilter[] = [
-        {
-            property: 'is_hidden',
-            label: 'Hidden',
-            options: [
-                { condition: true, label: 'is hidden' },
-                { condition: false, label: 'is not hidden', isActive: true }
-            ]
-        },
-        {
-            property: 'type',
-            label: 'Is PDF',
-            options: [
-                {
-                    condition: 'application/pdf',
-                    label: 'Is PDF file'
-                },
-                {
-                    condition: null,
-                    label: 'Is no PDF file'
-                }
-            ]
-        }
-    ];
+    /**
+     * A filter checking if a file is a pdf or not
+     */
+    public pdfOption: OsFilter = {
+        property: 'type',
+        label: 'Is PDF',
+        options: [
+            {
+                condition: 'application/pdf',
+                label: 'Is PDF file'
+            },
+            {
+                condition: null,
+                label: 'Is no PDF file'
+            }
+        ]
+    };
 
-    public constructor(store: StorageService, repo: MediafileRepositoryService) {
+    /**
+     * A filter checking if a file is hidden. Only included if the operator has permission to see hidden files
+     */
+    public hiddenOptions: OsFilter = {
+        property: 'is_hidden',
+        label: 'Hidden',
+        options: [{ condition: true, label: 'is hidden' }, { condition: false, label: 'is not hidden', isActive: true }]
+    };
+
+    /**
+     * Constructor. Sets the filter options according to permissions
+     * @param store
+     * @param repo
+     * @param operator
+     */
+    public constructor(store: StorageService, repo: MediafileRepositoryService, operator: OperatorService) {
         super(store, repo);
-        this.updateFilterDefinitions(this.filterOptions);
+        const filterOptions = operator.hasPerms('mediafiles.can_see_hidden')
+            ? [this.hiddenOptions, this.pdfOption]
+            : [this.pdfOption];
+        this.updateFilterDefinitions(filterOptions);
     }
 }


### PR DESCRIPTION
- hide filter 'hidden' for delegates
 - don't show empty menu for delegates
- fix full text filter for mediafiles (filter by file title (name given during import)
