### PR TITLE
Fix websocket connection for port 80

### DIFF
--- a/client/src/app/core/core-services/websocket.service.ts
+++ b/client/src/app/core/core-services/websocket.service.ts
@@ -138,7 +138,7 @@ export class WebsocketService {
 
         // Create the websocket
         let socketPath = location.protocol === 'https:' ? 'wss://' : 'ws://';
-        socketPath += window.location.hostname + ':' + window.location.port + '/ws/';
+        socketPath += window.location.host + '/ws/';
         socketPath += formatQueryParams(queryParams);
 
         this.websocket = new WebSocket(socketPath);


### PR DESCRIPTION
port 80 was interpretet as `http://<IP>:/ws` before.
Certain browser did not like the colon...