### PR TITLE
Add Service Work(e|a)r(round)

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -10,4 +10,9 @@ if (environment.production) {
 
 platformBrowserDynamic()
     .bootstrapModule(AppModule)
+    .then(() => {
+        if ('serviceWorker' in navigator && environment.production) {
+            navigator.serviceWorker.register('ngsw-worker.js');
+        }
+    })
     .catch(err => console.log(err));


### PR DESCRIPTION
uses the promise in returned by `.bootstrapModule`
to register the service worker if required.
Seems to work reliable, even in unstable environments.
Requires production mode to comprehend.
(at least ng build --prod)

This workaround currently shadows, that the [ApplicationRef](https://angular.io/api/core/ApplicationRef) does not consider the current state as "stable". It's currently not known if this is somehow severe or not.