### PR TITLE
Cleanup Repos

### DIFF
--- a/client/src/app/app-routing.module.ts
+++ b/client/src/app/app-routing.module.ts
@@ -29,7 +29,7 @@ const routes: Routes = [
 ];
 
 @NgModule({
-    imports: [RouterModule.forRoot(routes)],
+    imports: [RouterModule.forRoot(routes, { onSameUrlNavigation: 'reload' })],
     exports: [RouterModule]
 })
 export class AppRoutingModule {}

--- a/client/src/app/core/core-services/auth-guard.service.ts
+++ b/client/src/app/core/core-services/auth-guard.service.ts
@@ -28,10 +28,6 @@ export class AuthGuard implements CanActivate, CanActivateChild {
     public canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
         const basePerm: string | string[] = route.data.basePerm;
 
-        console.log('Auth guard');
-        console.log('motions.can_see:', this.operator.hasPerms('motions.can_see'));
-        console.log('motions.can_manage:', this.operator.hasPerms('motions.can_manage'));
-
         if (!basePerm) {
             return true;
         } else if (basePerm instanceof Array) {

--- a/client/src/app/core/core-services/data-send.service.ts
+++ b/client/src/app/core/core-services/data-send.service.ts
@@ -32,6 +32,7 @@ export class DataSendService {
 
     /**
      * Function to fully update a model on the server.
+     * TODO: Deprecated (?)
      *
      * @param model The model that is meant to be changed.
      */

--- a/client/src/app/core/core-services/openslides.service.ts
+++ b/client/src/app/core/core-services/openslides.service.ts
@@ -95,7 +95,6 @@ export class OpenSlidesService {
      * @param userId the id or null for guest
      */
     public async afterLoginBootup(userId: number | null): Promise<void> {
-        console.log('user id', userId);
         // Check, which user was logged in last time
         const lastUserId = await this.storageService.get<number>('lastUserLoggedIn');
         // if the user changed, reset the cache and save the new user.

--- a/client/src/app/core/repositories/agenda/item-repository.service.ts
+++ b/client/src/app/core/repositories/agenda/item-repository.service.ts
@@ -2,22 +2,21 @@ import { Injectable } from '@angular/core';
 import { tap, map } from 'rxjs/operators';
 import { Observable } from 'rxjs';
 
+import { BaseAgendaContentObjectRepository } from '../base-agenda-content-object-repository';
 import { BaseRepository } from '../base-repository';
+import { BaseAgendaViewModel } from 'app/site/base/base-agenda-view-model';
+import { BaseViewModel } from 'app/site/base/base-view-model';
 import { CollectionStringMapperService } from '../../core-services/collectionStringMapper.service';
 import { ConfigService } from 'app/core/ui-services/config.service';
 import { DataSendService } from 'app/core/core-services/data-send.service';
 import { DataStoreService } from '../../core-services/data-store.service';
 import { HttpService } from 'app/core/core-services/http.service';
-import { Identifiable } from 'app/shared/models/base/identifiable';
 import { Item } from 'app/shared/models/agenda/item';
 import { OSTreeSortEvent } from 'app/shared/components/sorting-tree/sorting-tree.component';
-import { ViewItem } from 'app/site/agenda/models/view-item';
-import { TreeService } from 'app/core/ui-services/tree.service';
-import { BaseAgendaViewModel } from 'app/site/base/base-agenda-view-model';
-import { ViewModelStoreService } from 'app/core/core-services/view-model-store.service';
-import { BaseViewModel } from 'app/site/base/base-view-model';
 import { TranslateService } from '@ngx-translate/core';
-import { BaseAgendaContentObjectRepository } from '../base-agenda-content-object-repository';
+import { TreeService } from 'app/core/ui-services/tree.service';
+import { ViewItem } from 'app/site/agenda/models/view-item';
+import { ViewModelStoreService } from 'app/core/core-services/view-model-store.service';
 
 /**
  * Repository service for users
@@ -42,13 +41,13 @@ export class ItemRepositoryService extends BaseRepository<ViewItem, Item> {
         DS: DataStoreService,
         mapperService: CollectionStringMapperService,
         viewModelStoreService: ViewModelStoreService,
+        protected dataSend: DataSendService,
         private httpService: HttpService,
         private config: ConfigService,
-        private dataSend: DataSendService,
         private treeService: TreeService,
         private translate: TranslateService
     ) {
-        super(DS, mapperService, viewModelStoreService, Item);
+        super(DS, dataSend, mapperService, viewModelStoreService, Item);
     }
 
     public getVerboseName = (plural: boolean = false) => {
@@ -119,18 +118,6 @@ export class ItemRepositoryService extends BaseRepository<ViewItem, Item> {
     }
 
     /**
-     * Updates an agenda item
-     *
-     * @param update contains the update data
-     * @param viewItem the item to update
-     */
-    public async update(update: Partial<Item>, viewItem: ViewItem): Promise<void> {
-        const updateItem = viewItem.item;
-        updateItem.patchValues(update);
-        return await this.dataSend.partialUpdateModel(updateItem);
-    }
-
-    /**
      * Trigger the automatic numbering sequence on the server
      */
     public async autoNumbering(): Promise<void> {
@@ -148,15 +135,6 @@ export class ItemRepositoryService extends BaseRepository<ViewItem, Item> {
     public async delete(item: ViewItem): Promise<void> {
         const restUrl = `/rest/${item.contentObject.collectionString}/${item.contentObject.id}/`;
         await this.httpService.delete(restUrl);
-    }
-
-    /**
-     * @ignore
-     *
-     * Agenda items are created implicitly and do not have on create functions
-     */
-    public async create(item: Item): Promise<Identifiable> {
-        throw new Error('Method not implemented.');
     }
 
     /**

--- a/client/src/app/core/repositories/agenda/topic-repository.service.ts
+++ b/client/src/app/core/repositories/agenda/topic-repository.service.ts
@@ -2,19 +2,17 @@ import { Injectable } from '@angular/core';
 
 import { TranslateService } from '@ngx-translate/core';
 
-import { Topic } from 'app/shared/models/topics/topic';
-import { Mediafile } from 'app/shared/models/mediafiles/mediafile';
-import { Item } from 'app/shared/models/agenda/item';
+import { BaseAgendaContentObjectRepository } from '../base-agenda-content-object-repository';
+import { CollectionStringMapperService } from 'app/core/core-services/collectionStringMapper.service';
 import { DataStoreService } from 'app/core/core-services/data-store.service';
 import { DataSendService } from 'app/core/core-services/data-send.service';
+import { Item } from 'app/shared/models/agenda/item';
+import { Mediafile } from 'app/shared/models/mediafiles/mediafile';
+import { Topic } from 'app/shared/models/topics/topic';
 import { ViewTopic } from 'app/site/agenda/models/view-topic';
-import { Identifiable } from 'app/shared/models/base/identifiable';
-import { CollectionStringMapperService } from 'app/core/core-services/collectionStringMapper.service';
-import { CreateTopic } from 'app/site/agenda/models/create-topic';
 import { ViewModelStoreService } from 'app/core/core-services/view-model-store.service';
 import { ViewMediafile } from 'app/site/mediafiles/models/view-mediafile';
 import { ViewItem } from 'app/site/agenda/models/view-item';
-import { BaseAgendaContentObjectRepository } from '../base-agenda-content-object-repository';
 
 /**
  * Repository for topics
@@ -34,10 +32,10 @@ export class TopicRepositoryService extends BaseAgendaContentObjectRepository<Vi
         DS: DataStoreService,
         mapperService: CollectionStringMapperService,
         viewModelStoreService: ViewModelStoreService,
-        private dataSend: DataSendService,
+        protected dataSend: DataSendService,
         private translate: TranslateService
     ) {
-        super(DS, mapperService, viewModelStoreService, Topic, [Mediafile, Item]);
+        super(DS, dataSend, mapperService, viewModelStoreService, Topic, [Mediafile, Item]);
     }
 
     public getAgendaTitle = (topic: Partial<Topic> | Partial<ViewTopic>) => {
@@ -67,39 +65,6 @@ export class TopicRepositoryService extends BaseAgendaContentObjectRepository<Vi
         viewTopic.getAgendaTitle = () => this.getAgendaTitle(viewTopic);
         viewTopic.getAgendaTitleWithType = () => this.getAgendaTitle(viewTopic);
         return viewTopic;
-    }
-
-    /**
-     * Save a new topic
-     *
-     * @param topicData Partial topic data to be created
-     * @returns an Identifiable (usually id) as promise
-     */
-    public async create(topic: CreateTopic): Promise<Identifiable> {
-        return await this.dataSend.createModel(topic);
-    }
-
-    /**
-     * Change an existing topic
-     *
-     * @param updateData form value containing the data meant to update the topic
-     * @param viewTopic the topic that should receive the update
-     */
-    public async update(updateData: Partial<Topic>, viewTopic: ViewTopic): Promise<void> {
-        const updateTopic = new Topic();
-        updateTopic.patchValues(viewTopic.topic);
-        updateTopic.patchValues(updateData);
-
-        return await this.dataSend.updateModel(updateTopic);
-    }
-
-    /**
-     * Delete a topic
-     *
-     * @param viewTopic the topic that should be removed
-     */
-    public async delete(viewTopic: ViewTopic): Promise<void> {
-        return await this.dataSend.deleteModel(viewTopic.topic);
     }
 
     /**

--- a/client/src/app/core/repositories/assignments/assignment-repository.service.ts
+++ b/client/src/app/core/repositories/assignments/assignment-repository.service.ts
@@ -2,19 +2,19 @@ import { Injectable } from '@angular/core';
 
 import { TranslateService } from '@ngx-translate/core';
 
-import { ViewAssignment } from 'app/site/assignments/models/view-assignment';
 import { Assignment } from 'app/shared/models/assignments/assignment';
-import { User } from 'app/shared/models/users/user';
-import { Tag } from 'app/shared/models/core/tag';
-import { Item } from 'app/shared/models/agenda/item';
-import { DataStoreService } from '../../core-services/data-store.service';
-import { Identifiable } from 'app/shared/models/base/identifiable';
-import { CollectionStringMapperService } from '../../core-services/collectionStringMapper.service';
-import { ViewModelStoreService } from 'app/core/core-services/view-model-store.service';
-import { ViewItem } from 'app/site/agenda/models/view-item';
-import { ViewUser } from 'app/site/users/models/view-user';
-import { ViewTag } from 'app/site/tags/models/view-tag';
 import { BaseAgendaContentObjectRepository } from '../base-agenda-content-object-repository';
+import { CollectionStringMapperService } from '../../core-services/collectionStringMapper.service';
+import { DataSendService } from 'app/core/core-services/data-send.service';
+import { DataStoreService } from '../../core-services/data-store.service';
+import { Item } from 'app/shared/models/agenda/item';
+import { Tag } from 'app/shared/models/core/tag';
+import { User } from 'app/shared/models/users/user';
+import { ViewAssignment } from 'app/site/assignments/models/view-assignment';
+import { ViewItem } from 'app/site/agenda/models/view-item';
+import { ViewModelStoreService } from 'app/core/core-services/view-model-store.service';
+import { ViewTag } from 'app/site/tags/models/view-tag';
+import { ViewUser } from 'app/site/users/models/view-user';
 
 /**
  * Repository Service for Assignments.
@@ -33,11 +33,12 @@ export class AssignmentRepositoryService extends BaseAgendaContentObjectReposito
      */
     public constructor(
         DS: DataStoreService,
+        dataSend: DataSendService,
         mapperService: CollectionStringMapperService,
         viewModelStoreService: ViewModelStoreService,
         private translate: TranslateService
     ) {
-        super(DS, mapperService, viewModelStoreService, Assignment, [User, Item, Tag]);
+        super(DS, dataSend, mapperService, viewModelStoreService, Assignment, [User, Item, Tag]);
     }
 
     public getAgendaTitle = (assignment: Partial<Assignment> | Partial<ViewAssignment>) => {
@@ -62,17 +63,5 @@ export class AssignmentRepositoryService extends BaseAgendaContentObjectReposito
         viewAssignment.getAgendaTitle = () => this.getAgendaTitle(viewAssignment);
         viewAssignment.getAgendaTitleWithType = () => this.getAgendaTitleWithType(viewAssignment);
         return viewAssignment;
-    }
-
-    public async update(assignment: Partial<Assignment>, viewAssignment: ViewAssignment): Promise<void> {
-        return null;
-    }
-
-    public async delete(viewAssignment: ViewAssignment): Promise<void> {
-        return null;
-    }
-
-    public async create(assignment: Assignment): Promise<Identifiable> {
-        return null;
     }
 }

--- a/client/src/app/core/repositories/base-agenda-content-object-repository.ts
+++ b/client/src/app/core/repositories/base-agenda-content-object-repository.ts
@@ -1,6 +1,7 @@
 import { BaseViewModel } from '../../site/base/base-view-model';
 import { BaseModel, ModelConstructor } from '../../shared/models/base/base-model';
 import { CollectionStringMapperService } from '../core-services/collectionStringMapper.service';
+import { DataSendService } from '../core-services/data-send.service';
 import { DataStoreService } from '../core-services/data-store.service';
 import { ViewModelStoreService } from '../core-services/view-model-store.service';
 import { BaseRepository } from './base-repository';
@@ -21,11 +22,12 @@ export abstract class BaseAgendaContentObjectRepository<
      */
     public constructor(
         DS: DataStoreService,
+        dataSend: DataSendService,
         collectionStringMapperService: CollectionStringMapperService,
         viewModelStoreService: ViewModelStoreService,
         baseModelCtor: ModelConstructor<M>,
         depsModelCtors?: ModelConstructor<BaseModel>[]
     ) {
-        super(DS, collectionStringMapperService, viewModelStoreService, baseModelCtor, depsModelCtors);
+        super(DS, dataSend, collectionStringMapperService, viewModelStoreService, baseModelCtor, depsModelCtors);
     }
 }

--- a/client/src/app/core/repositories/common/chatmessage-repository.service.ts
+++ b/client/src/app/core/repositories/common/chatmessage-repository.service.ts
@@ -1,12 +1,12 @@
 import { Injectable } from '@angular/core';
 import { DataStoreService } from '../../core-services/data-store.service';
 import { BaseRepository } from '../base-repository';
-import { Identifiable } from 'app/shared/models/base/identifiable';
 import { CollectionStringMapperService } from '../../core-services/collectionStringMapper.service';
 import { ChatMessage } from 'app/shared/models/core/chat-message';
 import { ViewChatMessage } from 'app/site/common/models/view-chatmessage';
 import { ViewModelStoreService } from 'app/core/core-services/view-model-store.service';
 import { TranslateService } from '@ngx-translate/core';
+import { DataSendService } from 'app/core/core-services/data-send.service';
 
 @Injectable({
     providedIn: 'root'
@@ -14,11 +14,12 @@ import { TranslateService } from '@ngx-translate/core';
 export class ChatMessageRepositoryService extends BaseRepository<ViewChatMessage, ChatMessage> {
     public constructor(
         DS: DataStoreService,
+        dataSend: DataSendService,
         mapperService: CollectionStringMapperService,
         viewModelStoreService: ViewModelStoreService,
         private translate: TranslateService
     ) {
-        super(DS, mapperService, viewModelStoreService, ChatMessage);
+        super(DS, dataSend, mapperService, viewModelStoreService, ChatMessage);
     }
 
     public getVerboseName = (plural: boolean = false) => {
@@ -29,17 +30,5 @@ export class ChatMessageRepositoryService extends BaseRepository<ViewChatMessage
         const viewChatMessage = new ViewChatMessage(message);
         viewChatMessage.getVerboseName = this.getVerboseName;
         return viewChatMessage;
-    }
-
-    public async create(message: ChatMessage): Promise<Identifiable> {
-        throw new Error('TODO');
-    }
-
-    public async update(message: Partial<ChatMessage>, viewMessage: ViewChatMessage): Promise<void> {
-        throw new Error('TODO');
-    }
-
-    public async delete(viewMessage: ViewChatMessage): Promise<void> {
-        throw new Error('TODO');
     }
 }

--- a/client/src/app/core/repositories/config/config-repository.service.ts
+++ b/client/src/app/core/repositories/config/config-repository.service.ts
@@ -4,10 +4,10 @@ import { Observable, BehaviorSubject } from 'rxjs';
 
 import { BaseRepository } from 'app/core/repositories/base-repository';
 import { Config } from 'app/shared/models/core/config';
+import { DataSendService } from 'app/core/core-services/data-send.service';
 import { DataStoreService } from 'app/core/core-services/data-store.service';
 import { ConstantsService } from 'app/core/ui-services/constants.service';
 import { HttpService } from 'app/core/core-services/http.service';
-import { Identifiable } from 'app/shared/models/base/identifiable';
 import { CollectionStringMapperService } from 'app/core/core-services/collectionStringMapper.service';
 import { ViewModelStoreService } from 'app/core/core-services/view-model-store.service';
 import { ViewConfig } from 'app/site/config/models/view-config';
@@ -97,13 +97,14 @@ export class ConfigRepositoryService extends BaseRepository<ViewConfig, Config> 
      */
     public constructor(
         DS: DataStoreService,
+        dataSend: DataSendService,
         mapperService: CollectionStringMapperService,
         viewModelStoreService: ViewModelStoreService,
         private constantsService: ConstantsService,
         private http: HttpService,
         private translate: TranslateService
     ) {
-        super(DS, mapperService, viewModelStoreService, Config);
+        super(DS, dataSend, mapperService, viewModelStoreService, Config);
 
         this.constantsService.get('OpenSlidesConfigVariables').subscribe(constant => {
             this.createConfigStructure(constant);
@@ -142,6 +143,7 @@ export class ConfigRepositoryService extends BaseRepository<ViewConfig, Config> 
         this.updateConfigListObservable();
 
         // Could be raise in error if the root injector is not known
+        // TODO go over repo
         this.DS.changeObservable.subscribe(model => {
             if (model instanceof Config) {
                 this.viewModelStore[model.id] = this.createViewModel(model as Config);
@@ -217,26 +219,6 @@ export class ConfigRepositoryService extends BaseRepository<ViewConfig, Config> 
         updatedConfig.patchValues(config);
         // TODO: Use datasendService, if it can switch correctly between put, post and patch
         await this.http.put('rest/' + updatedConfig.collectionString + '/' + updatedConfig.key + '/', updatedConfig);
-    }
-
-    /**
-     * This particular function should never be necessary since the creation of config
-     * values is not planed.
-     *
-     * Function exists solely to correctly implement {@link BaseRepository}
-     */
-    public async delete(config: ViewConfig): Promise<void> {
-        throw new Error('Config variables cannot be deleted');
-    }
-
-    /**
-     * This particular function should never be necessary since the creation of config
-     * values is not planed.
-     *
-     * Function exists solely to correctly implement {@link BaseRepository}
-     */
-    public async create(config: Config): Promise<Identifiable> {
-        throw new Error('Config variables cannot be created');
     }
 
     /**

--- a/client/src/app/core/repositories/history/history-repository.service.ts
+++ b/client/src/app/core/repositories/history/history-repository.service.ts
@@ -5,13 +5,13 @@ import { DataStoreService } from 'app/core/core-services/data-store.service';
 import { BaseRepository } from 'app/core/repositories/base-repository';
 import { History } from 'app/shared/models/core/history';
 import { User } from 'app/shared/models/users/user';
-import { Identifiable } from 'app/shared/models/base/identifiable';
 import { HttpService } from 'app/core/core-services/http.service';
 import { ViewHistory } from 'app/site/history/models/view-history';
 import { TimeTravelService } from 'app/core/core-services/time-travel.service';
 import { ViewModelStoreService } from 'app/core/core-services/view-model-store.service';
 import { ViewUser } from 'app/site/users/models/view-user';
 import { TranslateService } from '@ngx-translate/core';
+import { DataSendService } from 'app/core/core-services/data-send.service';
 
 /**
  * Repository for the history.
@@ -32,13 +32,14 @@ export class HistoryRepositoryService extends BaseRepository<ViewHistory, Histor
      */
     public constructor(
         DS: DataStoreService,
+        dataSend: DataSendService,
         mapperService: CollectionStringMapperService,
         viewModelStoreService: ViewModelStoreService,
         private httpService: HttpService,
         private timeTravel: TimeTravelService,
         private translate: TranslateService
     ) {
-        super(DS, mapperService, viewModelStoreService, History, [User]);
+        super(DS, dataSend, mapperService, viewModelStoreService, History, [User]);
     }
 
     public getVerboseName = (plural: boolean = false) => {
@@ -56,22 +57,6 @@ export class HistoryRepositoryService extends BaseRepository<ViewHistory, Histor
         const viewHistory = new ViewHistory(history, user);
         viewHistory.getVerboseName = this.getVerboseName;
         return viewHistory;
-    }
-
-    /**
-     * Clients usually do not need to create a history object themselves
-     * @ignore
-     */
-    public async create(): Promise<Identifiable> {
-        throw new Error('You cannot create a history object');
-    }
-
-    /**
-     * Clients usually do not need to modify existing history objects
-     * @ignore
-     */
-    public async update(): Promise<void> {
-        throw new Error('You cannot update a history object');
     }
 
     /**

--- a/client/src/app/core/repositories/mediafiles/mediafile-repository.service.ts
+++ b/client/src/app/core/repositories/mediafiles/mediafile-repository.service.ts
@@ -32,11 +32,11 @@ export class MediafileRepositoryService extends BaseRepository<ViewMediafile, Me
         DS: DataStoreService,
         mapperService: CollectionStringMapperService,
         viewModelStoreService: ViewModelStoreService,
-        private dataSend: DataSendService,
+        protected dataSend: DataSendService,
         private httpService: HttpService,
         private translate: TranslateService
     ) {
-        super(DS, mapperService, viewModelStoreService, Mediafile, [User]);
+        super(DS, dataSend, mapperService, viewModelStoreService, Mediafile, [User]);
     }
 
     public getVerboseName = (plural: boolean = false) => {
@@ -54,39 +54,6 @@ export class MediafileRepositoryService extends BaseRepository<ViewMediafile, Me
         const viewMediafile = new ViewMediafile(file, uploader);
         viewMediafile.getVerboseName = this.getVerboseName;
         return viewMediafile;
-    }
-
-    /**
-     * Alter a given mediaFile
-     * Usually just i.e change the name and the hidden flag.
-     *
-     * @param file contains the new values
-     * @param viewFile the file that should be updated
-     */
-    public async update(file: Partial<Mediafile>, viewFile: ViewMediafile): Promise<void> {
-        const updateFile = new Mediafile();
-        updateFile.patchValues(viewFile.mediafile);
-        updateFile.patchValues(file);
-        await this.dataSend.updateModel(updateFile);
-    }
-
-    /**
-     * Deletes the given file from the server
-     *
-     * @param file the file to delete
-     */
-    public async delete(file: ViewMediafile): Promise<void> {
-        return await this.dataSend.deleteModel(file.mediafile);
-    }
-
-    /**
-     * Mediafiles are uploaded using FormData objects and (usually) not created locally.
-     *
-     * @param file a new mediafile
-     * @returns the ID as a promise
-     */
-    public async create(file: Mediafile): Promise<Identifiable> {
-        return await this.dataSend.createModel(file);
     }
 
     /**

--- a/client/src/app/core/repositories/motions/category-repository.service.ts
+++ b/client/src/app/core/repositories/motions/category-repository.service.ts
@@ -10,7 +10,6 @@ import { ConfigService } from 'app/core/ui-services/config.service';
 import { DataSendService } from '../../core-services/data-send.service';
 import { DataStoreService } from '../../core-services/data-store.service';
 import { HttpService } from '../../core-services/http.service';
-import { Identifiable } from 'app/shared/models/base/identifiable';
 import { ViewCategory } from 'app/site/motions/models/view-category';
 import { ViewModelStoreService } from 'app/core/core-services/view-model-store.service';
 
@@ -44,12 +43,12 @@ export class CategoryRepositoryService extends BaseRepository<ViewCategory, Cate
         protected DS: DataStoreService,
         mapperService: CollectionStringMapperService,
         viewModelStoreService: ViewModelStoreService,
-        private dataSend: DataSendService,
+        protected dataSend: DataSendService,
         private httpService: HttpService,
         private configService: ConfigService,
         private translate: TranslateService
     ) {
-        super(DS, mapperService, viewModelStoreService, Category);
+        super(DS, dataSend, mapperService, viewModelStoreService, Category);
     }
 
     public getVerboseName = (plural: boolean = false) => {
@@ -60,26 +59,6 @@ export class CategoryRepositoryService extends BaseRepository<ViewCategory, Cate
         const viewCategory = new ViewCategory(category);
         viewCategory.getVerboseName = this.getVerboseName;
         return viewCategory;
-    }
-
-    public async create(newCategory: Category): Promise<Identifiable> {
-        return await this.dataSend.createModel(newCategory);
-    }
-
-    public async update(category: Partial<Category>, viewCategory: ViewCategory): Promise<void> {
-        let updateCategory: Category;
-        if (viewCategory) {
-            updateCategory = viewCategory.category;
-        } else {
-            updateCategory = new Category();
-        }
-        updateCategory.patchValues(category);
-        await this.dataSend.updateModel(updateCategory);
-    }
-
-    public async delete(viewCategory: ViewCategory): Promise<void> {
-        const category = viewCategory.category;
-        await this.dataSend.deleteModel(category);
     }
 
     /**

--- a/client/src/app/core/repositories/motions/change-recommendation-repository.service.ts
+++ b/client/src/app/core/repositories/motions/change-recommendation-repository.service.ts
@@ -47,10 +47,14 @@ export class ChangeRecommendationRepositoryService extends BaseRepository<
         DS: DataStoreService,
         mapperService: CollectionStringMapperService,
         viewModelStoreService: ViewModelStoreService,
-        private dataSend: DataSendService,
+        protected dataSend: DataSendService,
         private translate: TranslateService
     ) {
-        super(DS, mapperService, viewModelStoreService, MotionChangeRecommendation, [Category, User, Workflow]);
+        super(DS, dataSend, mapperService, viewModelStoreService, MotionChangeRecommendation, [
+            Category,
+            User,
+            Workflow
+        ]);
     }
 
     public getVerboseName = (plural: boolean = false) => {
@@ -69,51 +73,12 @@ export class ChangeRecommendationRepositoryService extends BaseRepository<
     }
 
     /**
-     * Creates a change recommendation
-     * Creates a (real) change recommendation and delegates it to the {@link DataSendService}
-     *
-     * @param {MotionChangeRecommendation} changeReco
-     */
-    public async create(changeReco: MotionChangeRecommendation): Promise<Identifiable> {
-        return await this.dataSend.createModel(changeReco);
-    }
-
-    /**
      * Given a change recommendation view object, a entry in the backend is created.
      * @param view
      * @returns The id of the created change recommendation
      */
     public async createByViewModel(view: ViewMotionChangeRecommendation): Promise<Identifiable> {
         return await this.dataSend.createModel(view.changeRecommendation);
-    }
-
-    /**
-     * Deleting a change recommendation.
-     *
-     * Extract the change recommendation out of the viewModel and delegate
-     * to {@link DataSendService}
-     * @param {ViewMotionChangeRecommendation} viewModel
-     */
-    public async delete(viewModel: ViewMotionChangeRecommendation): Promise<void> {
-        await this.dataSend.deleteModel(viewModel.changeRecommendation);
-    }
-
-    /**
-     * updates a change recommendation
-     *
-     * Updates a (real) change recommendation with patched data and delegate it
-     * to the {@link DataSendService}
-     *
-     * @param {Partial<MotionChangeRecommendation>} update the form data containing the update values
-     * @param {ViewMotionChangeRecommendation} viewModel The View Change Recommendation. If not present, a new motion will be created
-     */
-    public async update(
-        update: Partial<MotionChangeRecommendation>,
-        viewModel: ViewMotionChangeRecommendation
-    ): Promise<void> {
-        const changeReco = viewModel.changeRecommendation;
-        changeReco.patchValues(update);
-        await this.dataSend.partialUpdateModel(changeReco);
     }
 
     /**

--- a/client/src/app/core/repositories/motions/motion-block-repository.service.ts
+++ b/client/src/app/core/repositories/motions/motion-block-repository.service.ts
@@ -8,7 +8,6 @@ import { CollectionStringMapperService } from 'app/core/core-services/collection
 import { DataSendService } from 'app/core/core-services/data-send.service';
 import { DataStoreService } from 'app/core/core-services/data-store.service';
 import { HttpService } from 'app/core/core-services/http.service';
-import { Identifiable } from 'app/shared/models/base/identifiable';
 import { Motion } from 'app/shared/models/motions/motion';
 import { MotionBlock } from 'app/shared/models/motions/motion-block';
 import { MotionRepositoryService } from './motion-repository.service';
@@ -39,12 +38,12 @@ export class MotionBlockRepositoryService extends BaseAgendaContentObjectReposit
         DS: DataStoreService,
         mapperService: CollectionStringMapperService,
         viewModelStoreService: ViewModelStoreService,
-        private dataSend: DataSendService,
+        protected dataSend: DataSendService,
         private motionRepo: MotionRepositoryService,
         private httpService: HttpService,
         private translate: TranslateService
     ) {
-        super(DS, mapperService, viewModelStoreService, MotionBlock, [Item]);
+        super(DS, dataSend, mapperService, viewModelStoreService, MotionBlock, [Item]);
     }
 
     public getAgendaTitle = (motionBlock: Partial<MotionBlock> | Partial<ViewMotionBlock>) => {
@@ -72,38 +71,6 @@ export class MotionBlockRepositoryService extends BaseAgendaContentObjectReposit
         viewMotionBlock.getAgendaTitle = () => this.getAgendaTitle(viewMotionBlock);
         viewMotionBlock.getAgendaTitleWithType = () => this.getAgendaTitleWithType(viewMotionBlock);
         return viewMotionBlock;
-    }
-
-    /**
-     * Updates a given motion block
-     *
-     * @param update a partial motion block containing the update data
-     * @param viewBlock the motion block to update
-     */
-    public async update(update: Partial<MotionBlock>, viewBlock: ViewMotionBlock): Promise<void> {
-        const updateMotionBlock = new MotionBlock();
-        updateMotionBlock.patchValues(viewBlock.motionBlock);
-        updateMotionBlock.patchValues(update);
-        return await this.dataSend.updateModel(updateMotionBlock);
-    }
-
-    /**
-     * Deletes a motion block from the server
-     *
-     * @param newBlock the motion block to delete
-     */
-    public async delete(newBlock: ViewMotionBlock): Promise<void> {
-        return await this.dataSend.deleteModel(newBlock.motionBlock);
-    }
-
-    /**
-     * Creates a new motion block to the server
-     *
-     * @param newBlock The new block to create
-     * @returns the ID of the created model as promise
-     */
-    public async create(newBlock: MotionBlock): Promise<Identifiable> {
-        return await this.dataSend.createModel(newBlock);
     }
 
     /**

--- a/client/src/app/core/repositories/motions/motion-comment-section-repository.service.ts
+++ b/client/src/app/core/repositories/motions/motion-comment-section-repository.service.ts
@@ -6,7 +6,6 @@ import { BaseRepository } from '../base-repository';
 import { ViewMotionCommentSection } from 'app/site/motions/models/view-motion-comment-section';
 import { MotionCommentSection } from 'app/shared/models/motions/motion-comment-section';
 import { Group } from 'app/shared/models/users/group';
-import { Identifiable } from 'app/shared/models/base/identifiable';
 import { CollectionStringMapperService } from '../../core-services/collectionStringMapper.service';
 import { HttpService } from 'app/core/core-services/http.service';
 import { ViewModelStoreService } from 'app/core/core-services/view-model-store.service';
@@ -45,11 +44,11 @@ export class MotionCommentSectionRepositoryService extends BaseRepository<
         DS: DataStoreService,
         mapperService: CollectionStringMapperService,
         viewModelStoreService: ViewModelStoreService,
-        private dataSend: DataSendService,
+        protected dataSend: DataSendService,
         private http: HttpService,
         private translate: TranslateService
     ) {
-        super(DS, mapperService, viewModelStoreService, MotionCommentSection, [Group]);
+        super(DS, dataSend, mapperService, viewModelStoreService, MotionCommentSection, [Group]);
     }
 
     public getVerboseName = (plural: boolean = false) => {
@@ -68,42 +67,6 @@ export class MotionCommentSectionRepositoryService extends BaseRepository<
         const viewMotionCommentSection = new ViewMotionCommentSection(section, readGroups, writeGroups);
         viewMotionCommentSection.getVerboseName = this.getVerboseName;
         return viewMotionCommentSection;
-    }
-
-    /**
-     * Creates the Comment Section
-     *
-     * @param section section to be created
-     * @returns the promise to create the comment section
-     */
-    public async create(section: MotionCommentSection): Promise<Identifiable> {
-        return await this.dataSend.createModel(section);
-    }
-
-    /**
-     * Updates an existion CommentSection
-     *
-     * @param section the update that the section should be created on
-     * @param viewSection the view model representation of that section
-     */
-    public async update(section: Partial<MotionCommentSection>, viewSection?: ViewMotionCommentSection): Promise<void> {
-        let updateSection: MotionCommentSection;
-        if (viewSection) {
-            updateSection = viewSection.section;
-        } else {
-            updateSection = new MotionCommentSection();
-        }
-        updateSection.patchValues(section);
-        await this.dataSend.updateModel(updateSection);
-    }
-
-    /**
-     * Deletes a MotionCommentSection
-     *
-     * @param viewSection the view model representation of the model that should be deleted
-     */
-    public async delete(viewSection: ViewMotionCommentSection): Promise<void> {
-        await this.dataSend.deleteModel(viewSection.section);
     }
 
     /**

--- a/client/src/app/core/repositories/motions/motion-repository.service.ts
+++ b/client/src/app/core/repositories/motions/motion-repository.service.ts
@@ -7,12 +7,10 @@ import { tap, map } from 'rxjs/operators';
 import { Category } from 'app/shared/models/motions/category';
 import { ChangeRecoMode, ViewMotion } from 'app/site/motions/models/view-motion';
 import { CollectionStringMapperService } from '../../core-services/collectionStringMapper.service';
-import { CreateMotion } from 'app/site/motions/models/create-motion';
 import { DataSendService } from '../../core-services/data-send.service';
 import { DataStoreService } from '../../core-services/data-store.service';
 import { DiffLinesInParagraph, DiffService, LineRange, ModificationType } from '../../ui-services/diff.service';
 import { HttpService } from 'app/core/core-services/http.service';
-import { Identifiable } from 'app/shared/models/base/identifiable';
 import { Item } from 'app/shared/models/agenda/item';
 import { LinenumberingService } from '../../ui-services/linenumbering.service';
 import { Mediafile } from 'app/shared/models/mediafiles/mediafile';
@@ -75,7 +73,7 @@ export class MotionRepositoryService extends BaseAgendaContentObjectRepository<V
         DS: DataStoreService,
         mapperService: CollectionStringMapperService,
         viewModelStoreService: ViewModelStoreService,
-        private dataSend: DataSendService,
+        protected dataSend: DataSendService,
         private httpService: HttpService,
         private readonly lineNumbering: LinenumberingService,
         private readonly diff: DiffService,
@@ -83,7 +81,7 @@ export class MotionRepositoryService extends BaseAgendaContentObjectRepository<V
         private translate: TranslateService,
         private operator: OperatorService
     ) {
-        super(DS, mapperService, viewModelStoreService, Motion, [
+        super(DS, dataSend, mapperService, viewModelStoreService, Motion, [
             Category,
             User,
             Workflow,
@@ -256,45 +254,6 @@ export class MotionRepositoryService extends BaseAgendaContentObjectRepository<V
                 }
             })
         );
-    }
-
-    /**
-     * Creates a motion
-     * Creates a (real) motion with patched data and delegate it
-     * to the {@link DataSendService}
-     *
-     * @param update the form data containing the updated values
-     * @param viewMotion The View Motion. If not present, a new motion will be created
-     */
-    public async create(motion: CreateMotion): Promise<Identifiable> {
-        // TODO how to handle category id and motion_block id in  CreateMotion?
-        return await this.dataSend.createModel(motion);
-    }
-
-    /**
-     * updates a motion
-     *
-     * Creates a (real) motion with patched data and delegate it
-     * to the {@link DataSendService}
-     *
-     * @param update the form data containing the updated values
-     * @param viewMotion The View Motion. If not present, a new motion will be created
-     */
-    public async update(update: Partial<Motion>, viewMotion: ViewMotion): Promise<void> {
-        const motion = viewMotion.motion;
-        motion.patchValues(update);
-        return await this.dataSend.partialUpdateModel(motion);
-    }
-
-    /**
-     * Deleting a motion.
-     *
-     * Extract the motion out of the motionView and delegate
-     * to {@link DataSendService}
-     * @param viewMotion
-     */
-    public async delete(viewMotion: ViewMotion): Promise<void> {
-        return await this.dataSend.deleteModel(viewMotion.motion);
     }
 
     /**

--- a/client/src/app/core/repositories/motions/statute-paragraph-repository.service.ts
+++ b/client/src/app/core/repositories/motions/statute-paragraph-repository.service.ts
@@ -5,7 +5,6 @@ import { DataStoreService } from '../../core-services/data-store.service';
 import { BaseRepository } from '../base-repository';
 import { ViewStatuteParagraph } from 'app/site/motions/models/view-statute-paragraph';
 import { StatuteParagraph } from 'app/shared/models/motions/statute-paragraph';
-import { Identifiable } from 'app/shared/models/base/identifiable';
 import { CollectionStringMapperService } from '../../core-services/collectionStringMapper.service';
 import { ViewModelStoreService } from 'app/core/core-services/view-model-store.service';
 import { TranslateService } from '@ngx-translate/core';
@@ -34,10 +33,10 @@ export class StatuteParagraphRepositoryService extends BaseRepository<ViewStatut
         DS: DataStoreService,
         mapperService: CollectionStringMapperService,
         viewModelStoreService: ViewModelStoreService,
-        private dataSend: DataSendService,
+        protected dataSend: DataSendService,
         private translate: TranslateService
     ) {
-        super(DS, mapperService, viewModelStoreService, StatuteParagraph);
+        super(DS, dataSend, mapperService, viewModelStoreService, StatuteParagraph);
     }
 
     public getVerboseName = (plural: boolean = false) => {
@@ -48,22 +47,5 @@ export class StatuteParagraphRepositoryService extends BaseRepository<ViewStatut
         const viewStatuteParagraph = new ViewStatuteParagraph(statuteParagraph);
         viewStatuteParagraph.getVerboseName = this.getVerboseName;
         return viewStatuteParagraph;
-    }
-
-    public async create(statuteParagraph: StatuteParagraph): Promise<Identifiable> {
-        return await this.dataSend.createModel(statuteParagraph);
-    }
-
-    public async update(
-        statuteParagraph: Partial<StatuteParagraph>,
-        viewStatuteParagraph: ViewStatuteParagraph
-    ): Promise<void> {
-        const updateParagraph = viewStatuteParagraph.statuteParagraph;
-        updateParagraph.patchValues(statuteParagraph);
-        await this.dataSend.updateModel(updateParagraph);
-    }
-
-    public async delete(viewStatuteParagraph: ViewStatuteParagraph): Promise<void> {
-        await this.dataSend.deleteModel(viewStatuteParagraph.statuteParagraph);
     }
 }

--- a/client/src/app/core/repositories/motions/workflow-repository.service.ts
+++ b/client/src/app/core/repositories/motions/workflow-repository.service.ts
@@ -6,7 +6,6 @@ import { ViewWorkflow } from 'app/site/motions/models/view-workflow';
 import { DataSendService } from '../../core-services/data-send.service';
 import { DataStoreService } from '../../core-services/data-store.service';
 import { BaseRepository } from '../base-repository';
-import { Identifiable } from 'app/shared/models/base/identifiable';
 import { CollectionStringMapperService } from '../../core-services/collectionStringMapper.service';
 import { WorkflowState } from 'app/shared/models/motions/workflow-state';
 import { ViewMotion } from 'app/site/motions/models/view-motion';
@@ -45,12 +44,12 @@ export class WorkflowRepositoryService extends BaseRepository<ViewWorkflow, Work
     public constructor(
         DS: DataStoreService,
         mapperService: CollectionStringMapperService,
-        private httpService: HttpService,
         viewModelStoreService: ViewModelStoreService,
-        private dataSend: DataSendService,
+        protected dataSend: DataSendService,
+        private httpService: HttpService,
         private translate: TranslateService
     ) {
-        super(DS, mapperService, viewModelStoreService, Workflow);
+        super(DS, dataSend, mapperService, viewModelStoreService, Workflow);
         this.viewModelListSubject.pipe(auditTime(1)).subscribe(models => {
             if (models && models.length > 0) {
                 this.initSorting(models);
@@ -85,43 +84,6 @@ export class WorkflowRepositoryService extends BaseRepository<ViewWorkflow, Work
         const viewWorkflow = new ViewWorkflow(workflow);
         viewWorkflow.getVerboseName = this.getVerboseName;
         return viewWorkflow;
-    }
-
-    /**
-     * Creates a new workflow
-     *
-     * @param newWorkflow the workflow to create
-     * @returns the ID of a new workflow as promise
-     */
-    public async create(newWorkflow: Workflow): Promise<Identifiable> {
-        return await this.dataSend.createModel(newWorkflow);
-    }
-
-    /**
-     * Updates the workflow by the given changes
-     *
-     * @param workflow Contains the update
-     * @param viewWorkflow the target workflow
-     */
-    public async update(workflow: Partial<Workflow>, viewWorkflow: ViewWorkflow): Promise<void> {
-        let updateWorkflow: Workflow;
-        if (viewWorkflow) {
-            updateWorkflow = viewWorkflow.workflow;
-        } else {
-            updateWorkflow = new Workflow();
-        }
-        updateWorkflow.patchValues(workflow);
-        await this.dataSend.updateModel(updateWorkflow);
-    }
-
-    /**
-     * Deletes the given workflow
-     *
-     * @param viewWorkflow the workflow to delete
-     */
-    public async delete(viewWorkflow: ViewWorkflow): Promise<void> {
-        const workflow = viewWorkflow.workflow;
-        await this.dataSend.deleteModel(workflow);
     }
 
     /**

--- a/client/src/app/core/repositories/projector/countdown-repository.service.ts
+++ b/client/src/app/core/repositories/projector/countdown-repository.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@angular/core';
 import { DataSendService } from '../../core-services/data-send.service';
 import { DataStoreService } from '../../core-services/data-store.service';
 import { BaseRepository } from '../base-repository';
-import { Identifiable } from 'app/shared/models/base/identifiable';
 import { CollectionStringMapperService } from '../../core-services/collectionStringMapper.service';
 import { ViewCountdown } from 'app/site/projector/models/view-countdown';
 import { Countdown } from 'app/shared/models/core/countdown';
@@ -18,11 +17,11 @@ export class CountdownRepositoryService extends BaseRepository<ViewCountdown, Co
         DS: DataStoreService,
         mapperService: CollectionStringMapperService,
         viewModelStoreService: ViewModelStoreService,
-        private dataSend: DataSendService,
+        protected dataSend: DataSendService,
         private translate: TranslateService,
         private servertimeService: ServertimeService
     ) {
-        super(DS, mapperService, viewModelStoreService, Countdown);
+        super(DS, dataSend, mapperService, viewModelStoreService, Countdown);
     }
 
     public getVerboseName = (plural: boolean = false) => {
@@ -33,20 +32,6 @@ export class CountdownRepositoryService extends BaseRepository<ViewCountdown, Co
         const viewCountdown = new ViewCountdown(countdown);
         viewCountdown.getVerboseName = this.getVerboseName;
         return viewCountdown;
-    }
-
-    public async create(countdown: Countdown): Promise<Identifiable> {
-        return await this.dataSend.createModel(countdown);
-    }
-
-    public async update(countdown: Partial<Countdown>, viewCountdown: ViewCountdown): Promise<void> {
-        const update = viewCountdown.countdown;
-        update.patchValues(countdown);
-        await this.dataSend.updateModel(update);
-    }
-
-    public async delete(countdown: ViewCountdown): Promise<void> {
-        await this.dataSend.deleteModel(countdown.countdown);
     }
 
     public async start(countdown: ViewCountdown): Promise<void> {

--- a/client/src/app/core/repositories/projector/projector-message-repository.service.ts
+++ b/client/src/app/core/repositories/projector/projector-message-repository.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
 import { DataStoreService } from '../../core-services/data-store.service';
 import { BaseRepository } from '../base-repository';
-import { Identifiable } from 'app/shared/models/base/identifiable';
 import { CollectionStringMapperService } from '../../core-services/collectionStringMapper.service';
 import { ProjectorMessage } from 'app/shared/models/core/projector-message';
 import { ViewProjectorMessage } from 'app/site/projector/models/view-projector-message';
@@ -17,10 +16,10 @@ export class ProjectorMessageRepositoryService extends BaseRepository<ViewProjec
         DS: DataStoreService,
         mapperService: CollectionStringMapperService,
         viewModelStoreService: ViewModelStoreService,
-        private translate: TranslateService,
-        private dataSend: DataSendService
+        protected dataSend: DataSendService,
+        private translate: TranslateService
     ) {
-        super(DS, mapperService, viewModelStoreService, ProjectorMessage);
+        super(DS, dataSend, mapperService, viewModelStoreService, ProjectorMessage);
     }
 
     public getVerboseName = (plural: boolean = false) => {
@@ -31,19 +30,5 @@ export class ProjectorMessageRepositoryService extends BaseRepository<ViewProjec
         const viewProjectorMessage = new ViewProjectorMessage(message);
         viewProjectorMessage.getVerboseName = this.getVerboseName;
         return viewProjectorMessage;
-    }
-
-    public async create(message: ProjectorMessage): Promise<Identifiable> {
-        return await this.dataSend.createModel(message);
-    }
-
-    public async update(message: Partial<ProjectorMessage>, viewMessage: ViewProjectorMessage): Promise<void> {
-        const update = viewMessage.projectormessage;
-        update.patchValues(message);
-        await this.dataSend.updateModel(update);
-    }
-
-    public async delete(viewMessage: ViewProjectorMessage): Promise<void> {
-        await this.dataSend.deleteModel(viewMessage.projectormessage);
     }
 }

--- a/client/src/app/core/repositories/projector/projector-repository.service.ts
+++ b/client/src/app/core/repositories/projector/projector-repository.service.ts
@@ -39,11 +39,11 @@ export class ProjectorRepositoryService extends BaseRepository<ViewProjector, Pr
         DS: DataStoreService,
         mapperService: CollectionStringMapperService,
         viewModelStoreService: ViewModelStoreService,
-        private dataSend: DataSendService,
+        protected dataSend: DataSendService,
         private http: HttpService,
         private translate: TranslateService
     ) {
-        super(DS, mapperService, viewModelStoreService, Projector, [Projector]);
+        super(DS, dataSend, mapperService, viewModelStoreService, Projector, [Projector]);
     }
 
     public getVerboseName = (plural: boolean = false) => {
@@ -64,25 +64,6 @@ export class ProjectorRepositoryService extends BaseRepository<ViewProjector, Pr
         projector.patchValues(projectorData);
         projector.elements = [{ name: 'core/clock', stable: true }];
         return await this.dataSend.createModel(projector);
-    }
-
-    /**
-     * Updates a projector.
-     */
-    public async update(projectorData: Partial<Projector>, viewProjector: ViewProjector): Promise<void> {
-        const projector = new Projector();
-        projector.patchValues(viewProjector.projector);
-        projector.patchValues(projectorData);
-        await this.dataSend.updateModel(projector);
-    }
-
-    /**
-     * Deletes a given projector.
-     *
-     * @param projector
-     */
-    public async delete(projector: ViewProjector): Promise<void> {
-        await this.dataSend.deleteModel(projector.projector);
     }
 
     /**

--- a/client/src/app/core/repositories/tags/tag-repository.service.ts
+++ b/client/src/app/core/repositories/tags/tag-repository.service.ts
@@ -5,7 +5,6 @@ import { ViewTag } from 'app/site/tags/models/view-tag';
 import { DataSendService } from '../../core-services/data-send.service';
 import { DataStoreService } from '../../core-services/data-store.service';
 import { BaseRepository } from '../base-repository';
-import { Identifiable } from 'app/shared/models/base/identifiable';
 import { CollectionStringMapperService } from '../../core-services/collectionStringMapper.service';
 import { ViewModelStoreService } from 'app/core/core-services/view-model-store.service';
 import { TranslateService } from '@ngx-translate/core';
@@ -34,13 +33,13 @@ export class TagRepositoryService extends BaseRepository<ViewTag, Tag> {
      * @param dataSend sending changed objects
      */
     public constructor(
-        protected DS: DataStoreService,
+        DS: DataStoreService,
         mapperService: CollectionStringMapperService,
         viewModelStoreService: ViewModelStoreService,
-        private dataSend: DataSendService,
+        protected dataSend: DataSendService,
         private translate: TranslateService
     ) {
-        super(DS, mapperService, viewModelStoreService, Tag);
+        super(DS, dataSend, mapperService, viewModelStoreService, Tag);
     }
 
     public getVerboseName = (plural: boolean = false) => {
@@ -51,22 +50,5 @@ export class TagRepositoryService extends BaseRepository<ViewTag, Tag> {
         const viewTag = new ViewTag(tag);
         viewTag.getVerboseName = this.getVerboseName;
         return viewTag;
-    }
-
-    public async create(update: Tag): Promise<Identifiable> {
-        const newTag = new Tag();
-        newTag.patchValues(update);
-        return await this.dataSend.createModel(newTag);
-    }
-
-    public async update(update: Partial<Tag>, viewTag: ViewTag): Promise<void> {
-        const updateTag = new Tag();
-        updateTag.patchValues(viewTag.tag);
-        updateTag.patchValues(update);
-        await this.dataSend.updateModel(updateTag);
-    }
-
-    public async delete(viewTag: ViewTag): Promise<void> {
-        await this.dataSend.deleteModel(viewTag.tag);
     }
 }

--- a/client/src/app/core/repositories/users/group-repository.service.ts
+++ b/client/src/app/core/repositories/users/group-repository.service.ts
@@ -6,7 +6,6 @@ import { ConstantsService } from '../../ui-services/constants.service';
 import { DataSendService } from '../../core-services/data-send.service';
 import { DataStoreService } from '../../core-services/data-store.service';
 import { Group } from 'app/shared/models/users/group';
-import { Identifiable } from 'app/shared/models/base/identifiable';
 import { ViewGroup } from 'app/site/users/models/view-group';
 import { ViewModelStoreService } from 'app/core/core-services/view-model-store.service';
 import { TranslateService } from '@ngx-translate/core';
@@ -52,11 +51,11 @@ export class GroupRepositoryService extends BaseRepository<ViewGroup, Group> {
         DS: DataStoreService,
         mapperService: CollectionStringMapperService,
         viewModelStoreService: ViewModelStoreService,
-        private dataSend: DataSendService,
+        protected dataSend: DataSendService,
         private constants: ConstantsService,
         private translate: TranslateService
     ) {
-        super(DS, mapperService, viewModelStoreService, Group);
+        super(DS, dataSend, mapperService, viewModelStoreService, Group);
         this.sortPermsPerApp();
     }
 
@@ -160,36 +159,5 @@ export class GroupRepositoryService extends BaseRepository<ViewGroup, Group> {
                 app.permissions = see.concat(manage.concat(others));
             }
         });
-    }
-
-    /**
-     * creates and saves a new user
-     *
-     * @param groupData form value. Usually not yet a real user
-     */
-    public async create(groupData: Partial<Group>): Promise<Identifiable> {
-        const newGroup = new Group();
-        newGroup.patchValues(groupData);
-        return await this.dataSend.createModel(newGroup);
-    }
-
-    /**
-     * Updates the given Group with the new permission
-     *
-     * @param permission the new permission
-     * @param viewGroup the selected Group
-     */
-    public async update(groupData: Partial<Group>, viewGroup: ViewGroup): Promise<void> {
-        const updateGroup = new Group();
-        updateGroup.patchValues(viewGroup.group);
-        updateGroup.patchValues(groupData);
-        await this.dataSend.updateModel(updateGroup);
-    }
-
-    /**
-     * Deletes a given group
-     */
-    public async delete(viewGroup: ViewGroup): Promise<void> {
-        await this.dataSend.deleteModel(viewGroup.group);
     }
 }

--- a/client/src/app/core/repositories/users/personal-note-repository.service.ts
+++ b/client/src/app/core/repositories/users/personal-note-repository.service.ts
@@ -4,10 +4,10 @@ import { DataStoreService } from '../../core-services/data-store.service';
 import { BaseRepository } from '../base-repository';
 import { CollectionStringMapperService } from '../../core-services/collectionStringMapper.service';
 import { PersonalNote } from 'app/shared/models/users/personal-note';
-import { Identifiable } from 'app/shared/models/base/identifiable';
 import { ViewPersonalNote } from 'app/site/users/models/view-personal-note';
 import { ViewModelStoreService } from 'app/core/core-services/view-model-store.service';
 import { TranslateService } from '@ngx-translate/core';
+import { DataSendService } from 'app/core/core-services/data-send.service';
 
 /**
  */
@@ -21,11 +21,12 @@ export class PersonalNoteRepositoryService extends BaseRepository<ViewPersonalNo
      */
     public constructor(
         DS: DataStoreService,
+        dataSend: DataSendService,
         mapperService: CollectionStringMapperService,
         viewModelStoreService: ViewModelStoreService,
         private translate: TranslateService
     ) {
-        super(DS, mapperService, viewModelStoreService, PersonalNote);
+        super(DS, dataSend, mapperService, viewModelStoreService, PersonalNote);
     }
 
     public getVerboseName = (plural: boolean = false) => {
@@ -36,17 +37,5 @@ export class PersonalNoteRepositoryService extends BaseRepository<ViewPersonalNo
         const viewPersonalNote = new ViewPersonalNote(personalNote);
         viewPersonalNote.getVerboseName = this.getVerboseName;
         return viewPersonalNote;
-    }
-
-    public async create(personalNote: PersonalNote): Promise<Identifiable> {
-        throw new Error('Not supported');
-    }
-
-    public async update(personalNote: Partial<PersonalNote>, viewPersonalNote: ViewPersonalNote): Promise<void> {
-        throw new Error('Not supported');
-    }
-
-    public async delete(viewPersonalNote: ViewPersonalNote): Promise<void> {
-        throw new Error('Not supported');
     }
 }

--- a/client/src/app/shared/components/head-bar/head-bar.component.scss
+++ b/client/src/app/shared/components/head-bar/head-bar.component.scss
@@ -6,6 +6,9 @@
 
 .sticky-toolbar {
     position: -webkit-sticky;
+    position: -moz-sticky;
+    position: -ms-sticky;
+    position: -o-sticky;
     position: sticky;
     top: 0px;
     z-index: 3;

--- a/client/src/app/shared/components/search-value-selector/search-value-selector.component.ts
+++ b/client/src/app/shared/components/search-value-selector/search-value-selector.component.ts
@@ -87,7 +87,7 @@ export class SearchValueSelectorComponent implements OnInit, OnDestroy {
             this._inputListSubscription.unsubscribe();
         }
         this._inputListSubject = value;
-        this._inputListSubscription = this._inputListSubject.subscribe(values => {
+        this._inputListSubscription = this._inputListSubject.subscribe(() => {
             this.filterItems();
         });
     }

--- a/client/src/app/site/agenda/components/list-of-speakers/list-of-speakers.component.ts
+++ b/client/src/app/site/agenda/components/list-of-speakers/list-of-speakers.component.ts
@@ -159,9 +159,8 @@ export class ListOfSpeakersComponent extends BaseViewComponent implements OnInit
      */
     public ngOnInit(): void {
         // load and observe users
-        this.users = new BehaviorSubject(this.userRepository.getViewModelList());
-        this.userRepository.getSortedViewModelListObservable().subscribe(users => {
-            this.users.next(users);
+        this.users = this.userRepository.getViewModelListBehaviorSubject();
+        this.userRepository.getViewModelListBehaviorSubject().subscribe(newUsers => {
             if (this.viewItem) {
                 this.setSpeakerList(this.viewItem.id);
             }

--- a/client/src/app/site/agenda/components/topic-detail/topic-detail.component.ts
+++ b/client/src/app/site/agenda/components/topic-detail/topic-detail.component.ts
@@ -96,13 +96,8 @@ export class TopicDetailComponent extends BaseViewComponent {
         this.getTopicByUrl();
         this.createForm();
 
-        this.mediafilesObserver = new BehaviorSubject(this.mediafileRepo.getViewModelList());
-        this.itemObserver = new BehaviorSubject(this.itemRepo.getViewModelList());
-
-        this.mediafileRepo
-            .getViewModelListObservable()
-            .subscribe(mediafiles => this.mediafilesObserver.next(mediafiles));
-        this.itemRepo.getViewModelListObservable().subscribe(items => this.itemObserver.next(items));
+        this.mediafilesObserver = this.mediafileRepo.getViewModelListBehaviorSubject();
+        this.itemObserver = this.itemRepo.getViewModelListBehaviorSubject();
     }
 
     /**

--- a/client/src/app/site/agenda/models/view-create-topic.ts
+++ b/client/src/app/site/agenda/models/view-create-topic.ts
@@ -1,5 +1,6 @@
 import { CreateTopic } from './create-topic';
 import { ViewTopic } from './view-topic';
+import { Topic } from 'app/shared/models/topics/topic';
 
 /**
  * View model for Topic('Agenda item') creation.
@@ -106,6 +107,10 @@ export class ViewCreateTopic extends ViewTopic {
      */
     public constructor(topic: CreateTopic) {
         super(topic);
+    }
+
+    public getModel(): Topic {
+        return super.getModel();
     }
 
     public getVerboseName = () => {

--- a/client/src/app/site/agenda/models/view-item.ts
+++ b/client/src/app/site/agenda/models/view-item.ts
@@ -132,6 +132,10 @@ export class ViewItem extends BaseViewModel {
         this._contentObject = contentObject;
     }
 
+    public getModel(): Item {
+        return this.item;
+    }
+
     public updateDependencies(update: BaseViewModel): boolean {
         if (
             update &&

--- a/client/src/app/site/agenda/models/view-speaker.ts
+++ b/client/src/app/site/agenda/models/view-speaker.ts
@@ -1,6 +1,7 @@
 import { BaseViewModel } from 'app/site/base/base-view-model';
 import { Speaker, SpeakerState } from 'app/shared/models/agenda/speaker';
 import { ViewUser } from 'app/site/users/models/view-user';
+import { User } from 'app/shared/models/users/user';
 
 /**
  * Provides "safe" access to a speaker with all it's components
@@ -69,6 +70,10 @@ export class ViewSpeaker extends BaseViewModel {
     public getTitle = () => {
         return this.name;
     };
+
+    public getModel(): User {
+        return this.user.user;
+    }
 
     /**
      * Speaker is not a base model,

--- a/client/src/app/site/agenda/models/view-topic.ts
+++ b/client/src/app/site/agenda/models/view-topic.ts
@@ -71,6 +71,10 @@ export class ViewTopic extends BaseAgendaViewModel {
         }
     };
 
+    public getModel(): Topic {
+        return this.topic;
+    }
+
     public getAgendaItem(): ViewItem {
         return this.agendaItem;
     }

--- a/client/src/app/site/assignments/models/view-assignment.ts
+++ b/client/src/app/site/assignments/models/view-assignment.ts
@@ -75,6 +75,10 @@ export class ViewAssignment extends BaseAgendaViewModel {
         return this.title;
     };
 
+    public getModel(): Assignment {
+        return this.assignment;
+    }
+
     public formatForSearch(): SearchRepresentation {
         return [this.title];
     }

--- a/client/src/app/site/base/base-view-model.ts
+++ b/client/src/app/site/base/base-view-model.ts
@@ -1,6 +1,7 @@
 import { Displayable } from './displayable';
 import { Identifiable } from '../../shared/models/base/identifiable';
 import { Collection } from 'app/shared/models/base/collection';
+import { BaseModel } from 'app/shared/models/base/base-model';
 
 export interface ViewModelConstructor<T extends BaseViewModel> {
     COLLECTIONSTRING: string;
@@ -55,6 +56,9 @@ export abstract class BaseViewModel implements Displayable, Identifiable, Collec
     public getListTitle: () => string = () => {
         return this.getTitle();
     };
+
+    /** return the main model of a view model */
+    public abstract getModel(): BaseModel;
 
     public abstract updateDependencies(update: BaseViewModel): void;
 

--- a/client/src/app/site/base/base-view.ts
+++ b/client/src/app/site/base/base-view.ts
@@ -35,6 +35,18 @@ export abstract class BaseViewComponent extends BaseComponent implements OnDestr
     }
 
     /**
+     * automatically dismisses the error snack bar and clears subscriptions
+     * if the component is destroyed.
+     */
+    public ngOnDestroy(): void {
+        if (this.messageSnackBar) {
+            this.messageSnackBar.dismiss();
+        }
+
+        this.cleanSubjects();
+    }
+
+    /**
      * Opens the snack bar with the given message.
      * This snack bar will only dismiss if the user clicks the 'OK'-button.
      */
@@ -65,24 +77,23 @@ export abstract class BaseViewComponent extends BaseComponent implements OnDestr
     }
 
     /**
-     * To catch swipe gestures.
-     * Should be overwritten by children which need swipe gestures
+     * Manually clears all stored subscriptions.
+     * Necessary for manual routing control, since the Angular
+     * life cycle does not accept that navigation to the same URL
+     * executes the life cycle again
      */
-    protected swipe(e: TouchEvent, when: string): void {}
-
-    /**
-     * automatically dismisses the error snack bar and clears subscriptions
-     * if the component is destroyed.
-     */
-    public ngOnDestroy(): void {
-        if (this.messageSnackBar) {
-            this.messageSnackBar.dismiss();
-        }
-
+    protected cleanSubjects(): void {
         if (this.subscriptions.length > 0) {
             for (const sub of this.subscriptions) {
                 sub.unsubscribe();
             }
+            this.subscriptions = [];
         }
     }
+
+    /**
+     * To catch swipe gestures.
+     * Should be overwritten by children which need swipe gestures
+     */
+    protected swipe(e: TouchEvent, when: string): void {}
 }

--- a/client/src/app/site/base/list-view-base.ts
+++ b/client/src/app/site/base/list-view-base.ts
@@ -104,7 +104,7 @@ export abstract class ListViewBaseComponent<V extends BaseViewModel, M extends B
     }
 
     /**
-     * Standard sorting function. Siffucient for most list views but can be overwritten
+     * Standard sorting function. Sufficient for most list views but can be overwritten
      */
     protected onSort(): void {
         this.subscriptions.push(

--- a/client/src/app/site/common/components/start/start.component.ts
+++ b/client/src/app/site/common/components/start/start.component.ts
@@ -4,11 +4,11 @@ import { Title } from '@angular/platform-browser';
 import { TranslateService } from '@ngx-translate/core'; // showcase
 
 import { BaseComponent } from 'app/base.component';
+import { ConfigService } from 'app/core/ui-services/config.service';
 
-// for testing the DS and BaseModel
-import { Config } from 'app/shared/models/core/config';
-import { DataStoreService } from 'app/core/core-services/data-store.service';
-
+/**
+ * The start component. Greeting page for OpenSlides
+ */
 @Component({
     selector: 'os-start',
     templateUrl: './start.component.html'
@@ -22,8 +22,9 @@ export class StartComponent extends BaseComponent implements OnInit {
      *
      * @param titleService the title serve
      * @param translate to translation module
+     * @param configService read out config values
      */
-    public constructor(titleService: Title, protected translate: TranslateService, private DS: DataStoreService) {
+    public constructor(titleService: Title, translate: TranslateService, private configService: ConfigService) {
         super(titleService, translate);
     }
 
@@ -31,51 +32,18 @@ export class StartComponent extends BaseComponent implements OnInit {
      * Init the component.
      *
      * Sets the welcomeTitle and welcomeText.
-     * Tries to read them from the DataStore (which will fail initially)
-     * And observes DataStore for changes
-     * Set title and observe DataStore for changes.
      */
     public ngOnInit(): void {
-        // required dummy translation, cause translations for config values were never set
-        // tslint:disable-next-line
-        const welcomeTitleTranslateDummy = this.translate.instant('Welcome to OpenSlides');
         super.setTitle('Home');
-        // set welcome title and text
-        const welcomeTitleConfig = this.DS.filter<Config>(
-            Config,
-            config => config.key === 'general_event_welcome_title'
-        )[0] as Config;
 
-        if (welcomeTitleConfig) {
-            this.welcomeTitle = welcomeTitleConfig.value as string;
-        }
+        // set the welcome title
+        this.configService
+            .get<string>('general_event_welcome_title')
+            .subscribe(welcomeTitle => (this.welcomeTitle = welcomeTitle));
 
-        const welcomeTextConfig = this.DS.filter<Config>(
-            Config,
-            config => config.key === 'general_event_welcome_text'
-        )[0] as Config;
-
-        if (welcomeTextConfig) {
-            this.welcomeText = welcomeTextConfig.value as string;
-        }
-
-        // observe title and text in DS
-        this.DS.changeObservable.subscribe(newModel => {
-            if (newModel instanceof Config) {
-                if (newModel.key === 'general_event_welcome_title') {
-                    this.welcomeTitle = newModel.value as string;
-                } else if (newModel.key === 'general_event_welcome_text') {
-                    this.welcomeText = newModel.value as string;
-                }
-            }
-        });
-    }
-
-    /**
-     * test translations in component
-     */
-    public TranslateTest(): void {
-        console.log('lets translate the word "motion" in the current in the current lang');
-        console.log('Motions in ' + this.translate.currentLang + ' is ' + this.translate.instant('Motions'));
+        // set the welcome text
+        this.configService
+            .get<string>('general_event_welcome_text')
+            .subscribe(welcomeText => (this.welcomeText = welcomeText as string));
     }
 }

--- a/client/src/app/site/common/models/view-chatmessage.ts
+++ b/client/src/app/site/common/models/view-chatmessage.ts
@@ -32,5 +32,9 @@ export class ViewChatMessage extends BaseViewModel {
         return 'Chatmessage';
     };
 
+    public getModel(): ChatMessage {
+        return this.chatmessage;
+    }
+
     public updateDependencies(message: BaseViewModel): void {}
 }

--- a/client/src/app/site/config/models/view-config.ts
+++ b/client/src/app/site/config/models/view-config.ts
@@ -111,6 +111,10 @@ export class ViewConfig extends BaseViewModel {
 
     public updateDependencies(update: BaseViewModel): void {}
 
+    public getModel(): Config {
+        return this.config;
+    }
+
     /**
      * Returns the time this config field needs to debounce before sending a request to the server.
      * A little debounce time for all inputs is given here and is usefull, if inputs sends multiple onChange-events,

--- a/client/src/app/site/history/models/view-history.ts
+++ b/client/src/app/site/history/models/view-history.ts
@@ -113,6 +113,10 @@ export class ViewHistory extends BaseViewModel {
         return this.element_id;
     };
 
+    public getModel(): History {
+        return this.history;
+    }
+
     /**
      * Updates the history object with new values
      *

--- a/client/src/app/site/mediafiles/models/view-mediafile.ts
+++ b/client/src/app/site/mediafiles/models/view-mediafile.ts
@@ -80,6 +80,10 @@ export class ViewMediafile extends BaseProjectableViewModel implements Searchabl
         return this.title;
     };
 
+    public getModel(): Mediafile {
+        return this.mediafile;
+    }
+
     public formatForSearch(): SearchRepresentation {
         const searchValues = [this.title];
         if (this.uploader) {

--- a/client/src/app/site/motions/models/view-category.ts
+++ b/client/src/app/site/motions/models/view-category.ts
@@ -65,6 +65,10 @@ export class ViewCategory extends BaseViewModel implements Searchable {
         return '/motions/category';
     }
 
+    public getModel(): Category {
+        return this.category;
+    }
+
     /**
      * Updates the local objects if required
      * @param update

--- a/client/src/app/site/motions/models/view-change-recommendation.ts
+++ b/client/src/app/site/motions/models/view-change-recommendation.ts
@@ -39,6 +39,10 @@ export class ViewMotionChangeRecommendation extends BaseViewModel implements Vie
 
     public updateDependencies(update: BaseViewModel): void {}
 
+    public getModel(): MotionChangeRecommendation {
+        return this.changeRecommendation;
+    }
+
     public updateChangeReco(type: number, text: string, internal: boolean): void {
         // @TODO HTML sanitazion
         this._changeRecommendation.type = type;

--- a/client/src/app/site/motions/models/view-motion-block.ts
+++ b/client/src/app/site/motions/models/view-motion-block.ts
@@ -81,6 +81,10 @@ export class ViewMotionBlock extends BaseAgendaViewModel implements Searchable {
         return this.title;
     };
 
+    public getModel(): MotionBlock {
+        return this.motionBlock;
+    }
+
     public getSlide(): ProjectorElementBuildDeskriptor {
         return {
             getBasicProjectorElement: options => ({

--- a/client/src/app/site/motions/models/view-motion-comment-section.ts
+++ b/client/src/app/site/motions/models/view-motion-comment-section.ts
@@ -65,6 +65,10 @@ export class ViewMotionCommentSection extends BaseViewModel {
         return this.name;
     };
 
+    public getModel(): MotionCommentSection {
+        return this.section;
+    }
+
     /**
      * Updates the local objects if required
      * @param section

--- a/client/src/app/site/motions/models/view-motion.ts
+++ b/client/src/app/site/motions/models/view-motion.ts
@@ -396,6 +396,10 @@ export class ViewMotion extends BaseAgendaViewModel implements Searchable {
         return this.item;
     }
 
+    public getModel(): Motion {
+        return this.motion;
+    }
+
     /**
      * Formats the category for search
      *

--- a/client/src/app/site/motions/models/view-statute-paragraph.ts
+++ b/client/src/app/site/motions/models/view-statute-paragraph.ts
@@ -49,6 +49,10 @@ export class ViewStatuteParagraph extends BaseViewModel implements Searchable {
         return this.title;
     };
 
+    public getModel(): StatuteParagraph {
+        return this.statuteParagraph;
+    }
+
     public formatForSearch(): SearchRepresentation {
         return [this.title];
     }

--- a/client/src/app/site/motions/models/view-workflow.ts
+++ b/client/src/app/site/motions/models/view-workflow.ts
@@ -61,6 +61,10 @@ export class ViewWorkflow extends BaseViewModel {
         this.workflow.sortStates();
     }
 
+    public getModel(): Workflow {
+        return this.workflow;
+    }
+
     /**
      * Updates the local objects if required
      *

--- a/client/src/app/site/motions/modules/motion-block/components/motion-block-list/motion-block-list.component.ts
+++ b/client/src/app/site/motions/modules/motion-block/components/motion-block-list/motion-block-list.component.ts
@@ -105,9 +105,9 @@ export class MotionBlockListComponent extends ListViewBaseComponent<ViewMotionBl
         super.setTitle('Motion Blocks');
         this.initTable();
 
-        this.items = new BehaviorSubject(this.itemRepo.getViewModelList());
-        this.itemRepo.getViewModelListObservable().subscribe(items => this.items.next(items));
+        this.items = this.itemRepo.getViewModelListBehaviorSubject();
 
+        // TODO: Should fall under generic sorting in PR 4411
         this.repo.getViewModelListObservable().subscribe(newMotionblocks => {
             newMotionblocks.sort((a, b) => (a > b ? 1 : -1));
             this.dataSource.data = newMotionblocks;

--- a/client/src/app/site/motions/modules/motion-comment-section/motion-comment-section-list.component.ts
+++ b/client/src/app/site/motions/modules/motion-comment-section/motion-comment-section-list.component.ts
@@ -74,6 +74,15 @@ export class MotionCommentSectionListComponent extends BaseViewComponent impleme
     }
 
     /**
+     * Init function.
+     */
+    public ngOnInit(): void {
+        super.setTitle('Comment fields');
+        this.groups = this.groupRepo.getViewModelListBehaviorSubject();
+        this.repo.getViewModelListObservable().subscribe(newViewSections => (this.commentSections = newViewSections));
+    }
+
+    /**
      * Event on Key Down in update or create form.
      *
      * @param event the keyboard event
@@ -94,16 +103,6 @@ export class MotionCommentSectionListComponent extends BaseViewComponent impleme
                 this.commentSectionToCreate = null;
             }
         }
-    }
-
-    /**
-     * Init function.
-     */
-    public ngOnInit(): void {
-        super.setTitle('Comment fields');
-        this.groups = new BehaviorSubject(this.groupRepo.getViewModelList());
-        this.groupRepo.getViewModelListObservable().subscribe(groups => this.groups.next(groups));
-        this.repo.getViewModelListObservable().subscribe(newViewSections => (this.commentSections = newViewSections));
     }
 
     /**

--- a/client/src/app/site/motions/modules/motion-detail/components/manage-submitters/manage-submitters.component.ts
+++ b/client/src/app/site/motions/modules/motion-detail/components/manage-submitters/manage-submitters.component.ts
@@ -97,8 +97,7 @@ export class ManageSubmittersComponent extends BaseViewComponent {
         this.addSubmitterForm.reset();
 
         // get all users for the submitter add form
-        this.users = new BehaviorSubject<ViewUser[]>(this.userRepository.getViewModelList());
-        this.userRepository.getViewModelListObservable().subscribe(users => this.users.next(users));
+        this.users = this.userRepository.getViewModelListBehaviorSubject();
     }
 
     /**

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.html
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.html
@@ -494,7 +494,9 @@
                 mat-icon-button
                 [matMenuTriggerFor]="changeRecoMenu"
                 matTooltip="{{ 'Change recommendations' | translate }}"
-                *ngIf="motion && !motion.isParagraphBasedAmendment() && allChangingObjects.length > 0"
+                *ngIf="
+                    motion && !motion.isParagraphBasedAmendment() && allChangingObjects && allChangingObjects.length > 0
+                "
             >
                 <mat-icon>rate_review</mat-icon>
             </button>
@@ -503,7 +505,7 @@
                 type="button"
                 mat-icon-button
                 matTooltip="{{ 'Create final print template' | translate }}"
-                *osPerms="'motions.can_manage';and:isRecoMode(ChangeRecoMode.Final)"
+                *osPerms="'motions.can_manage'; and: isRecoMode(ChangeRecoMode.Final)"
                 (click)="createModifiedFinalVersion()"
             >
                 <mat-icon>description</mat-icon>
@@ -886,7 +888,7 @@
     <button
         mat-menu-item
         translate
-        *osPerms="'motions.can_manage';and:isRecoMode(ChangeRecoMode.Final)"
+        *osPerms="'motions.can_manage'; and: isRecoMode(ChangeRecoMode.Final)"
         (click)="setChangeRecoMode(ChangeRecoMode.ModifiedFinal)"
         [ngClass]="{ selected: motion?.crMode === ChangeRecoMode.ModifiedFinal }"
     >

--- a/client/src/app/site/motions/modules/motion-detail/motion-detail-routing.module.ts
+++ b/client/src/app/site/motions/modules/motion-detail/motion-detail-routing.module.ts
@@ -5,7 +5,7 @@ import { MotionDetailComponent } from './components/motion-detail/motion-detail.
 import { AmendmentCreateWizardComponent } from './components/amendment-create-wizard/amendment-create-wizard.component';
 
 const routes: Routes = [
-    { path: '', component: MotionDetailComponent, pathMatch: 'full' },
+    { path: '', component: MotionDetailComponent, pathMatch: 'full', runGuardsAndResolvers: 'paramsChange' },
     { path: 'create-amendment', component: AmendmentCreateWizardComponent }
 ];
 

--- a/client/src/app/site/motions/motions-routing.module.ts
+++ b/client/src/app/site/motions/motions-routing.module.ts
@@ -41,7 +41,8 @@ const routes: Routes = [
     },
     {
         path: ':id',
-        loadChildren: './modules/motion-detail/motion-detail.module#MotionDetailModule'
+        loadChildren: './modules/motion-detail/motion-detail.module#MotionDetailModule',
+        runGuardsAndResolvers: 'paramsChange'
     }
 ];
 

--- a/client/src/app/site/projector/models/view-countdown.ts
+++ b/client/src/app/site/projector/models/view-countdown.ts
@@ -54,6 +54,10 @@ export class ViewCountdown extends BaseProjectableViewModel {
         return this.description ? `${this.title} (${this.description})` : this.title;
     };
 
+    public getModel(): Countdown {
+        return this.countdown;
+    }
+
     public updateDependencies(update: BaseViewModel): void {}
 
     public getSlide(): ProjectorElementBuildDeskriptor {

--- a/client/src/app/site/projector/models/view-projector-message.ts
+++ b/client/src/app/site/projector/models/view-projector-message.ts
@@ -35,6 +35,10 @@ export class ViewProjectorMessage extends BaseProjectableViewModel {
         return 'Message';
     };
 
+    public getModel(): ProjectorMessage {
+        return this.projectormessage;
+    }
+
     public updateDependencies(update: BaseViewModel): void {}
 
     public getSlide(): ProjectorElementBuildDeskriptor {

--- a/client/src/app/site/projector/models/view-projector.ts
+++ b/client/src/app/site/projector/models/view-projector.ts
@@ -106,6 +106,10 @@ export class ViewProjector extends BaseViewModel {
         return this.name;
     };
 
+    public getModel(): Projector {
+        return this.projector;
+    }
+
     public updateDependencies(update: BaseViewModel): void {
         if (update instanceof ViewProjector && this.reference_projector_id === update.id) {
             this._referenceProjector = update;

--- a/client/src/app/site/tags/models/view-tag.ts
+++ b/client/src/app/site/tags/models/view-tag.ts
@@ -41,6 +41,10 @@ export class ViewTag extends BaseViewModel implements Searchable {
         return this.name;
     };
 
+    public getModel(): Tag {
+        return this.tag;
+    }
+
     public formatForSearch(): SearchRepresentation {
         return [this.name];
     }

--- a/client/src/app/site/users/components/group-list/group-list.component.ts
+++ b/client/src/app/site/users/components/group-list/group-list.component.ts
@@ -107,7 +107,7 @@ export class GroupListComponent extends BaseViewComponent implements OnInit {
         if (!this.groupForm.value || !this.groupForm.valid) {
             return;
         }
-        this.repo.create(this.groupForm.value).then(() => {
+        this.repo.create(this.groupForm.value as Group).then(() => {
             this.groupForm.reset();
             this.cancelEditing();
         }, this.raiseError);

--- a/client/src/app/site/users/models/view-csv-create-user.ts
+++ b/client/src/app/site/users/models/view-csv-create-user.ts
@@ -41,6 +41,10 @@ export class ViewCsvCreateUser extends ViewUser {
         super(user);
     }
 
+    public getModel(): User {
+        return super.getModel();
+    }
+
     /**
      * takes a list of solved group maps to update. Returns the amount of
      * entries that remain unmatched

--- a/client/src/app/site/users/models/view-group.ts
+++ b/client/src/app/site/users/models/view-group.ts
@@ -76,6 +76,10 @@ export class ViewGroup extends BaseViewModel {
         return this.name;
     };
 
+    public getModel(): Group {
+        return this.group;
+    }
+
     public updateDependencies(update: BaseViewModel): void {
         console.log('ViewGroups wants to update Values with : ', update);
     }

--- a/client/src/app/site/users/models/view-personal-note.ts
+++ b/client/src/app/site/users/models/view-personal-note.ts
@@ -36,5 +36,9 @@ export class ViewPersonalNote extends BaseViewModel {
         return this.personalNote ? this.personalNote.toString() : null;
     };
 
+    public getModel(): PersonalNote {
+        return this.personalNote;
+    }
+
     public updateDependencies(update: BaseViewModel): void {}
 }

--- a/client/src/app/site/users/models/view-user.ts
+++ b/client/src/app/site/users/models/view-user.ts
@@ -179,6 +179,10 @@ export class ViewUser extends BaseProjectableViewModel implements Searchable {
         this._groups = groups;
     }
 
+    public getModel(): User {
+        return this.user;
+    }
+
     /**
      * Formats the category for search
      *


### PR DESCRIPTION
Add an getViewModelListBehaviorSubject that simplifies
how to get most model lists in the view

unified update, delete and create methods and removed redundant code from the repos
(where it was possible)

cleaned up the motion detail to not directly use the DataStore

Add information about the "main model" to all ViewModels, to call the
correct constructor in the BaseRepo

Briefly tested all the creation and delteion