### PR TITLE
Disable various expensive sorting functions

### DIFF
--- a/client/src/app/core/repositories/motions/category-repository.service.ts
+++ b/client/src/app/core/repositories/motions/category-repository.service.ts
@@ -115,6 +115,8 @@ export class CategoryRepositoryService extends BaseRepository<ViewCategory, Cate
      *
      * @param categories
      * @returns the categories sorted by prefix or name, according to the config setting
+     *
+     * TODO: That operation is HEAVY
      */
     public sortViewCategoriesByConfig(categories: ViewCategory[]): ViewCategory[] {
         const sort = this.configService.instant<'prefix' | 'name'>('motions_category_sorting') || 'prefix';

--- a/client/src/app/core/repositories/users/user-repository.service.ts
+++ b/client/src/app/core/repositories/users/user-repository.service.ts
@@ -305,6 +305,7 @@ export class UserRepositoryService extends BaseRepository<ViewUser, User> {
 
     /**
      * Returns all duplicates of an user (currently: full name matches)
+     *
      * @param user
      */
     public getUserDuplicates(user: ViewUser): ViewUser[] {
@@ -313,6 +314,8 @@ export class UserRepositoryService extends BaseRepository<ViewUser, User> {
 
     /**
      * @returns the observable for users sorted according to configuration
+     *
+     * TODO: This is leading to heavy operations
      */
     public getSortedViewModelListObservable(): Observable<ViewUser[]> {
         const subject = new BehaviorSubject<ViewUser[]>([]);
@@ -329,6 +332,8 @@ export class UserRepositoryService extends BaseRepository<ViewUser, User> {
      * @returns the users sorted by first name, last name or number, according
      * to the config setting. Fallthrough and identical cases will be sorted by
      * 'short_name'
+     *
+     * TODO: That operation is HEAVY
      */
     public sortViewUsersByConfig(users: ViewUser[]): ViewUser[] {
         const sort = this.configService.instant<'first_name' | 'last_name' | 'number'>('users_sort_by') || 'last_name';

--- a/client/src/app/site/agenda/components/agenda-list/agenda-list.component.html
+++ b/client/src/app/site/agenda/components/agenda-list/agenda-list.component.html
@@ -90,9 +90,12 @@
         <ng-container matColumnDef="menu">
             <mat-header-cell *matHeaderCellDef mat-sort-header>Menu</mat-header-cell>
             <mat-cell *matCellDef="let item">
-                <button mat-icon-button
-                *osPerms="'agenda.can_manage'"
-                [matMenuTriggerFor]="singleItemMenu" [matMenuTriggerData]="{ item: item }">
+                <button
+                    mat-icon-button
+                    *osPerms="'agenda.can_manage'"
+                    [matMenuTriggerFor]="singleItemMenu"
+                    [matMenuTriggerData]="{ item: item }"
+                >
                     <mat-icon>more_vert</mat-icon>
                 </button>
             </mat-cell>

--- a/client/src/app/site/assignments/models/view-assignment.ts
+++ b/client/src/app/site/assignments/models/view-assignment.ts
@@ -65,9 +65,7 @@ export class ViewAssignment extends BaseAgendaViewModel {
         this._tags = tags;
     }
 
-    public updateDependencies(update: BaseViewModel): void {
-        console.log('TODO: assignment updateDependencies');
-    }
+    public updateDependencies(update: BaseViewModel): void {}
 
     public getAgendaItem(): ViewItem {
         return this.agendaItem;

--- a/client/src/app/site/base/base-view.ts
+++ b/client/src/app/site/base/base-view.ts
@@ -5,6 +5,7 @@ import { MatSnackBar, MatSnackBarRef, SimpleSnackBar } from '@angular/material';
 import { TranslateService } from '@ngx-translate/core';
 
 import { BaseComponent } from '../../base.component';
+import { Subscription } from 'rxjs';
 
 /**
  * A base class for all views. Implements a generic error handling by raising a snack bar
@@ -18,6 +19,11 @@ export abstract class BaseViewComponent extends BaseComponent implements OnDestr
     private messageSnackBar: MatSnackBarRef<SimpleSnackBar>;
 
     /**
+     * Subscriptions added to this list will be cleared 'on destroy'
+     */
+    protected subscriptions: Subscription[];
+
+    /**
      * Constructor for bas elist views
      * @param titleService the title serivce, passed to the base component
      * @param translate the translate service, passed to the base component
@@ -25,6 +31,7 @@ export abstract class BaseViewComponent extends BaseComponent implements OnDestr
      */
     public constructor(titleService: Title, translate: TranslateService, private matSnackBar: MatSnackBar) {
         super(titleService, translate);
+        this.subscriptions = [];
     }
 
     /**
@@ -58,11 +65,18 @@ export abstract class BaseViewComponent extends BaseComponent implements OnDestr
     }
 
     /**
-     * automatically dismisses the error snack bar, if the component is destroyed.
+     * automatically dismisses the error snack bar and clears subscriptions
+     * if the component is destroyed.
      */
     public ngOnDestroy(): void {
         if (this.messageSnackBar) {
             this.messageSnackBar.dismiss();
+        }
+
+        if (this.subscriptions.length > 0) {
+            for (const sub of this.subscriptions) {
+                sub.unsubscribe();
+            }
         }
     }
 }

--- a/client/src/app/site/base/list-view-base.ts
+++ b/client/src/app/site/base/list-view-base.ts
@@ -96,20 +96,24 @@ export abstract class ListViewBaseComponent<V extends BaseViewModel, M extends B
      * Standard filtering function. Sufficient for most list views but can be overwritten
      */
     protected onFilter(): void {
-        this.filterService.filter().subscribe(filteredData => (this.sortService.data = filteredData));
+        this.subscriptions.push(
+            this.filterService.filter().subscribe(filteredData => (this.sortService.data = filteredData))
+        );
     }
 
     /**
      * Standard sorting function. Siffucient for most list views but can be overwritten
      */
     protected onSort(): void {
-        this.sortService.sort().subscribe(sortedData => {
-            // the dataArray needs to be cleared (since angular 7)
-            // changes are not detected properly anymore
-            this.dataSource.data = [];
-            this.dataSource.data = sortedData;
-            this.checkSelection();
-        });
+        this.subscriptions.push(
+            this.sortService.sort().subscribe(sortedData => {
+                // the dataArray needs to be cleared (since angular 7)
+                // changes are not detected properly anymore
+                this.dataSource.data = [];
+                this.dataSource.data = sortedData;
+                this.checkSelection();
+            })
+        );
     }
 
     public onSortButton(itemProperty: string): void {

--- a/client/src/app/site/motions/components/manage-submitters/manage-submitters.component.ts
+++ b/client/src/app/site/motions/components/manage-submitters/manage-submitters.component.ts
@@ -80,12 +80,6 @@ export class ManageSubmittersComponent extends BaseViewComponent {
         this.addSubmitterForm = new FormGroup({ userId: new FormControl([]) });
         this.editSubmitterObservable = this.editSubmitterSubject.asObservable();
 
-        // get all users for the submitter add form
-        this.users = new BehaviorSubject<ViewUser[]>(
-            this.userRepository.sortViewUsersByConfig(this.userRepository.getViewModelList())
-        );
-        this.userRepository.getSortedViewModelListObservable().subscribe(users => this.users.next(users));
-
         // detect changes in the form
         this.addSubmitterForm.valueChanges.subscribe(formResult => {
             if (formResult && formResult.userId) {
@@ -101,6 +95,10 @@ export class ManageSubmittersComponent extends BaseViewComponent {
         this.isEditMode = true;
         this.editSubmitterSubject.next(this.motion.submitters.map(x => x));
         this.addSubmitterForm.reset();
+
+        // get all users for the submitter add form
+        this.users = new BehaviorSubject<ViewUser[]>(this.userRepository.getViewModelList());
+        this.userRepository.getViewModelListObservable().subscribe(users => this.users.next(users));
     }
 
     /**


### PR DESCRIPTION
Prevents the usage of: "sortViewUsersByConfig" of the user Repository
since it's an incredible heavy operation for ~500 (real) users.

I would advice to sort the data store rather than the lists
in the view to prevent unnecessary sorting overhead