### PR TITLE
rework login system (again)

### DIFF
--- a/client/src/app/core/core-services/auth-guard.service.ts
+++ b/client/src/app/core/core-services/auth-guard.service.ts
@@ -28,6 +28,10 @@ export class AuthGuard implements CanActivate, CanActivateChild {
     public canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
         const basePerm: string | string[] = route.data.basePerm;
 
+        console.log('Auth guard');
+        console.log('motions.can_see:', this.operator.hasPerms('motions.can_see'));
+        console.log('motions.can_manage:', this.operator.hasPerms('motions.can_manage'));
+
         if (!basePerm) {
             return true;
         } else if (basePerm instanceof Array) {

--- a/tests/integration/users/test_views.py
+++ b/tests/integration/users/test_views.py
@@ -15,7 +15,7 @@ class TestWhoAmIView(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             json.loads(response.content.decode()),
-            {"user_id": None, "user": None, "guest_enabled": False},
+            {"user_id": None, "user": None, "permissions": [], "guest_enabled": False},
         )
 
     def test_get_authenticated_user(self):
@@ -56,6 +56,10 @@ class TestUserLogoutView(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertFalse(hasattr(self.client.session, "test_key"))
+        self.assertEqual(
+            json.loads(response.content.decode()),
+            {"user_id": None, "user": None, "permissions": [], "guest_enabled": False},
+        )
 
 
 class TestUserLoginView(TestCase):


### PR DESCRIPTION
There is a bit to do left: Cleanup the code (especially operator, check docs..).

@tsiegleauq Permissions are now included into the whoami data. Now on login and logout, the server sends whoami-information. This is used to always have the current permissions earlier then the auth guard.

I added two permission checks in the auth guard for motion.can_manage and can_see. Try to login/logoff with different users (also anonymous) and see how the permission output behaves (Don't get confused with the load of other prints ;) ). You see, that the authguard always have the right permission info (hopefully..). This should help you to implement the auth guard correctly.

@normanjaeckel @ostcar Changes on the server: Next to always returning the same data (login, logout and whoami) I added the users permissions to it. This is genericly done in `WhoAmIDataView`, which gives a method to build the WhoAmI-context-data for every mentioned view. Is there a better way to query all permissions from a user?

@emanuelschuetze @MaximilianKrambach Please click around and test login/logoff, cache clears, etc. a bit...