### PR TITLE
Fix a race condition when creating config.key_to_id

### DIFF
--- a/openslides/core/config.py
+++ b/openslides/core/config.py
@@ -68,9 +68,9 @@ class ConfigHandler:
         This uses the element_cache. It expects, that the config values are in the database
         before this is called.
         """
-        self.key_to_id = {}
         all_data = await element_cache.get_all_full_data()
         elements = all_data[self.get_collection_string()]
+        self.key_to_id = {}
         for element in elements:
             self.key_to_id[element["key"]] = element["id"]
 


### PR DESCRIPTION
This fixes a bug that seems to come from redis but was actually in openslides.

With this bug sometimes there comes a KeyError that the dict `key_to_id` does not have the key `general_system_enable_anonymous`.

With this commit this should be fixed.