### PR TITLE
fix legalnotice and privacy z-index issue

### DIFF
--- a/client/src/app/shared/components/legal-notice-content/legal-notice-content.component.html
+++ b/client/src/app/shared/components/legal-notice-content/legal-notice-content.component.html
@@ -1,8 +1,8 @@
-<mat-card class="os-card on-transition-fade">
+<mat-card class="os-card">
     <div>
-        <div class='legal-notice-text' [innerHtml]='legalNotice'></div>
+        <div class="legal-notice-text" [innerHtml]="legalNotice"></div>
         <mat-divider></mat-divider>
-        <div *ngIf="versionInfo" class='version-text'>
+        <div *ngIf="versionInfo" class="version-text">
             <a [attr.href]="versionInfo.openslides_url" target="_blank">
                 OpenSlides {{ versionInfo.openslides_version }}
             </a>
@@ -11,12 +11,8 @@
             <div *ngIf="versionInfo.plugins.length">
                 <p><span translate>Installed plugins</span>:</p>
                 <div *ngFor="let plugin of versionInfo.plugins">
-                    <a [attr.href]="plugin.url" target="_blank">
-                        {{ plugin.verbose_name }} {{ plugin.version }}
-                    </a>
-                    <div *ngIf="plugin.license">
-                        (<span translate>License</span>: {{ plugin.license }})
-                    </div>
+                    <a [attr.href]="plugin.url" target="_blank"> {{ plugin.verbose_name }} {{ plugin.version }} </a>
+                    <div *ngIf="plugin.license">(<span translate>License</span>: {{ plugin.license }})</div>
                 </div>
             </div>
         </div>

--- a/client/src/app/shared/components/privacy-policy-content/privacy-policy-content.component.html
+++ b/client/src/app/shared/components/privacy-policy-content/privacy-policy-content.component.html
@@ -1,6 +1,6 @@
-<mat-card class='os-card on-transition-fade'>
-    <div *ngIf='privacyPolicy' [innerHtml]='privacyPolicy'></div>
-    <div *ngIf='!privacyPolicy' translate>
+<mat-card class="os-card">
+    <div *ngIf="privacyPolicy" [innerHtml]="privacyPolicy"></div>
+    <div *ngIf="!privacyPolicy" translate>
         The event manager hasn't set up a privacy policy yet.
     </div>
 </mat-card>

--- a/client/src/app/site/agenda/components/topic-detail/topic-detail.component.html
+++ b/client/src/app/site/agenda/components/topic-detail/topic-detail.component.html
@@ -24,7 +24,7 @@
     </div>
 </os-head-bar>
 
-<mat-card *ngIf="topic || editTopic" [ngClass]="editTopic ? 'os-form-card' : 'os-card'" class="on-transition-fade">
+<mat-card *ngIf="topic || editTopic" [ngClass]="editTopic ? 'os-form-card' : 'os-card'">
     <div *ngIf="!editTopic">
         <h1>{{ topic.getTitle() }}</h1>
     </div>


### PR DESCRIPTION
**Hotfix**
I just removed the on-transition-fade class on these two components. In this case it had no negative effect on any fade-out.


**better approach**
just changing the z-index of 'on-transition-fade' from 100 to  2 (head bar has 3), but I'm not sure if this brakes things somewhere else (we use this css class a lot)
