### PR TITLE
increasing default upload size

### DIFF
--- a/openslides/utils/settings.py.tpl
+++ b/openslides/utils/settings.py.tpl
@@ -48,6 +48,9 @@ EMAIL_PORT = 587
 EMAIL_HOST_USER = ''
 EMAIL_HOST_PASSWORD = ''
 
+# Increasing Upload size to 100mb (default is 2.5mb)
+DATA_UPLOAD_MAX_MEMORY_SIZE = 104857600
+
 # Database
 # https://docs.djangoproject.com/en/1.10/ref/settings/#databases
 


### PR DESCRIPTION
The standard upload size is 2.5mb, which results in a 413, even though we normally allow upload sizes of up to 100mb in our standard-setup.

reference: https://docs.djangoproject.com/en/2.1/ref/settings/#data-upload-max-memory-size