### PR TITLE
workflow table state sort

### DIFF
--- a/client/src/app/shared/components/media-upload-content/media-upload-content.component.scss
+++ b/client/src/app/shared/components/media-upload-content/media-upload-content.component.scss
@@ -1,9 +1,9 @@
+@import '~assets/styles/tables.scss';
+
 .table-container {
     overflow: auto;
 
     table {
-        width: 100%;
-
         /** Title */
         .mat-column-title {
             min-width: 100px;

--- a/client/src/app/shared/models/motions/workflow.ts
+++ b/client/src/app/shared/models/motions/workflow.ts
@@ -32,6 +32,13 @@ export class Workflow extends BaseModel<Workflow> {
         return this.states.some(state => state.id === id);
     }
 
+    /**
+     * Sorts the states of this workflow
+     */
+    public sortStates(): void {
+        this.states.sort((a, b) => (a.id > b.id ? 1 : -1));
+    }
+
     public deserialize(input: any): void {
         Object.assign(this, input);
 

--- a/client/src/app/site/motions/models/view-workflow.ts
+++ b/client/src/app/site/motions/models/view-workflow.ts
@@ -57,6 +57,10 @@ export class ViewWorkflow extends BaseViewModel {
         return this.name;
     };
 
+    public sortStates(): void {
+        this.workflow.sortStates();
+    }
+
     /**
      * Updates the local objects if required
      *

--- a/client/src/app/site/motions/modules/motion-workflow/components/workflow-detail/workflow-detail.component.scss
+++ b/client/src/app/site/motions/modules/motion-workflow/components/workflow-detail/workflow-detail.component.scss
@@ -1,10 +1,10 @@
+@import '~assets/styles/tables.scss';
+
 .title-line {
     margin: 20px 25px;
 }
 
 table {
-    width: 100%;
-
     .mat-header-cell {
         min-width: 150px;
         position: relative;

--- a/client/src/app/site/users/components/group-list/group-list.component.scss
+++ b/client/src/app/site/users/components/group-list/group-list.component.scss
@@ -1,6 +1,6 @@
-table {
-    width: 100%;
+@import '~assets/styles/tables.scss';
 
+table {
     .mat-cell {
         min-width: 80px;
     }
@@ -24,7 +24,7 @@ table {
     padding-left: 25px;
 }
 
-.new-group-form {
+.new-group-forrm {
     text-align: center;
     padding-top: 10px;
     background-color: #ffffff; // put in theme later

--- a/client/src/assets/styles/tables.scss
+++ b/client/src/assets/styles/tables.scss
@@ -1,0 +1,10 @@
+// shared definition for most (if not all) used tables
+.mat-table {
+    width: 100%;
+
+    // important is necessary, since the "sticky" attribute does not alter the real `.mat-table-sticky-class`
+    // but rather "patches" the DOM tree.
+    .mat-table-sticky {
+        z-index: 3 !important;
+    }
+}


### PR DESCRIPTION
Sorts the Workflow table to be more predictable

Adds new shared SCSS table rules.
Adds a default with as 100% (there have never been half tables)
Overwrites the rules for sticky tables