### PR TITLE
set allow_null for integerfields, when they are not required

### DIFF
--- a/client/src/app/site/motions/services/local-permissions.service.ts
+++ b/client/src/app/site/motions/services/local-permissions.service.ts
@@ -109,6 +109,7 @@ export class LocalPermissionsService {
                         motion.state.allow_submitter_edit &&
                         motion.submitters &&
                         motion.submitters.length &&
+                        !this.operator.isAnonymous &&
                         motion.submitters.some(submitter => submitter.id === this.operator.user.id))
                 );
             }
@@ -139,6 +140,7 @@ export class LocalPermissionsService {
                     this.operator.hasPerms('motions.can_manage_metadata') ||
                     (motion.state &&
                         motion.state.allow_submitter_edit &&
+                        !this.operator.isAnonymous &&
                         motion.submitters &&
                         motion.submitters.some(submitter => submitter.id === this.operator.user.id))
                 );

--- a/openslides/motions/serializers.py
+++ b/openslides/motions/serializers.py
@@ -68,7 +68,7 @@ class MotionBlockSerializer(ModelSerializer):
     """
 
     agenda_type = IntegerField(
-        write_only=True, required=False, min_value=1, max_value=3
+        write_only=True, required=False, min_value=1, max_value=3, allow_null=True
     )
     agenda_parent_id = IntegerField(write_only=True, required=False, min_value=1)
 
@@ -397,7 +397,7 @@ class MotionSerializer(ModelSerializer):
         min_value=1, required=False, validators=[validate_workflow_field]
     )
     agenda_type = IntegerField(
-        write_only=True, required=False, min_value=1, max_value=3
+        write_only=True, required=False, min_value=1, max_value=3, allow_null=True
     )
     agenda_parent_id = IntegerField(write_only=True, required=False, min_value=1)
     submitters = SubmitterSerializer(many=True, read_only=True)

--- a/openslides/topics/serializers.py
+++ b/openslides/topics/serializers.py
@@ -11,7 +11,7 @@ class TopicSerializer(ModelSerializer):
     """
 
     agenda_type = IntegerField(
-        write_only=True, required=False, min_value=1, max_value=3
+        write_only=True, required=False, min_value=1, max_value=3, allow_null=True
     )
     agenda_parent_id = IntegerField(write_only=True, required=False, min_value=1)
     agenda_comment = CharField(write_only=True, required=False, allow_blank=True)


### PR DESCRIPTION
Then `required=False`, the value might be `None`. The `IntegerField` validators doesn't allow null (must be between 1 and 3 in this case), so adding `Allow_null=True` let `None` pass throgh this validation step (https://stackoverflow.com/questions/19780731/django-rest-framework-serializer-field-required-false)

The client changes are for the anonymous user.