### PR TITLE
personal note pdf only if personal note is present

### DIFF
--- a/client/src/app/site/motions/modules/motion-detail/components/personal-note/personal-note.component.html
+++ b/client/src/app/site/motions/modules/motion-detail/components/personal-note/personal-note.component.html
@@ -25,7 +25,8 @@
         matTooltip="{{ 'Edit' | translate }}">
             <mat-icon>edit</mat-icon>
         </button>
-        <button mat-icon-button *ngIf="!isEditMode && motion && motion.personalNote" (click)="printPersonalNote()"
+        <button mat-icon-button *ngIf="!isEditMode && motion && motion.personalNote && motion.personalNote.note"
+        (click)="printPersonalNote()"
         matTooltip="{{ 'Export personal note only' | translate }}">
             <mat-icon>picture_as_pdf</mat-icon>
         </button>


### PR DESCRIPTION
small one-liner
(right now personal note pdf also activates if the motion is 'favorite', but has no notes)