### PR TITLE
clarifying duration service usage

### DIFF
--- a/client/src/app/core/ui-services/duration.service.ts
+++ b/client/src/app/core/ui-services/duration.service.ts
@@ -22,10 +22,10 @@ import { Injectable } from '@angular/core';
  * @example
  * ```ts
  * // will result in 01:10 h
- * const a = this.durationService.durationToString(70);
+ * const a = this.durationService.durationToString(70, 'h');
  *
  * // will result in 00:30 m (30 is interpreted as seconds)
- * const a = this.durationService.durationToString(30);
+ * const a = this.durationService.durationToString(30, 'm');
  * ```
  */
 @Injectable({
@@ -65,10 +65,11 @@ export class DurationService {
     /**
      * Converts a duration number (given in minutes or seconds)
      *
-     * @param duration value in minutes
+     * @param duration value in minutes or seconds (60 units being the next bigger unit)
+     * @param suffix any suffix to add.
      * @returns a more human readable time representation
      */
-    public durationToString(duration: number, suffix: 'h' | 'm' = 'h'): string {
+    public durationToString(duration: number, suffix: 'h' | 'm'): string {
         const major = Math.floor(duration / 60);
         const minor = `0${duration % 60}`.slice(-2);
         if (!isNaN(+major) && !isNaN(+minor)) {

--- a/client/src/app/site/agenda/components/agenda-import-list/agenda-import-list.component.ts
+++ b/client/src/app/site/agenda/components/agenda-import-list/agenda-import-list.component.ts
@@ -98,7 +98,7 @@ export class AgendaImportListComponent extends BaseImportListComponent<ViewCreat
      */
     public getDuration(duration: number): string {
         if (duration >= 0) {
-            return this.durationService.durationToString(duration);
+            return this.durationService.durationToString(duration, 'h');
         } else {
             return '';
         }

--- a/client/src/app/site/agenda/components/agenda-list/agenda-list.component.html
+++ b/client/src/app/site/agenda/components/agenda-list/agenda-list.component.html
@@ -60,7 +60,7 @@
                     </div>
                     <div *ngIf="item.duration">
                         <mat-icon>access_time</mat-icon>
-                        {{ durationService.durationToString(item.duration) }}
+                        {{ durationService.durationToString(item.duration, 'h') }}
                     </div>
                     <div *ngIf="item.comment">
                         <mat-icon>comment</mat-icon>

--- a/client/src/app/site/agenda/components/agenda-list/agenda-list.component.ts
+++ b/client/src/app/site/agenda/components/agenda-list/agenda-list.component.ts
@@ -296,7 +296,7 @@ export class AgendaListComponent extends ListViewBaseComponent<ViewItem, Item> i
         if (!duration) {
             return '';
         }
-        const durationString = this.durationService.durationToString(duration);
+        const durationString = this.durationService.durationToString(duration, 'h');
         const endTime = this.repo.calculateEndTime();
         const result = `${this.translate.instant('Duration')}: ${durationString}`;
         if (endTime) {

--- a/client/src/app/site/agenda/components/item-info-dialog/item-info-dialog.component.ts
+++ b/client/src/app/site/agenda/components/item-info-dialog/item-info-dialog.component.ts
@@ -49,7 +49,7 @@ export class ItemInfoDialogComponent {
 
         // load current values
         this.agendaInfoForm.get('type').setValue(item.type);
-        this.agendaInfoForm.get('durationText').setValue(this.durationService.durationToString(item.duration));
+        this.agendaInfoForm.get('durationText').setValue(this.durationService.durationToString(item.duration, 'h'));
         this.agendaInfoForm.get('item_number').setValue(item.itemNumber);
         this.agendaInfoForm.get('comment').setValue(item.comment);
     }

--- a/client/src/app/site/agenda/components/list-of-speakers/list-of-speakers.component.ts
+++ b/client/src/app/site/agenda/components/list-of-speakers/list-of-speakers.component.ts
@@ -382,6 +382,6 @@ export class ListOfSpeakersComponent extends BaseViewComponent implements OnInit
         const duration = Math.floor(
             (new Date(speaker.end_time).valueOf() - new Date(speaker.begin_time).valueOf()) / 1000
         );
-        return `${this.durationService.durationToString(duration, 'm')} ${this.translate.instant('minutes')}`;
+        return `${this.durationService.durationToString(duration, 'm')}`;
     }
 }


### PR DESCRIPTION
I made the 'h' non-optional, so we always force a conscious thought about 'what type of time is this here?'

Perhaps later we could make the string customizable, so that stuff like `translate('minutes')` could be used (once the linguistic discussions have settled down)