### PR TITLE
show save feedback on more config fields

### DIFF
--- a/client/src/app/site/config/components/config-field/config-field.component.html
+++ b/client/src/app/site/config/components/config-field/config-field.component.html
@@ -44,15 +44,30 @@
             <div class="config-form-group" *ngIf="isExcludedType(configItem.inputType)">
                 <div *ngIf="configItem.inputType === 'boolean'">
                     <mat-checkbox formControlName="value">{{ configItem.label | translate }}</mat-checkbox>
-                    <mat-hint class="hint" *ngIf="configItem.helpText && !error">{{ configItem.helpText | translate }}</mat-hint>
+                    <mat-hint class="hint" *ngIf="configItem.helpText && !error">
+                        {{ configItem.helpText | translate }}
+                    </mat-hint>
                     <div class="error" *ngIf="error">{{ error }}</div>
                 </div>
 
                 <!-- textarea -->
                 <div *ngIf="configItem.inputType === 'text'">
                     <mat-form-field>
-                        <textarea rows="10" matInput placeholder="{{ configItem.label | translate }}" [value]="translatedValue"></textarea>
-                        <mat-hint class="hint" *ngIf="configItem.helpText && !error">{{ configItem.helpText | translate }}</mat-hint>
+                        <textarea
+                            formControlName="value"
+                            rows="10"
+                            matInput
+                            placeholder="{{ configItem.label | translate }}"
+                            [value]="translatedValue"
+                        ></textarea>
+                        <mat-hint class="hint" *ngIf="configItem.helpText && !error">
+                            {{ configItem.helpText | translate }}
+                        </mat-hint>
+                        <span matSuffix>
+                            <mat-icon pull="right" class="text-success" *ngIf="updateSuccessIcon">
+                                check_circle
+                            </mat-icon>
+                        </span>
                     </mat-form-field>
                 </div>
 
@@ -77,11 +92,17 @@
                 <div *ngIf="configItem.inputType === 'markupText'">
                     <h4>{{ configItem.label | translate }}</h4>
                     <editor formControlName="value" [init]="tinyMceSettings"></editor>
+                    <span matSuffix>
+                        <mat-icon pull="right" class="text-success" *ngIf="updateSuccessIcon">check_circle</mat-icon>
+                    </span>
                 </div>
 
                 <!-- Custom Translations -->
                 <div *ngIf="configItem.inputType === 'translations'">
                     <os-custom-translation formControlName="value"></os-custom-translation>
+                    <span matSuffix>
+                        <mat-icon pull="right" class="text-success" *ngIf="updateSuccessIcon">check_circle</mat-icon>
+                    </span>
                 </div>
             </div>
         </form>


### PR DESCRIPTION
I could not reproduce any 'does not save the config'- just the display of 'successfully saved' was off for some items. @emanuelschuetze 
