### PR TITLE
fix identifier setting on mass setstate

### DIFF
--- a/openslides/motions/views.py
+++ b/openslides/motions/views.py
@@ -666,9 +666,18 @@ class MotionViewSet(ModelViewSet):
                     {"detail": f"You can not set the state to {state_id}."}
                 )
             motion.set_state(state_id)
+            state = State.objects.get(pk=state_id)
 
             # Save motion.
-            motion.save(update_fields=["state", "last_modified"], skip_autoupdate=True)
+            if not state.dont_set_identifier:
+                motion.save(
+                    update_fields=["state", "last_modified", "identifier"],
+                    skip_autoupdate=True,
+                )
+            else:
+                motion.save(
+                    update_fields=["state", "last_modified"], skip_autoupdate=True
+                )
 
             # Write the log message.
             motion.write_log(


### PR DESCRIPTION
Problem: Identifier was not set and updated correctly for each updated motion in complex workflows.

(only line 673 is needed. Others are to reduce overhead, unsure if it really does this)
