### PR TITLE
Revive the global search.

### DIFF
--- a/client/src/app/core/app-config.ts
+++ b/client/src/app/core/app-config.ts
@@ -19,6 +19,7 @@ export interface ModelEntry extends BaseModelEntry {
 export interface SearchableModelEntry extends BaseModelEntry {
     viewModel: ViewModelConstructor<BaseViewModel & Searchable>;
     searchOrder: number;
+    openInNewTab?: boolean;
 }
 
 /**

--- a/client/src/app/core/core-services/app-load.service.ts
+++ b/client/src/app/core/core-services/app-load.service.ts
@@ -79,7 +79,12 @@ export class AppLoadService {
                         repository
                     );
                     if (this.isSearchableModelEntry(entry)) {
-                        this.searchService.registerModel(entry.collectionString, entry.viewModel, entry.searchOrder);
+                        this.searchService.registerModel(
+                            entry.collectionString,
+                            repository,
+                            entry.searchOrder,
+                            entry.openInNewTab
+                        );
                     }
                 });
             }

--- a/client/src/app/core/repositories/agenda/item-repository.service.ts
+++ b/client/src/app/core/repositories/agenda/item-repository.service.ts
@@ -54,6 +54,10 @@ export class ItemRepositoryService extends BaseRepository<ViewItem, Item> {
         super(DS, mapperService, viewModelStoreService, Item);
     }
 
+    public getVerboseName = (plural: boolean = false) => {
+        return this.translate.instant(plural ? 'Items' : 'Item');
+    };
+
     protected setupDependencyObservation(): void {
         this.DS.secondaryModelChangeSubject.subscribe(model => {
             const viewModel = this.viewModelStoreService.get(model.collectionString, model.id);
@@ -75,9 +79,7 @@ export class ItemRepositoryService extends BaseRepository<ViewItem, Item> {
     public createViewModel(item: Item): ViewItem {
         const contentObject = this.getContentObject(item);
         const viewItem = new ViewItem(item, contentObject);
-        viewItem.getVerboseName = (plural: boolean = false) => {
-            return this.translate.instant(plural ? 'Items' : 'Item');
-        };
+        viewItem.getVerboseName = this.getVerboseName;
         viewItem.getTitle = () => {
             if (viewItem.contentObject) {
                 return viewItem.contentObject.getAgendaTitle();

--- a/client/src/app/core/repositories/base-agenda-content-object-repository.ts
+++ b/client/src/app/core/repositories/base-agenda-content-object-repository.ts
@@ -7,12 +7,7 @@ import { BaseRepository } from './base-repository';
 
 export function isBaseAgendaContentObjectRepository(obj: any): obj is BaseAgendaContentObjectRepository<any, any> {
     const repo = obj as BaseAgendaContentObjectRepository<any, any>;
-    return (
-        !!obj &&
-        repo.getVerboseName !== undefined &&
-        repo.getAgendaTitle !== undefined &&
-        repo.getAgendaTitleWithType !== undefined
-    );
+    return !!obj && repo.getAgendaTitle !== undefined && repo.getAgendaTitleWithType !== undefined;
 }
 
 export abstract class BaseAgendaContentObjectRepository<
@@ -21,7 +16,6 @@ export abstract class BaseAgendaContentObjectRepository<
 > extends BaseRepository<V, M> {
     public abstract getAgendaTitle: (model: Partial<M> | Partial<V>) => string;
     public abstract getAgendaTitleWithType: (model: Partial<M> | Partial<V>) => string;
-    public abstract getVerboseName: (plural?: boolean) => string;
 
     /**
      */

--- a/client/src/app/core/repositories/base-repository.ts
+++ b/client/src/app/core/repositories/base-repository.ts
@@ -46,6 +46,8 @@ export abstract class BaseRepository<V extends BaseViewModel, M extends BaseMode
         return this._collectionString;
     }
 
+    public abstract getVerboseName: (plural?: boolean) => string;
+
     /**
      * Construction routine for the base repository
      *

--- a/client/src/app/core/repositories/common/chatmessage-repository.service.ts
+++ b/client/src/app/core/repositories/common/chatmessage-repository.service.ts
@@ -21,11 +21,13 @@ export class ChatMessageRepositoryService extends BaseRepository<ViewChatMessage
         super(DS, mapperService, viewModelStoreService, ChatMessage);
     }
 
+    public getVerboseName = (plural: boolean = false) => {
+        return this.translate.instant(plural ? 'Chatmessages' : 'Chatmessage');
+    };
+
     protected createViewModel(message: ChatMessage): ViewChatMessage {
         const viewChatMessage = new ViewChatMessage(message);
-        viewChatMessage.getVerboseName = (plural: boolean = false) => {
-            return this.translate.instant(plural ? 'Chatmessages' : 'Chatmessage');
-        };
+        viewChatMessage.getVerboseName = this.getVerboseName;
         return viewChatMessage;
     }
 

--- a/client/src/app/core/repositories/config/config-repository.service.ts
+++ b/client/src/app/core/repositories/config/config-repository.service.ts
@@ -112,15 +112,17 @@ export class ConfigRepositoryService extends BaseRepository<ViewConfig, Config> 
         });
     }
 
+    public getVerboseName = (plural: boolean = false) => {
+        return this.translate.instant(plural ? 'Configs' : 'Config');
+    };
+
     /**
      * Creates a new ViewConfig of a given Config object
      * @param config
      */
     public createViewModel(config: Config): ViewConfig {
         const viewConfig = new ViewConfig(config);
-        viewConfig.getVerboseName = (plural: boolean = false) => {
-            return this.translate.instant(plural ? 'Configs' : 'Config');
-        };
+        viewConfig.getVerboseName = this.getVerboseName;
         return viewConfig;
     }
 

--- a/client/src/app/core/repositories/history/history-repository.service.ts
+++ b/client/src/app/core/repositories/history/history-repository.service.ts
@@ -41,6 +41,10 @@ export class HistoryRepositoryService extends BaseRepository<ViewHistory, Histor
         super(DS, mapperService, viewModelStoreService, History, [User]);
     }
 
+    public getVerboseName = (plural: boolean = false) => {
+        return this.translate.instant(plural ? 'Histories' : 'History');
+    };
+
     /**
      * Creates a new ViewHistory objects out of a historyObject
      *
@@ -50,9 +54,7 @@ export class HistoryRepositoryService extends BaseRepository<ViewHistory, Histor
     public createViewModel(history: History): ViewHistory {
         const user = this.viewModelStoreService.get(ViewUser, history.user_id);
         const viewHistory = new ViewHistory(history, user);
-        viewHistory.getVerboseName = (plural: boolean = false) => {
-            return this.translate.instant(plural ? 'Histories' : 'History'); // Whats about the plural case??
-        };
+        viewHistory.getVerboseName = this.getVerboseName;
         return viewHistory;
     }
 

--- a/client/src/app/core/repositories/mediafiles/mediafile-repository.service.ts
+++ b/client/src/app/core/repositories/mediafiles/mediafile-repository.service.ts
@@ -39,6 +39,10 @@ export class MediafileRepositoryService extends BaseRepository<ViewMediafile, Me
         super(DS, mapperService, viewModelStoreService, Mediafile, [User]);
     }
 
+    public getVerboseName = (plural: boolean = false) => {
+        return this.translate.instant(plural ? 'Files' : 'File');
+    };
+
     /**
      * Creates mediafile ViewModels out of given mediafile objects
      *
@@ -48,9 +52,7 @@ export class MediafileRepositoryService extends BaseRepository<ViewMediafile, Me
     public createViewModel(file: Mediafile): ViewMediafile {
         const uploader = this.viewModelStoreService.get(ViewUser, file.uploader_id);
         const viewMediafile = new ViewMediafile(file, uploader);
-        viewMediafile.getVerboseName = (plural: boolean = false) => {
-            return this.translate.instant(plural ? 'Files' : 'File');
-        };
+        viewMediafile.getVerboseName = this.getVerboseName;
         return viewMediafile;
     }
 

--- a/client/src/app/core/repositories/motions/category-repository.service.ts
+++ b/client/src/app/core/repositories/motions/category-repository.service.ts
@@ -52,11 +52,13 @@ export class CategoryRepositoryService extends BaseRepository<ViewCategory, Cate
         super(DS, mapperService, viewModelStoreService, Category);
     }
 
+    public getVerboseName = (plural: boolean = false) => {
+        return this.translate.instant(plural ? 'Categories' : 'Category');
+    };
+
     protected createViewModel(category: Category): ViewCategory {
         const viewCategory = new ViewCategory(category);
-        viewCategory.getVerboseName = (plural: boolean = false) => {
-            return this.translate.instant(plural ? 'Categories' : 'Category');
-        };
+        viewCategory.getVerboseName = this.getVerboseName;
         return viewCategory;
     }
 

--- a/client/src/app/core/repositories/motions/change-recommendation-repository.service.ts
+++ b/client/src/app/core/repositories/motions/change-recommendation-repository.service.ts
@@ -53,6 +53,10 @@ export class ChangeRecommendationRepositoryService extends BaseRepository<
         super(DS, mapperService, viewModelStoreService, MotionChangeRecommendation, [Category, User, Workflow]);
     }
 
+    public getVerboseName = (plural: boolean = false) => {
+        return this.translate.instant(plural ? 'Change recommendations' : 'Change recommendation');
+    };
+
     /**
      * Creates this view wrapper based on an actual Change Recommendation model
      *
@@ -60,9 +64,7 @@ export class ChangeRecommendationRepositoryService extends BaseRepository<
      */
     protected createViewModel(model: MotionChangeRecommendation): ViewMotionChangeRecommendation {
         const viewMotionChangeRecommendation = new ViewMotionChangeRecommendation(model);
-        viewMotionChangeRecommendation.getVerboseName = (plural: boolean = false) => {
-            return this.translate.instant(plural ? 'Change recommendations' : 'Change recommendation');
-        };
+        viewMotionChangeRecommendation.getVerboseName = this.getVerboseName;
         return viewMotionChangeRecommendation;
     }
 

--- a/client/src/app/core/repositories/motions/motion-comment-section-repository.service.ts
+++ b/client/src/app/core/repositories/motions/motion-comment-section-repository.service.ts
@@ -51,6 +51,10 @@ export class MotionCommentSectionRepositoryService extends BaseRepository<
         super(DS, mapperService, viewModelStoreService, MotionCommentSection, [Group]);
     }
 
+    public getVerboseName = (plural: boolean = false) => {
+        return this.translate.instant(plural ? 'Comment sections' : 'Comment section');
+    };
+
     /**
      * Creates the ViewModel for the MotionComment Section
      *
@@ -61,9 +65,7 @@ export class MotionCommentSectionRepositoryService extends BaseRepository<
         const readGroups = this.viewModelStoreService.getMany(ViewGroup, section.read_groups_id);
         const writeGroups = this.viewModelStoreService.getMany(ViewGroup, section.write_groups_id);
         const viewMotionCommentSection = new ViewMotionCommentSection(section, readGroups, writeGroups);
-        viewMotionCommentSection.getVerboseName = (plural: boolean = false) => {
-            return this.translate.instant(plural ? 'Comment sections' : 'Comment section');
-        };
+        viewMotionCommentSection.getVerboseName = this.getVerboseName;
         return viewMotionCommentSection;
     }
 

--- a/client/src/app/core/repositories/motions/statute-paragraph-repository.service.ts
+++ b/client/src/app/core/repositories/motions/statute-paragraph-repository.service.ts
@@ -40,11 +40,13 @@ export class StatuteParagraphRepositoryService extends BaseRepository<ViewStatut
         super(DS, mapperService, viewModelStoreService, StatuteParagraph);
     }
 
+    public getVerboseName = (plural: boolean = false) => {
+        return this.translate.instant(plural ? 'Statute paragraphs' : 'Statute paragraph');
+    };
+
     protected createViewModel(statuteParagraph: StatuteParagraph): ViewStatuteParagraph {
         const viewStatuteParagraph = new ViewStatuteParagraph(statuteParagraph);
-        viewStatuteParagraph.getVerboseName = (plural: boolean = false) => {
-            return this.translate.instant(plural ? 'Statute paragraphs' : 'Statute paragraph');
-        };
+        viewStatuteParagraph.getVerboseName = this.getVerboseName;
         return viewStatuteParagraph;
     }
 

--- a/client/src/app/core/repositories/motions/workflow-repository.service.ts
+++ b/client/src/app/core/repositories/motions/workflow-repository.service.ts
@@ -52,6 +52,10 @@ export class WorkflowRepositoryService extends BaseRepository<ViewWorkflow, Work
         super(DS, mapperService, viewModelStoreService, Workflow);
     }
 
+    public getVerboseName = (plural: boolean = false) => {
+        return this.translate.instant(plural ? 'Workflows' : 'Workflow');
+    };
+
     /**
      * Creates a ViewWorkflow from a given Workflow
      *
@@ -59,9 +63,7 @@ export class WorkflowRepositoryService extends BaseRepository<ViewWorkflow, Work
      */
     protected createViewModel(workflow: Workflow): ViewWorkflow {
         const viewWorkflow = new ViewWorkflow(workflow);
-        viewWorkflow.getVerboseName = (plural: boolean = false) => {
-            return this.translate.instant(plural ? 'Workflows' : 'Workflow');
-        };
+        viewWorkflow.getVerboseName = this.getVerboseName;
         return viewWorkflow;
     }
 

--- a/client/src/app/core/repositories/projector/countdown-repository.service.ts
+++ b/client/src/app/core/repositories/projector/countdown-repository.service.ts
@@ -25,11 +25,13 @@ export class CountdownRepositoryService extends BaseRepository<ViewCountdown, Co
         super(DS, mapperService, viewModelStoreService, Countdown);
     }
 
+    public getVerboseName = (plural: boolean = false) => {
+        return this.translate.instant(plural ? 'Countdowns' : 'Countdown');
+    };
+
     protected createViewModel(countdown: Countdown): ViewCountdown {
         const viewCountdown = new ViewCountdown(countdown);
-        viewCountdown.getVerboseName = (plural: boolean = false) => {
-            return this.translate.instant(plural ? 'Countdowns' : 'Countdown');
-        };
+        viewCountdown.getVerboseName = this.getVerboseName;
         return viewCountdown;
     }
 

--- a/client/src/app/core/repositories/projector/projector-message-repository.service.ts
+++ b/client/src/app/core/repositories/projector/projector-message-repository.service.ts
@@ -23,11 +23,13 @@ export class ProjectorMessageRepositoryService extends BaseRepository<ViewProjec
         super(DS, mapperService, viewModelStoreService, ProjectorMessage);
     }
 
+    public getVerboseName = (plural: boolean = false) => {
+        return this.translate.instant(plural ? 'Messages' : 'Message');
+    };
+
     protected createViewModel(message: ProjectorMessage): ViewProjectorMessage {
         const viewProjectorMessage = new ViewProjectorMessage(message);
-        viewProjectorMessage.getVerboseName = (plural: boolean = false) => {
-            return this.translate.instant(plural ? 'Messages' : 'Message');
-        };
+        viewProjectorMessage.getVerboseName = this.getVerboseName;
         return viewProjectorMessage;
     }
 

--- a/client/src/app/core/repositories/projector/projector-repository.service.ts
+++ b/client/src/app/core/repositories/projector/projector-repository.service.ts
@@ -46,11 +46,13 @@ export class ProjectorRepositoryService extends BaseRepository<ViewProjector, Pr
         super(DS, mapperService, viewModelStoreService, Projector);
     }
 
+    public getVerboseName = (plural: boolean = false) => {
+        return this.translate.instant(plural ? 'Projectors' : 'Projector');
+    };
+
     public createViewModel(projector: Projector): ViewProjector {
         const viewProjector = new ViewProjector(projector);
-        viewProjector.getVerboseName = (plural: boolean = false) => {
-            return this.translate.instant(plural ? 'Projectors' : 'Projector');
-        };
+        viewProjector.getVerboseName = this.getVerboseName;
         return viewProjector;
     }
 

--- a/client/src/app/core/repositories/tags/tag-repository.service.ts
+++ b/client/src/app/core/repositories/tags/tag-repository.service.ts
@@ -43,11 +43,13 @@ export class TagRepositoryService extends BaseRepository<ViewTag, Tag> {
         super(DS, mapperService, viewModelStoreService, Tag);
     }
 
+    public getVerboseName = (plural: boolean = false) => {
+        return this.translate.instant(plural ? 'Tags' : 'Tag');
+    };
+
     protected createViewModel(tag: Tag): ViewTag {
         const viewTag = new ViewTag(tag);
-        viewTag.getVerboseName = (plural: boolean = false) => {
-            return this.translate.instant(plural ? 'Tags' : 'Tag');
-        };
+        viewTag.getVerboseName = this.getVerboseName;
         return viewTag;
     }
 

--- a/client/src/app/core/repositories/users/group-repository.service.ts
+++ b/client/src/app/core/repositories/users/group-repository.service.ts
@@ -60,11 +60,13 @@ export class GroupRepositoryService extends BaseRepository<ViewGroup, Group> {
         this.sortPermsPerApp();
     }
 
+    public getVerboseName = (plural: boolean = false) => {
+        return this.translate.instant(plural ? 'Groups' : 'Group');
+    };
+
     public createViewModel(group: Group): ViewGroup {
         const viewGroup = new ViewGroup(group);
-        viewGroup.getVerboseName = (plural: boolean = false) => {
-            return this.translate.instant(plural ? 'Groups' : 'Group');
-        };
+        viewGroup.getVerboseName = this.getVerboseName;
         return viewGroup;
     }
 

--- a/client/src/app/core/repositories/users/personal-note-repository.service.ts
+++ b/client/src/app/core/repositories/users/personal-note-repository.service.ts
@@ -28,11 +28,13 @@ export class PersonalNoteRepositoryService extends BaseRepository<ViewPersonalNo
         super(DS, mapperService, viewModelStoreService, PersonalNote);
     }
 
+    public getVerboseName = (plural: boolean = false) => {
+        return this.translate.instant(plural ? 'Personal notes' : 'Personal note');
+    };
+
     protected createViewModel(personalNote: PersonalNote): ViewPersonalNote {
         const viewPersonalNote = new ViewPersonalNote();
-        viewPersonalNote.getVerboseName = (plural: boolean = false) => {
-            return this.translate.instant(plural ? 'Personal notes' : 'Personal note');
-        };
+        viewPersonalNote.getVerboseName = this.getVerboseName;
         return viewPersonalNote;
     }
 

--- a/client/src/app/core/repositories/users/user-repository.service.ts
+++ b/client/src/app/core/repositories/users/user-repository.service.ts
@@ -51,13 +51,14 @@ export class UserRepositoryService extends BaseRepository<ViewUser, User> {
         super(DS, mapperService, viewModelStoreService, User, [Group]);
     }
 
+    public getVerboseName = (plural: boolean = false) => {
+        return this.translate.instant(plural ? 'Participants' : 'Participant');
+    };
+
     public createViewModel(user: User): ViewUser {
         const groups = this.viewModelStoreService.getMany(ViewGroup, user.groups_id);
         const viewUser = new ViewUser(user, groups);
-        viewUser.getVerboseName = (plural: boolean = false) => {
-            return this.translate.instant(plural ? 'Participants' : 'Participant');
-        };
-
+        viewUser.getVerboseName = this.getVerboseName;
         viewUser.getNumberForName = (nr: number) => {
             return `${this.translate.instant('No.')} ${nr}`;
         };

--- a/client/src/app/site/assignments/assignments.config.ts
+++ b/client/src/app/site/assignments/assignments.config.ts
@@ -10,7 +10,7 @@ export const AssignmentsAppConfig: AppConfig = {
             collectionString: 'assignments/assignment',
             model: Assignment,
             viewModel: ViewAssignment,
-            searchOrder: 3,
+            // searchOrder: 3, // TODO: enable, if there is a detail page and so on.
             repository: AssignmentRepositoryService
         }
     ],

--- a/client/src/app/site/assignments/models/view-assignment.ts
+++ b/client/src/app/site/assignments/models/view-assignment.ts
@@ -76,7 +76,7 @@ export class ViewAssignment extends BaseAgendaViewModel {
     };
 
     public formatForSearch(): SearchRepresentation {
-        throw new Error('TODO');
+        return [this.title];
     }
 
     public getDetailStateURL(): string {

--- a/client/src/app/site/common/components/search/search.component.html
+++ b/client/src/app/site/common/components/search/search.component.html
@@ -44,10 +44,10 @@
             <mat-card-content>
                 <mat-list>
                     <mat-list-item *ngFor="let model of searchResult.models">
-                        <a
-                            [routerLink]="model.getDetailStateURL()"
-                            target="{{ searchResult.collectionString === 'mediafiles/mediafile' ? '_blank' : '' }}"
-                        >
+                        <a *ngIf="!searchResult.openInNewTab" [routerLink]="model.getDetailStateURL()">
+                            {{ model.getTitle() }}
+                        </a>
+                        <a *ngIf="searchResult.openInNewTab" [routerLink]="model.getDetailStateURL()" target="_blank" >
                             {{ model.getTitle() }}
                         </a>
                     </mat-list-item>

--- a/client/src/app/site/common/components/search/search.component.ts
+++ b/client/src/app/site/common/components/search/search.component.ts
@@ -114,7 +114,9 @@ export class SearchComponent extends BaseViewComponent implements OnInit {
         this.searchResults = this.searchService.search(this.query, collectionStrings);
 
         // Because the results are per model, we need to accumulate the total number of all search results.
-        this.searchResultCount = this.searchResults.map(sr => sr.models.length).reduce((acc, current) => acc + current);
+        this.searchResultCount = this.searchResults
+            .map(sr => sr.models.length)
+            .reduce((acc, current) => acc + current, 0);
 
         // Update the URL.
         this.router.navigate([], {

--- a/client/src/app/site/mediafiles/mediafile.config.ts
+++ b/client/src/app/site/mediafiles/mediafile.config.ts
@@ -11,6 +11,7 @@ export const MediafileAppConfig: AppConfig = {
             model: Mediafile,
             viewModel: ViewMediafile,
             searchOrder: 5,
+            openInNewTab: true,
             repository: MediafileRepositoryService
         }
     ],

--- a/client/src/app/site/mediafiles/models/view-mediafile.ts
+++ b/client/src/app/site/mediafiles/models/view-mediafile.ts
@@ -85,7 +85,7 @@ export class ViewMediafile extends BaseProjectableViewModel implements Searchabl
     }
 
     public getDetailStateURL(): string {
-        throw new Error('TODO');
+        return this.downloadUrl;
     }
 
     public getSlide(): ProjectorElementBuildDeskriptor {

--- a/client/src/app/site/tags/models/view-tag.ts
+++ b/client/src/app/site/tags/models/view-tag.ts
@@ -46,7 +46,7 @@ export class ViewTag extends BaseViewModel implements Searchable {
     }
 
     public getDetailStateURL(): string {
-        throw new Error('TODO');
+        return `/tags`;
     }
 
     /**

--- a/client/src/app/site/users/models/view-user.ts
+++ b/client/src/app/site/users/models/view-user.ts
@@ -189,7 +189,7 @@ export class ViewUser extends BaseProjectableViewModel implements Searchable {
     }
 
     public getDetailStateURL(): string {
-        throw new Error('TODO');
+        return `/users/${this.id}`;
     }
 
     public getSlide(): ProjectorElementBuildDeskriptor {


### PR DESCRIPTION
Fixed leftovers from the viewModel restructure. Repositories always have a verboseName now. Does not implement new logic to follow related models (e.g. motions->submitters).