### PR TITLE
Fixed SW registration issues due to pending mikrotasks

### DIFF
--- a/client/src/app/app.component.spec.ts
+++ b/client/src/app/app.component.spec.ts
@@ -1,10 +1,11 @@
-import { TestBed, async } from '@angular/core/testing';
+import { TestBed, async, fakeAsync, tick } from '@angular/core/testing';
 import { AppComponent } from './app.component';
 import { E2EImportsModule } from './../e2e-imports.module';
 import { ServertimeService } from './core/core-services/servertime.service';
+import { TranslateService } from '@ngx-translate/core';
 
 describe('AppComponent', () => {
-    let servertimeService;
+    let servertimeService, translate;
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({
@@ -12,12 +13,21 @@ describe('AppComponent', () => {
         }).compileComponents();
 
         servertimeService = TestBed.get(ServertimeService);
+        translate = TestBed.get(TranslateService);
         spyOn(servertimeService, 'startScheduler').and.stub();
+        spyOn(translate, 'addLangs').and.stub();
+        spyOn(translate, 'setDefaultLang').and.stub();
+        spyOn(translate, 'getBrowserLang').and.stub();
+        spyOn(translate, 'getLangs').and.returnValue([]);
+        spyOn(translate, 'use').and.stub();
     }));
-    it('should create the app', async(() => {
+    it('should create the app', fakeAsync(() => {
         const fixture = TestBed.createComponent(AppComponent);
         const app = fixture.debugElement.componentInstance;
         expect(app).toBeTruthy();
-        expect(servertimeService.startScheduler).toHaveBeenCalled();
+        tick();
+        fixture.whenStable().then(() => {
+            expect(servertimeService.startScheduler).toHaveBeenCalled();
+        });
     }));
 });

--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -1,5 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, ApplicationRef } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
+
+import { take, filter } from 'rxjs/operators';
 
 import { ConfigService } from './core/ui-services/config.service';
 import { ConstantsService } from './core/ui-services/constants.service';
@@ -45,7 +47,8 @@ export class AppComponent {
         themeService: ThemeService,
         countUsersService: CountUsersService, // Needed to register itself.
         configService: ConfigService,
-        loadFontService: LoadFontService
+        loadFontService: LoadFontService,
+        appRef: ApplicationRef
     ) {
         // manually add the supported languages
         translate.addLangs(['en', 'de', 'cs']);
@@ -57,7 +60,17 @@ export class AppComponent {
         translate.use(translate.getLangs().includes(browserLang) ? browserLang : 'en');
         // change default JS functions
         this.overloadArrayToString();
-        servertimeService.startScheduler();
+
+        appRef.isStable.subscribe(s => console.log('is stable', s));
+        appRef.isStable
+            .pipe(
+                filter(s => s),
+                take(1)
+            )
+            .subscribe(() => {
+                console.log('start scheduler');
+                servertimeService.startScheduler();
+            });
     }
 
     /**

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1,4 +1,4 @@
-import { enableProdMode, NgModuleRef } from '@angular/core';
+import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 
 import { AppModule } from './app/app.module';
@@ -10,9 +10,4 @@ if (environment.production) {
 
 platformBrowserDynamic()
     .bootstrapModule(AppModule)
-    .then(() => {
-        if ('serviceWorker' in navigator && environment.production) {
-            navigator.serviceWorker.register('ngsw-worker.js');
-        }
-    })
     .catch(err => console.log(err));


### PR DESCRIPTION
I had the `serverTimeService` under suspicion since #4458 . With `startScheduler` a `setTimeout` will be started, that re-registers itself again. So in contrast to the mentioned comment, `setTimeout` is evil, if it's used as a fancy `setInterval`. There is always a pending microtask, that blocks the application from being stable. Starting the service when the application is stable works not only this first time: For instance observing the `console.log("is stable")` on navigations one can see, that the application state always goes back to a stable state.

I'll invite you to check out this PR and play a bit with it. If it's ok (I could not test the SW..), I'll remove any `console.log` and this can be merged.