### PR TITLE
Update django and other dependencys

### DIFF
--- a/requirements/big_mode.txt
+++ b/requirements/big_mode.txt
@@ -1,7 +1,7 @@
 # Requirements for Redis and PostgreSQL support
 channels-redis>=2.2,<2.4
 django-redis-sessions>=0.6.1,<0.7
-psycopg2-binary>=2.7.3.2,<2.8
+psycopg2-binary>=2.7.3.2,<2.9
 aioredis>=1.1.0,<1.3
 
 # Requirements for fast asgi server

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -2,12 +2,12 @@
 bleach>=1.5.0,<3.2
 channels>=2.1.2,<2.2
 daphne>=2.2,<2.3
-Django>=1.11.17,<2.2
+Django>=2.1,<2.3
 djangorestframework>=3.4,<3.10
 jsonfield2>=3.0,<3.1
 jsonschema>=3.0,<3.1
 mypy_extensions>=0.4,<0.5
 PyPDF2>=1.26,<1.27
 roman>=2.0,<3.2
-setuptools>=29.0,<41.0
+setuptools>=29.0,<42.0
 typing_extensions>=3.6.6,<3.8


### PR DESCRIPTION
The update to django was not a problem at all. 

See https://www.djangoproject.com/download/ for all supported django versions.

Django 2.0 is not supported anymore. We could drop django 1.11 and 2.0 before the release. What do you think?