### PR TITLE
Diff-Bugfix: Newlines and split paragraphs

### DIFF
--- a/client/src/app/core/ui-services/diff.service.spec.ts
+++ b/client/src/app/core/ui-services/diff.service.spec.ts
@@ -809,6 +809,24 @@ describe('DiffService', () => {
             );
         }));
 
+        it('does not like splitting paragraphs too much, but respects line breaks between paragraphs', inject(
+            [DiffService],
+            (service: DiffService) => {
+                const before =
+                        '<P>Bavaria ipsum dolor sit amet o’ha wea nia ausgähd, kummt nia hoam i hob di narrisch gean helfgod ebba ded baddscher. Des so so, nia Biawambn back mas? Kaiwe Hetschapfah Trachtnhuat, a bravs.</P>',
+                    after =
+                        '<p>Bavaria ipsum dolor sit amet o’ha wea nia ausgähd, kummt nia hoam i hob di narrisch gean helfgod ebba ded baddscher.</p>\n<p>Des so so, nia Biawambn back mas? Kaiwe Hetschapfah Trachtnhuat, a bravs.';
+                const diff = service.diff(before, after);
+
+                expect(diff).toBe(
+                    '<P class="delete">Bavaria ipsum dolor sit amet o’ha wea nia ausgähd, kummt nia hoam i hob di narrisch gean helfgod ebba ded baddscher. Des so so, nia Biawambn back mas? Kaiwe Hetschapfah Trachtnhuat, a bravs.</P>' +
+                        '<P class="insert">Bavaria ipsum dolor sit amet o’ha wea nia ausgähd, kummt nia hoam i hob di narrisch gean helfgod ebba ded baddscher.</P>' +
+                        '<INS>\n</INS>' +
+                        '<P class="insert">Des so so, nia Biawambn back mas? Kaiwe Hetschapfah Trachtnhuat, a bravs.</P>'
+                );
+            }
+        ));
+
         it('does not repeat the last word (1)', inject([DiffService], (service: DiffService) => {
             const before = '<P>sem. Nulla consequat massa quis enim. </P>',
                 after = '<p>sem. Nulla consequat massa quis enim. TEST<br>\nTEST</p>';

--- a/client/src/app/core/ui-services/diff.service.ts
+++ b/client/src/app/core/ui-services/diff.service.ts
@@ -940,8 +940,8 @@ export class DiffService {
     private diffDetectBrokenDiffHtml(html: string): boolean {
         // If other HTML tags are contained within INS/DEL (e.g. "<ins>Test</p></ins>"), let's better be cautious
         // The "!!(found=...)"-construction is only used to make jshint happy :)
-        const findDel = /<del>(.*?)<\/del>/gi,
-            findIns = /<ins>(.*?)<\/ins>/gi;
+        const findDel = /<del>([\s\S]*?)<\/del>/gi,
+            findIns = /<ins>([\s\S]*?)<\/ins>/gi;
         let found, inner;
         while (!!(found = findDel.exec(html))) {
             inner = found[1].replace(/<br[^>]*>/gi, '');


### PR DESCRIPTION
@emanuelschuetze This should be a bugfix for the diff-bug you reported, that occurred when splitting a paragraph into two and a newline character sneaked in between the `<\/p>...<\/p>`.
Note that the result is still not very aesthetical, as this case still leads into a situation where the whole old paragraph is deleted and the new ones are inserted.