### PR TITLE
Fixed permission check for hidden and internal items.

### DIFF
--- a/openslides/agenda/access_permissions.py
+++ b/openslides/agenda/access_permissions.py
@@ -71,11 +71,13 @@ class ItemAccessPermissions(BaseAccessPermissions):
 
                 data = []
                 for full in full_data:
-                    if full["is_hidden"] and can_see_hidden:
-                        # Same filtering for internal and hidden items
-                        data.append(
-                            filtered_data(full, blocked_keys_internal_hidden_case)
-                        )
+                    if full["is_hidden"]:
+                        if can_see_hidden:
+                            # Same filtering for internal and hidden items
+                            data.append(
+                                filtered_data(full, blocked_keys_internal_hidden_case)
+                            )
+                        # If can_see_hidden is false, the user (which is a non manager) can not see anything.
                     elif full["is_internal"]:
                         data.append(
                             filtered_data(full, blocked_keys_internal_hidden_case)


### PR DESCRIPTION
@emanuelschuetze Please have a look at the ~~16~~ 12 different cases:

* agenda can see
* agenda can see and can see internal
* agenda can see and can manage
* angedan can see and can see internal and can manage

for different agenda items

* normal
* internal
* hidden
* ~~internal AND hidden~~

In some cases you see all, in other you see everything but comments, in other cases you see only some list of speakers fields, in other cases you see nothing.
