### PR TITLE
Resort python import for isort 4.3.11 (fixes #4467)

### DIFF
--- a/openslides/agenda/models.py
+++ b/openslides/agenda/models.py
@@ -15,8 +15,8 @@ from openslides.utils.exceptions import OpenSlidesError
 from openslides.utils.models import RESTModelMixin
 from openslides.utils.utils import to_roman
 
-from .access_permissions import ItemAccessPermissions
 from ..utils.models import CASCADE_AND_AUTOUODATE, SET_NULL_AND_AUTOUPDATE
+from .access_permissions import ItemAccessPermissions
 
 
 class ItemManager(models.Manager):

--- a/openslides/agenda/signals.py
+++ b/openslides/agenda/signals.py
@@ -1,8 +1,8 @@
 from django.apps import apps
 from django.contrib.contenttypes.models import ContentType
 
-from .models import Item
 from ..utils.autoupdate import inform_changed_data
+from .models import Item
 
 
 def listen_to_related_object_post_save(sender, instance, created, **kwargs):

--- a/openslides/agenda/views.py
+++ b/openslides/agenda/views.py
@@ -16,9 +16,9 @@ from openslides.utils.rest_api import (
     list_route,
 )
 
+from ..utils.auth import has_perm
 from .access_permissions import ItemAccessPermissions
 from .models import Item, Speaker
-from ..utils.auth import has_perm
 
 
 # Viewsets for the REST API

--- a/openslides/assignments/models.py
+++ b/openslides/assignments/models.py
@@ -21,8 +21,8 @@ from openslides.utils.autoupdate import inform_changed_data
 from openslides.utils.exceptions import OpenSlidesError
 from openslides.utils.models import RESTModelMixin
 
-from .access_permissions import AssignmentAccessPermissions
 from ..utils.models import CASCADE_AND_AUTOUODATE, SET_NULL_AND_AUTOUPDATE
+from .access_permissions import AssignmentAccessPermissions
 
 
 class AssignmentRelatedUser(RESTModelMixin, models.Model):

--- a/openslides/assignments/serializers.py
+++ b/openslides/assignments/serializers.py
@@ -12,6 +12,7 @@ from openslides.utils.rest_api import (
     ValidationError,
 )
 
+from ..utils.validate import validate_html
 from .models import (
     Assignment,
     AssignmentOption,
@@ -20,7 +21,6 @@ from .models import (
     AssignmentVote,
     models,
 )
-from ..utils.validate import validate_html
 
 
 def posts_validator(data):

--- a/openslides/assignments/views.py
+++ b/openslides/assignments/views.py
@@ -12,10 +12,10 @@ from openslides.utils.rest_api import (
     detail_route,
 )
 
+from ..utils.auth import has_perm
 from .access_permissions import AssignmentAccessPermissions
 from .models import Assignment, AssignmentPoll, AssignmentRelatedUser
 from .serializers import AssignmentAllPollSerializer
-from ..utils.auth import has_perm
 
 
 # Viewsets for the REST API

--- a/openslides/core/config.py
+++ b/openslides/core/config.py
@@ -5,9 +5,9 @@ from django.apps import apps
 from django.core.exceptions import ValidationError as DjangoValidationError
 from mypy_extensions import TypedDict
 
+from ..utils.cache import element_cache
 from .exceptions import ConfigError, ConfigNotFound
 from .models import ConfigStore
-from ..utils.cache import element_cache
 
 
 INPUT_TYPE_MAPPING = {

--- a/openslides/core/models.py
+++ b/openslides/core/models.py
@@ -4,6 +4,13 @@ from django.db import models, transaction
 from django.utils.timezone import now
 from jsonfield import JSONField
 
+from ..utils.autoupdate import Element
+from ..utils.cache import element_cache, get_element_id
+from ..utils.models import (
+    CASCADE_AND_AUTOUODATE,
+    SET_NULL_AND_AUTOUPDATE,
+    RESTModelMixin,
+)
 from .access_permissions import (
     ChatMessageAccessPermissions,
     ConfigAccessPermissions,
@@ -12,13 +19,6 @@ from .access_permissions import (
     ProjectorAccessPermissions,
     ProjectorMessageAccessPermissions,
     TagAccessPermissions,
-)
-from ..utils.autoupdate import Element
-from ..utils.cache import element_cache, get_element_id
-from ..utils.models import (
-    CASCADE_AND_AUTOUODATE,
-    SET_NULL_AND_AUTOUPDATE,
-    RESTModelMixin,
 )
 
 

--- a/openslides/core/serializers.py
+++ b/openslides/core/serializers.py
@@ -1,5 +1,8 @@
 from typing import Any
 
+from ..utils.projector import projector_slides
+from ..utils.rest_api import Field, IntegerField, ModelSerializer, ValidationError
+from ..utils.validate import validate_html
 from .models import (
     ChatMessage,
     ConfigStore,
@@ -10,9 +13,6 @@ from .models import (
     ProjectorMessage,
     Tag,
 )
-from ..utils.projector import projector_slides
-from ..utils.rest_api import Field, IntegerField, ModelSerializer, ValidationError
-from ..utils.validate import validate_html
 
 
 class JSONSerializerField(Field):

--- a/openslides/core/views.py
+++ b/openslides/core/views.py
@@ -11,28 +11,6 @@ from django.utils.timezone import now
 from django.views import static
 from django.views.generic.base import View
 
-from .access_permissions import (
-    ChatMessageAccessPermissions,
-    ConfigAccessPermissions,
-    CountdownAccessPermissions,
-    HistoryAccessPermissions,
-    ProjectorAccessPermissions,
-    ProjectorMessageAccessPermissions,
-    TagAccessPermissions,
-)
-from .config import config
-from .exceptions import ConfigError, ConfigNotFound
-from .models import (
-    ChatMessage,
-    ConfigStore,
-    Countdown,
-    History,
-    HistoryData,
-    ProjectionDefault,
-    Projector,
-    ProjectorMessage,
-    Tag,
-)
 from .. import __license__ as license, __url__ as url, __version__ as version
 from ..users.models import User
 from ..utils import views as utils_views
@@ -55,6 +33,28 @@ from ..utils.rest_api import (
     ValidationError,
     detail_route,
     list_route,
+)
+from .access_permissions import (
+    ChatMessageAccessPermissions,
+    ConfigAccessPermissions,
+    CountdownAccessPermissions,
+    HistoryAccessPermissions,
+    ProjectorAccessPermissions,
+    ProjectorMessageAccessPermissions,
+    TagAccessPermissions,
+)
+from .config import config
+from .exceptions import ConfigError, ConfigNotFound
+from .models import (
+    ChatMessage,
+    ConfigStore,
+    Countdown,
+    History,
+    HistoryData,
+    ProjectionDefault,
+    Projector,
+    ProjectorMessage,
+    Tag,
 )
 
 

--- a/openslides/mediafiles/models.py
+++ b/openslides/mediafiles/models.py
@@ -1,10 +1,10 @@
 from django.conf import settings
 from django.db import models
 
-from .access_permissions import MediafileAccessPermissions
 from ..core.config import config
 from ..utils.autoupdate import inform_changed_data
 from ..utils.models import SET_NULL_AND_AUTOUPDATE, RESTModelMixin
+from .access_permissions import MediafileAccessPermissions
 
 
 class Mediafile(RESTModelMixin, models.Model):

--- a/openslides/mediafiles/serializers.py
+++ b/openslides/mediafiles/serializers.py
@@ -5,8 +5,8 @@ from django.db import models as dbmodels
 from PyPDF2 import PdfFileReader
 from PyPDF2.utils import PdfReadError
 
-from .models import Mediafile
 from ..utils.rest_api import FileField, ModelSerializer, SerializerMethodField
+from .models import Mediafile
 
 
 class AngularCompatibleFileField(FileField):

--- a/openslides/mediafiles/views.py
+++ b/openslides/mediafiles/views.py
@@ -1,11 +1,11 @@
 from django.http import HttpResponseForbidden, HttpResponseNotFound
 from django.views.static import serve
 
-from .access_permissions import MediafileAccessPermissions
-from .models import Mediafile
 from ..core.config import config
 from ..utils.auth import has_perm
 from ..utils.rest_api import ModelViewSet, ValidationError
+from .access_permissions import MediafileAccessPermissions
+from .models import Mediafile
 
 
 # Viewsets for the REST API

--- a/openslides/motions/models.py
+++ b/openslides/motions/models.py
@@ -23,6 +23,7 @@ from openslides.utils.autoupdate import inform_changed_data
 from openslides.utils.exceptions import OpenSlidesError
 from openslides.utils.models import RESTModelMixin
 
+from ..utils.models import CASCADE_AND_AUTOUODATE, SET_NULL_AND_AUTOUPDATE
 from .access_permissions import (
     CategoryAccessPermissions,
     MotionAccessPermissions,
@@ -33,7 +34,6 @@ from .access_permissions import (
     WorkflowAccessPermissions,
 )
 from .exceptions import WorkflowError
-from ..utils.models import CASCADE_AND_AUTOUODATE, SET_NULL_AND_AUTOUPDATE
 
 
 class StatuteParagraph(RESTModelMixin, models.Model):

--- a/openslides/motions/serializers.py
+++ b/openslides/motions/serializers.py
@@ -2,20 +2,6 @@ from typing import Dict, Optional
 
 from django.db import transaction
 
-from .models import (
-    Category,
-    Motion,
-    MotionBlock,
-    MotionChangeRecommendation,
-    MotionComment,
-    MotionCommentSection,
-    MotionLog,
-    MotionPoll,
-    State,
-    StatuteParagraph,
-    Submitter,
-    Workflow,
-)
 from ..core.config import config
 from ..poll.serializers import default_votes_validator
 from ..utils.auth import get_group_model
@@ -32,6 +18,20 @@ from ..utils.rest_api import (
     ValidationError,
 )
 from ..utils.validate import validate_html
+from .models import (
+    Category,
+    Motion,
+    MotionBlock,
+    MotionChangeRecommendation,
+    MotionComment,
+    MotionCommentSection,
+    MotionLog,
+    MotionPoll,
+    State,
+    StatuteParagraph,
+    Submitter,
+    Workflow,
+)
 
 
 def validate_workflow_field(value):

--- a/openslides/motions/views.py
+++ b/openslides/motions/views.py
@@ -10,6 +10,22 @@ from django.db.models.deletion import ProtectedError
 from django.http.request import QueryDict
 from rest_framework import status
 
+from ..core.config import config
+from ..core.models import Tag
+from ..utils.auth import has_perm, in_some_groups
+from ..utils.autoupdate import inform_changed_data, inform_deleted_data
+from ..utils.rest_api import (
+    CreateModelMixin,
+    DestroyModelMixin,
+    GenericViewSet,
+    ModelViewSet,
+    Response,
+    ReturnDict,
+    UpdateModelMixin,
+    ValidationError,
+    detail_route,
+    list_route,
+)
 from .access_permissions import (
     CategoryAccessPermissions,
     MotionAccessPermissions,
@@ -34,22 +50,6 @@ from .models import (
     Workflow,
 )
 from .serializers import MotionPollSerializer, StateSerializer
-from ..core.config import config
-from ..core.models import Tag
-from ..utils.auth import has_perm, in_some_groups
-from ..utils.autoupdate import inform_changed_data, inform_deleted_data
-from ..utils.rest_api import (
-    CreateModelMixin,
-    DestroyModelMixin,
-    GenericViewSet,
-    ModelViewSet,
-    Response,
-    ReturnDict,
-    UpdateModelMixin,
-    ValidationError,
-    detail_route,
-    list_route,
-)
 
 
 # Viewsets for the REST API

--- a/openslides/topics/models.py
+++ b/openslides/topics/models.py
@@ -3,10 +3,10 @@ from typing import Any, Dict
 from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
 
-from .access_permissions import TopicAccessPermissions
 from ..agenda.models import Item
 from ..mediafiles.models import Mediafile
 from ..utils.models import RESTModelMixin
+from .access_permissions import TopicAccessPermissions
 
 
 class TopicManager(models.Manager):

--- a/openslides/topics/views.py
+++ b/openslides/topics/views.py
@@ -1,8 +1,8 @@
 from openslides.utils.rest_api import ModelViewSet
 
+from ..utils.auth import has_perm
 from .access_permissions import TopicAccessPermissions
 from .models import Topic
-from ..utils.auth import has_perm
 
 
 class TopicViewSet(ModelViewSet):

--- a/openslides/users/models.py
+++ b/openslides/users/models.py
@@ -17,14 +17,14 @@ from django.db.models import Prefetch
 from django.utils import timezone
 from jsonfield import JSONField
 
+from ..core.config import config
+from ..utils.auth import GROUP_ADMIN_PK
+from ..utils.models import CASCADE_AND_AUTOUODATE, RESTModelMixin
 from .access_permissions import (
     GroupAccessPermissions,
     PersonalNoteAccessPermissions,
     UserAccessPermissions,
 )
-from ..core.config import config
-from ..utils.auth import GROUP_ADMIN_PK
-from ..utils.models import CASCADE_AND_AUTOUODATE, RESTModelMixin
 
 
 class UserManager(BaseUserManager):

--- a/openslides/users/serializers.py
+++ b/openslides/users/serializers.py
@@ -1,7 +1,6 @@
 from django.contrib.auth.hashers import make_password
 from django.contrib.auth.models import Permission
 
-from .models import Group, PersonalNote, User
 from ..utils.autoupdate import inform_changed_data
 from ..utils.rest_api import (
     IdPrimaryKeyRelatedField,
@@ -10,6 +9,7 @@ from ..utils.rest_api import (
     RelatedField,
     ValidationError,
 )
+from .models import Group, PersonalNote, User
 
 
 USERCANSEESERIALIZER_FIELDS = (

--- a/openslides/users/signals.py
+++ b/openslides/users/signals.py
@@ -2,8 +2,8 @@ from django.apps import apps
 from django.contrib.auth.models import Permission
 from django.db.models import Q
 
-from .models import Group, User
 from ..utils.auth import GROUP_ADMIN_PK, GROUP_DEFAULT_PK
+from .models import Group, User
 
 
 def get_permission_change_data(sender, permissions=None, **kwargs):

--- a/openslides/users/views.py
+++ b/openslides/users/views.py
@@ -20,13 +20,6 @@ from django.http.request import QueryDict
 from django.utils.encoding import force_bytes, force_text
 from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
 
-from .access_permissions import (
-    GroupAccessPermissions,
-    PersonalNoteAccessPermissions,
-    UserAccessPermissions,
-)
-from .models import Group, PersonalNote, User
-from .serializers import GroupSerializer, PermissionRelatedField
 from ..core.config import config
 from ..core.signals import permission_change
 from ..utils.auth import (
@@ -47,6 +40,13 @@ from ..utils.rest_api import (
     status,
 )
 from ..utils.views import APIView
+from .access_permissions import (
+    GroupAccessPermissions,
+    PersonalNoteAccessPermissions,
+    UserAccessPermissions,
+)
+from .models import Group, PersonalNote, User
+from .serializers import GroupSerializer, PermissionRelatedField
 
 
 # Viewsets for the REST API

--- a/tests/integration/utils/test_consumers.py
+++ b/tests/integration/utils/test_consumers.py
@@ -17,8 +17,8 @@ from openslides.utils.autoupdate import (
 )
 from openslides.utils.cache import element_cache
 
-from ..helpers import TConfig, TProjector, TUser
 from ...unit.utils.cache_provider import Collection1, Collection2, get_cachable_provider
+from ..helpers import TConfig, TProjector, TUser
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
One dot imports are again behind two dot imports since this new isort
release.