### PR TITLE
user detail page display permission update

### DIFF
--- a/client/src/app/site/users/components/user-detail/user-detail.component.html
+++ b/client/src/app/site/users/components/user-detail/user-detail.component.html
@@ -2,6 +2,7 @@
     [mainButton]="isAllowed('changePersonal')"
     mainButtonIcon="edit"
     [nav]="false"
+    [goBack]="!isAllowed('seeOtherUsers')"
     [editMode]="editUser"
     (mainEvent)="setEditMode(!editUser)"
     (saveEvent)="saveUser()"
@@ -21,7 +22,7 @@
     </div>
 
     <mat-menu #userExtraMenu="matMenu">
-        <button mat-menu-item *ngIf="isAllowed('changePersonal')" (click)="changePassword()">
+        <button mat-menu-item *ngIf="isAllowed('changePassword')" (click)="changePassword()">
             <mat-icon>security</mat-icon>
             <span translate>Change password</span>
         </button>
@@ -40,7 +41,7 @@
     </mat-menu>
 </os-head-bar>
 
-<mat-card [ngClass]="editUser ? 'os-form-card' : 'os-card'" *osPerms="'users.can_see_name'">
+<mat-card [ngClass]="editUser ? 'os-form-card' : 'os-card'" *ngIf="isAllowed('seeName')">
     <form
         [ngClass]="{ 'mat-form-field-enabled': editUser }"
         [formGroup]="personalInfoForm"
@@ -156,7 +157,7 @@
                     matInput
                     placeholder="{{ 'Initial password' | translate }}"
                     formControlName="default_password"
-                    [value]="user.default_password"
+                    [value]="user.default_password || ''"
                 />
                 <mat-hint align="end">Generate</mat-hint>
                 <button
@@ -200,7 +201,7 @@
                     matInput
                     placeholder="{{ 'Comment' | translate }}"
                     formControlName="comment"
-                    [value]="user.comment"
+                    [value]="user.comment || ''"
                 />
                 <mat-hint translate>Only for internal notes.</mat-hint>
             </mat-form-field>

--- a/client/src/app/site/users/components/user-detail/user-detail.component.ts
+++ b/client/src/app/site/users/components/user-detail/user-detail.component.ts
@@ -168,10 +168,12 @@ export class UserDetailComponent extends BaseViewComponent implements OnInit {
      * actions might be:
      * - delete         (deleting the user) (users.can_manage and not ownPage)
      * - seeName        (title, 1st, last) (user.can_see_name or ownPage)
+     * - seeOtherUsers  (title, 1st, last) (user.can_see_name)
      * - seeExtra       (checkboxes, comment) (user.can_see_extra_data)
      * - seePersonal    (mail, username, about) (user.can_see_extra_data or ownPage)
      * - manage         (everything) (user.can_manage)
      * - changePersonal (mail, username, about) (user.can_manage or ownPage)
+     * - changePassword (user.can_change_password)
      *
      * @param action the action the user tries to perform
      */
@@ -183,12 +185,16 @@ export class UserDetailComponent extends BaseViewComponent implements OnInit {
                 return this.operator.hasPerms('users.can_manage');
             case 'seeName':
                 return this.operator.hasPerms('users.can_see_name', 'users.can_manage') || this.ownPage;
+            case 'seeOtherUsers':
+                return this.operator.hasPerms('users.can_see_name', 'users.can_manage');
             case 'seeExtra':
                 return this.operator.hasPerms('users.can_see_extra_data', 'users.can_manage');
             case 'seePersonal':
                 return this.operator.hasPerms('users.can_see_extra_data', 'users.can_manage') || this.ownPage;
             case 'changePersonal':
                 return this.operator.hasPerms('users.can_manage') || this.ownPage;
+            case 'changePassword':
+                return this.ownPage && this.operator.hasPerms('users.can_change_password');
             default:
                 return false;
         }


### PR DESCRIPTION
- The user detail view should not go back to the user-list if `can_see_users` is not set
- change/resetting passwords should not be offered if user has not can_change_password permissions (or if it's another users page)
- an unset initial password should not show up as 'undefined'
- user should be able to see own information, even if not allowed to see other peoples' information


(Note: General security is ensured server-side, this is just to avoid non-/half functional gui elements)