### PR TITLE
copy parent's tags to a new amendment

### DIFF
--- a/client/src/app/site/motions/modules/motion-detail/components/amendment-create-wizard/amendment-create-wizard.component.ts
+++ b/client/src/app/site/motions/modules/motion-detail/components/amendment-create-wizard/amendment-create-wizard.component.ts
@@ -212,6 +212,7 @@ export class AmendmentCreateWizardComponent extends BaseViewComponent {
             text: text, // Workaround as 'text' is required from the backend
             parent_id: this.motion.id,
             category_id: this.motion.category_id,
+            tags_id: this.motion.tags_id,
             motion_block_id: this.motion.motion_block_id,
             amendment_paragraphs: amendedParagraphs
         };

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.ts
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.ts
@@ -617,12 +617,14 @@ export class MotionDetailComponent extends BaseViewComponent implements OnInit, 
                     defaultMotion.title = defaultTitle;
                     defaultMotion.parent_id = parentMotion.id;
                     defaultMotion.category_id = parentMotion.category_id;
+                    defaultMotion.tags_id = parentMotion.tags_id;
                     defaultMotion.motion_block_id = parentMotion.motion_block_id;
                     this.contentForm.patchValue({
                         title: defaultTitle,
                         category_id: parentMotion.category_id,
                         motion_block_id: parentMotion.motion_block_id,
-                        parent_id: parentMotion.id
+                        parent_id: parentMotion.id,
+                        tags_id: parentMotion.tags_id
                     });
                 }
                 if (mode === 'fulltext') {
@@ -697,6 +699,7 @@ export class MotionDetailComponent extends BaseViewComponent implements OnInit, 
             submitters_id: [],
             supporters_id: [[]],
             workflow_id: [],
+            tags_id: [],
             origin: [''],
             selected_paragraphs: [],
             statute_amendment: [''], // Internal value for the checkbox, not saved to the model


### PR DESCRIPTION
A newly created amendment should, by default, inherit the tags of their parent motion.

This will fix empty 'subheader lines' in call lists (which are really empty subheader lines of 'no tag')