### PR TITLE
More flexible parsing of font sizes and margins

### DIFF
--- a/client/src/app/core/ui-services/html-to-pdf.service.ts
+++ b/client/src/app/core/ui-services/html-to-pdf.service.ts
@@ -603,11 +603,11 @@ export class HtmlToPdfService {
                 if (styleDefinition.length === 2) {
                     switch (key) {
                         case 'padding-left': {
-                            styleObject.margin = [+value, 0, 0, 0];
+                            styleObject.margin = [parseFloat(value), 0, 0, 0];
                             break;
                         }
                         case 'font-size': {
-                            styleObject.fontSize = +value;
+                            styleObject.fontSize = parseFloat(value);
                             break;
                         }
                         case 'text-align': {


### PR DESCRIPTION
I noticed that I got NaN for font-size in case my text style was for example "font-size: 12px".
That is because +'12px' results in NaN
When using parseFloat instead, 12px would just become 12 instead of NaN.
parseFloat is available on all browsers according to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseFloat , so its safe to use...