### PR TITLE
Prevent drag and final versions without perms

### DIFF
--- a/client/src/app/shared/components/sorting-list/sorting-list.component.html
+++ b/client/src/app/shared/components/sorting-list/sorting-list.component.html
@@ -1,9 +1,9 @@
-<div cdkDropList class="os-card" (cdkDropListDropped)="drop($event)">
+<div cdkDropList class="os-card" [cdkDropListDisabled]="!enable" (cdkDropListDropped)="drop($event)">
     <div class="box line" *ngIf="!array.length">
         <span translate>No data</span>
     </div>
     <div class="box line" *ngFor="let item of array; let i = index" cdkDrag>
-        <div class="section-one" cdkDragHandle>
+        <div class="section-one" cdkDragHandle *ngIf="enable">
             <mat-icon>drag_indicator</mat-icon>
         </div>
         <div class="section-two">

--- a/client/src/app/shared/components/sorting-list/sorting-list.component.ts
+++ b/client/src/app/shared/components/sorting-list/sorting-list.component.ts
@@ -60,6 +60,12 @@ export class SortingListComponent implements OnInit, OnDestroy {
     public count = false;
 
     /**
+     * Can be set to false to disable drag n drop
+     */
+    @Input()
+    public enable = true;
+
+    /**
      * The Input List Values
      *
      * If live updates are enabled, new values are always converted into the sorting array.

--- a/client/src/app/shared/directives/perms.directive.ts
+++ b/client/src/app/shared/directives/perms.directive.ts
@@ -47,6 +47,12 @@ export class PermsDirective implements OnInit, OnDestroy {
      */
     private complement: boolean;
 
+    /**
+     * Add a true-false-condition additional to osPerms
+     * `*osPerms="'motions.can_manage';and:isRecoMode(ChangeRecoMode.Final)"`
+     */
+    private and = true;
+
     private operatorSubscription: Subscription | null;
 
     /**
@@ -111,6 +117,16 @@ export class PermsDirective implements OnInit, OnDestroy {
     }
 
     /**
+     * Comes from the view.
+     * `;and:` turns into osPermsAnd during runtime.
+     */
+    @Input('osPermsAnd')
+    public set osPermsAnd(value: boolean) {
+        this.and = value;
+        this.updateView();
+    }
+
+    /**
      * Shows or hides certain content in the view.
      */
     private updateView(): void {
@@ -133,7 +149,10 @@ export class PermsDirective implements OnInit, OnDestroy {
      * Returns true if the users permissions fit.
      */
     private checkPermissions(): boolean {
-        const hasPerms = this.permissions.length === 0 || this.operator.hasPerms(...this.permissions);
+        const hasPerms = this.and
+            ? this.permissions.length === 0 || this.operator.hasPerms(...this.permissions)
+            : false;
+
         if (this.complement) {
             return !hasPerms;
         } else {

--- a/client/src/app/site/agenda/components/list-of-speakers/list-of-speakers.component.html
+++ b/client/src/app/site/agenda/components/list-of-speakers/list-of-speakers.component.html
@@ -60,7 +60,13 @@
     <!-- Waiting speakers -->
     <div>
         <div class="waiting-list" *ngIf="speakers && speakers.length > 0">
-            <os-sorting-list [input]="speakers" [live]="true" [count]="true" (sortEvent)="onSortingChange($event)">
+            <os-sorting-list
+                [input]="speakers"
+                [live]="true"
+                [count]="true"
+                [enable]="opCanManage()"
+                (sortEvent)="onSortingChange($event)"
+            >
                 <!-- implicit item references into the component using ng-template slot -->
                 <ng-template let-item>
                     <span *osPerms="'agenda.can_manage_list_of_speakers'">

--- a/client/src/app/site/agenda/components/list-of-speakers/list-of-speakers.component.ts
+++ b/client/src/app/site/agenda/components/list-of-speakers/list-of-speakers.component.ts
@@ -176,6 +176,10 @@ export class ListOfSpeakersComponent extends BaseViewComponent implements OnInit
         });
     }
 
+    public opCanManage(): boolean {
+        return this.op.hasPerms('agenda.can_manage_list_of_speakers');
+    }
+
     /**
      * Check the URL to determine a current list of Speakers
      */

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.html
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.html
@@ -495,7 +495,7 @@
                 type="button"
                 mat-icon-button
                 matTooltip="{{ 'Create final print template' | translate }}"
-                *ngIf="isRecoMode(ChangeRecoMode.Final)"
+                *osPerms="'motions.can_manage';and:isRecoMode(ChangeRecoMode.Final)"
                 (click)="createModifiedFinalVersion()"
             >
                 <mat-icon>description</mat-icon>
@@ -878,7 +878,7 @@
     <button
         mat-menu-item
         translate
-        *ngIf="motion?.modified_final_version"
+        *osPerms="'motions.can_manage';and:isRecoMode(ChangeRecoMode.Final)"
         (click)="setChangeRecoMode(ChangeRecoMode.ModifiedFinal)"
         [ngClass]="{ selected: motion?.crMode === ChangeRecoMode.ModifiedFinal }"
     >


### PR DESCRIPTION
Fixes an issue where users without manage rights
were able to use the drag and drop feature of the
list of speakers.
Also hides "modified final version" prints without
sufficient permissions.

Alters OSPerms to support "and" operators,
so "perm" and "other condition" is now possible