### PR TITLE
Fix path matching

### DIFF
--- a/client/src/app/site/site-routing.module.ts
+++ b/client/src/app/site/site-routing.module.ts
@@ -16,8 +16,7 @@ const routes: Routes = [
         children: [
             {
                 path: '',
-                loadChildren: './common/os-common.module#OsCommonModule',
-                pathMatch: 'full'
+                loadChildren: './common/os-common.module#OsCommonModule'
             },
             {
                 path: 'agenda',


### PR DESCRIPTION
Fixed an error where navigation to not-lazy-loaded was prevented by full
path-matching.
Was preventing the sites for Search, Legal Notice and PP to show up