### PR TITLE
Fixes error from `mediafile-list.component` when logging out

### DIFF
--- a/client/src/app/core/ui-services/media-manage.service.ts
+++ b/client/src/app/core/ui-services/media-manage.service.ts
@@ -117,7 +117,7 @@ export class MediaManageService {
      * @param action the logo action or font action
      * @returns A media config object containing the requested values
      */
-    public getMediaConfig(action: string): ImageConfigObject | FontConfigObject {
+    public getMediaConfig(action: string): ImageConfigObject | FontConfigObject | null {
         return this.config.instant(action);
     }
 }

--- a/client/src/app/site/mediafiles/components/mediafile-list/mediafile-list.component.ts
+++ b/client/src/app/site/mediafiles/components/mediafile-list/mediafile-list.component.ts
@@ -239,7 +239,7 @@ export class MediafileListComponent extends ListViewBaseComponent<ViewMediafile,
      */
     public isUsedAs(file: ViewMediafile, mediaFileAction: string): boolean {
         const config = this.mediaManage.getMediaConfig(mediaFileAction);
-        return config.path === file.downloadUrl;
+        return config ? config.path === file.downloadUrl : false;
     }
 
     /**


### PR DESCRIPTION
- If the user is seeing the mediafiles and wants to log out, an error occurred causing by querying an attribute from undefined object.