### PR TITLE
Add tags to motion pdf

### DIFF
--- a/client/src/app/site/motions/components/motion-export-dialog/motion-export-dialog.component.html
+++ b/client/src/app/site/motions/components/motion-export-dialog/motion-export-dialog.component.html
@@ -49,6 +49,7 @@
                 <mat-button-toggle value="state"> <span translate>State</span> </mat-button-toggle>
                 <mat-button-toggle value="recommendation"> <span translate>Recommendation</span> </mat-button-toggle>
                 <mat-button-toggle value="category"> <span translate>Category</span> </mat-button-toggle>
+                <mat-button-toggle value="tags"> <span translate>Tags</span> </mat-button-toggle>
                 <mat-button-toggle value="origin"> <span translate>Origin</span> </mat-button-toggle>
                 <mat-button-toggle value="block"> <span translate>Motion block</span> </mat-button-toggle>
                 <mat-button-toggle value="poll" #votingResultButton>
@@ -59,11 +60,7 @@
         </div>
         <div *ngIf="commentsToExport.length && exportForm.get('format').value === 'pdf'">
             <p class="toggle-group-head" translate>Comments</p>
-            <mat-button-toggle-group
-                class="smaller-buttons"
-                multiple
-                formControlName="comments"
-            >
+            <mat-button-toggle-group class="smaller-buttons" multiple formControlName="comments">
                 <mat-button-toggle *ngFor="let comment of commentsToExport" [value]="comment.id">
                     <span>{{ comment.name }}</span>
                 </mat-button-toggle>

--- a/client/src/app/site/motions/components/motion-export-dialog/motion-export-dialog.component.ts
+++ b/client/src/app/site/motions/components/motion-export-dialog/motion-export-dialog.component.ts
@@ -51,6 +51,7 @@ export class MotionExportDialogComponent implements OnInit {
         'recommendation',
         'category',
         'origin',
+        'tags',
         'block',
         'polls',
         'id'

--- a/client/src/app/site/motions/components/motion-list/motion-list.component.ts
+++ b/client/src/app/site/motions/components/motion-list/motion-list.component.ts
@@ -198,7 +198,7 @@ export class MotionListComponent extends ListViewBaseComponent<ViewMotion, Motio
      */
     public openExportDialog(): void {
         const exportDialogRef = this.dialog.open(MotionExportDialogComponent, {
-            width: '950px',
+            width: '1100px',
             maxWidth: '90vw',
             maxHeight: '90vh',
             data: this.dataSource

--- a/client/src/app/site/motions/services/motion-pdf.service.ts
+++ b/client/src/app/site/motions/services/motion-pdf.service.ts
@@ -23,6 +23,7 @@ export type InfoToExport =
     | 'category'
     | 'block'
     | 'origin'
+    | 'tags'
     | 'polls'
     | 'id'
     | 'allcomments';
@@ -248,6 +249,25 @@ export class MotionPdfService {
                     text: motion.category.prefix
                         ? `${motion.category.prefix} - ${motion.category.name}`
                         : `${motion.category.name}`
+                }
+            ]);
+        }
+
+        // tags
+        if (motion.tags.length && (!infoToExport || infoToExport.includes('tags'))) {
+            const tags = motion.tags
+                .map(tag => {
+                    return tag;
+                })
+                .join(', ');
+
+            metaTableBody.push([
+                {
+                    text: `${this.translate.instant('Tags')}:`,
+                    style: 'boldText'
+                },
+                {
+                    text: tags
                 }
             ]);
         }


### PR DESCRIPTION
Adds tags to motion pdf. Adjusts the export dialog to also support selecting and deselecting
tags. Increases the target with of the export dialog to 1100px so the tags also fit there.
Not too pretty, yet effective