### PR TITLE
Motion block permission fixes

### DIFF
--- a/client/src/app/site/motions/modules/motion-block/components/motion-block-detail/motion-block-detail.component.html
+++ b/client/src/app/site/motions/modules/motion-block/components/motion-block-detail/motion-block-detail.component.html
@@ -45,7 +45,9 @@
         <!-- title column -->
         <ng-container matColumnDef="title">
             <mat-header-cell *matHeaderCellDef mat-sort-header> <span translate>Motion</span> </mat-header-cell>
-            <mat-cell *matCellDef="let motion" (click)="onClickMotionTitle(motion)"> {{ motion.title }} </mat-cell>
+            <mat-cell *matCellDef="let motion" (click)="onClickMotionTitle(motion)">
+                {{ motion.getTitle() }}
+            </mat-cell>
         </ng-container>
 
         <!-- state column -->

--- a/client/src/app/site/motions/modules/motion-block/components/motion-block-list/motion-block-list.component.ts
+++ b/client/src/app/site/motions/modules/motion-block/components/motion-block-list/motion-block-list.component.ts
@@ -122,9 +122,12 @@ export class MotionBlockListComponent extends ListViewBaseComponent<ViewMotionBl
      * @returns an array of strings building the column definition
      */
     public getColumnDefinition(): string[] {
-        let columns = ['title', 'amount', 'menu'];
+        let columns = ['title', 'amount'];
         if (this.operator.hasPerms('core.can_manage_projector')) {
             columns = ['projector'].concat(columns);
+        }
+        if (this.operator.hasPerms('motions.can_manage')) {
+            columns = columns.concat(['menu']);
         }
         return columns;
     }

--- a/client/src/app/site/motions/modules/motion-list/components/motion-list/motion-list.component.html
+++ b/client/src/app/site/motions/modules/motion-list/components/motion-list/motion-list.component.html
@@ -165,10 +165,14 @@
                 <mat-icon>device_hub</mat-icon>
                 <span translate>Categories</span>
             </button>
+        </div>
+        <div *ngIf="perms.isAllowed('manage') || motionBlocks.length">
             <button mat-menu-item routerLink="blocks">
                 <mat-icon>widgets</mat-icon>
                 <span translate>Motion blocks</span>
             </button>
+        </div>
+        <div *ngIf="perms.isAllowed('manage')">
             <button mat-menu-item routerLink="statute-paragraphs" *ngIf="statutesEnabled">
                 <mat-icon>account_balance</mat-icon>
                 <span translate>Statute</span>


### PR DESCRIPTION
Adds fixes to motion block permission checks.
Users with "Can See motion"
Can see motion blocks in list view

The menu-column in motion blocks list will be completely hidden
without "Motion Can Manage" permissions

In motion block list view, the motion will be displayed with
identifier rather than just the title