### PR TITLE
Temp Fix creation of Workflow States

### DIFF
--- a/client/src/app/core/repositories/motions/workflow-repository.service.ts
+++ b/client/src/app/core/repositories/motions/workflow-repository.service.ts
@@ -95,6 +95,8 @@ export class WorkflowRepositoryService extends BaseRepository<ViewWorkflow, Work
     public async addState(stateName: string, viewWorkflow: ViewWorkflow): Promise<void> {
         const newStatePayload = {
             name: stateName,
+            // TODO: The server requires a string-array of restrictions. Should really not be necessary
+            restriction: [],
             workflow_id: viewWorkflow.id
         };
         await this.httpService.post(this.restStateUrl, newStatePayload);

--- a/client/src/app/site/motions/modules/motion-workflow/components/workflow-detail/workflow-detail.component.ts
+++ b/client/src/app/site/motions/modules/motion-workflow/components/workflow-detail/workflow-detail.component.ts
@@ -49,7 +49,7 @@ interface AmendmentIntoFinal {
 }
 
 /**
- * Defines the structre of restrictions
+ * Defines the structure of restrictions
  */
 interface Restriction {
     key: string;
@@ -107,7 +107,7 @@ export class WorkflowDetailComponent extends BaseViewComponent implements OnInit
             selector: 'show_recommendation_extension_field',
             type: 'check'
         },
-        { name: 'Show amendment in parent motoin', selector: 'merge_amendment_into_final', type: 'amendment' },
+        { name: 'Show amendment in parent motion', selector: 'merge_amendment_into_final', type: 'amendment' },
         { name: 'Restrictions', selector: 'restriction', type: 'restriction' },
         { name: 'Label color', selector: 'css_class', type: 'color' },
         { name: 'Next states', selector: 'next_states_id', type: 'state' }


### PR DESCRIPTION
Offers an empty error during the creation of new workflow states.

This should really nor be necessary. The server has to accept new workflow states without manually setting restrictions.