### PR TITLE
Show sequential number in motion list

### DIFF
--- a/client/src/app/site/base/list-view-base.ts
+++ b/client/src/app/site/base/list-view-base.ts
@@ -163,6 +163,12 @@ export abstract class ListViewBaseComponent<V extends BaseViewModel, M extends B
         this.dataSource.paginator = this.paginator;
     }
 
+    /**
+     * Central search/filter function. Can be extended and overwritten by a filterPredicate.
+     * Functions for that are usually called 'setFulltextFilter'
+     *
+     * @param event the string to search for
+     */
     public searchFilter(event: string): void {
         this.dataSource.filter = event;
     }

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.html
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.html
@@ -683,18 +683,18 @@
             ></os-search-value-selector>
         </div>
 
-        <div class="extra-data" *osPerms="'motion.can_manage'">
+        <div class="extra-data">
             <!-- Attachments -->
             <div *ngIf="motion.hasAttachments() || editMotion" class="content-field">
                 <div *ngIf="!editMotion">
                     <h3>{{ 'Attachments' | translate }}<mat-icon>attach_file</mat-icon></h3>
                     <mat-list dense>
                         <mat-list-item *ngFor="let file of motion.attachments">
-                            <a [routerLink]="" (click)="onClickAttacment(file)">{{ file.title }}</a>
+                            <a [routerLink]="" (click)="onClickAttachment(file)">{{ file.title }}</a>
                         </mat-list-item>
                     </mat-list>
                 </div>
-                <div *ngIf="editMotion" class="shortened-selector">
+                <div *osPerms="'motions.can_manage';and:editMotion" class="shortened-selector">
                     <os-search-value-selector
                         class="selector"
                         ngDefaultControl

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.ts
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.ts
@@ -1294,7 +1294,7 @@ export class MotionDetailComponent extends BaseViewComponent implements OnInit, 
      *
      * @param attachment the selected file
      */
-    public onClickAttacment(attachment: Mediafile): void {
+    public onClickAttachment(attachment: Mediafile): void {
         window.open(attachment.downloadUrl);
     }
 

--- a/client/src/app/site/motions/modules/motion-list/components/motion-list/motion-list.component.html
+++ b/client/src/app/site/motions/modules/motion-list/components/motion-list/motion-list.component.html
@@ -75,6 +75,11 @@
                     <!-- submitters line -->
                     <div class="submitters-line ellipsis-overflow" *ngIf="motion.submitters.length">
                         <span translate>by</span> {{ motion.submitters }}
+                        <span *osPerms="'motions.can_manage'">
+                            &middot;
+                            <span translate>Sequential number</span>
+                            {{ motion.id }}
+                        </span>
                     </div>
                     <!-- state line-->
                     <div class="ellipsis-overflow white">

--- a/client/src/app/site/motions/modules/motion-list/components/motion-list/motion-list.component.ts
+++ b/client/src/app/site/motions/modules/motion-list/components/motion-list/motion-list.component.ts
@@ -295,7 +295,7 @@ export class MotionListComponent extends ListViewBaseComponent<ViewMotion, Motio
 
     /**
      * Overwrites the dataSource's string filter with a case-insensitive search
-     * in the identifier, title, state, recommendations, submitters and motion blocks
+     * in the identifier, title, state, recommendations, submitters, motion blocks and id
      */
     private setFulltextFilter(): void {
         this.dataSource.filterPredicate = (data, filter) => {
@@ -332,6 +332,12 @@ export class MotionListComponent extends ListViewBaseComponent<ViewMotion, Motio
             if (data.identifier && data.identifier.toLowerCase().includes(filter)) {
                 return true;
             }
+
+            const dataid = '' + data.id;
+            if (dataid.includes(filter)) {
+                return true;
+            }
+
             return false;
         };
     }


### PR DESCRIPTION
Shows the sequential number (ID) in motion list
~~- under the submitters.~~
~~- under the identifier~~
next to the submitters!

~~I would prefer to not show it at all, but from the both possible solutions, it seems better to put it under the submitter.~~
~~Decide where to put this information~~