### PR TITLE
Adjust the export order and dialog order

### DIFF
--- a/client/src/app/site/motions/modules/motion-list/components/motion-export-dialog/motion-export-dialog.component.html
+++ b/client/src/app/site/motions/modules/motion-list/components/motion-export-dialog/motion-export-dialog.component.html
@@ -46,17 +46,12 @@
         <div>
             <p class="toggle-group-head" translate>Meta information</p>
             <mat-button-toggle-group class="smaller-buttons" multiple formControlName="metaInfo">
-                <mat-button-toggle value="submitters"> <span translate>Submitters</span> </mat-button-toggle>
-                <mat-button-toggle value="state"> <span translate>State</span> </mat-button-toggle>
-                <mat-button-toggle value="recommendation"> <span translate>Recommendation</span> </mat-button-toggle>
-                <mat-button-toggle value="category"> <span translate>Category</span> </mat-button-toggle>
-                <mat-button-toggle value="tags"> <span translate>Tags</span> </mat-button-toggle>
-                <mat-button-toggle value="origin"> <span translate>Origin</span> </mat-button-toggle>
-                <mat-button-toggle value="motion_block"> <span translate>Motion block</span> </mat-button-toggle>
+                <mat-button-toggle *ngFor="let metaInfo of metaInfoExportOrder" [value]="metaInfo">
+                    <span translate>{{ getLabelForMetadata(metaInfo) }}</span>
+                </mat-button-toggle>
                 <mat-button-toggle value="polls" #votingResultButton>
                     <span translate>Voting result</span>
                 </mat-button-toggle>
-                <mat-button-toggle value="id"><span translate>Sequential number</span></mat-button-toggle>
             </mat-button-toggle-group>
         </div>
         <div *ngIf="commentsToExport.length && exportForm.get('format').value === 'pdf'">

--- a/client/src/app/site/motions/modules/motion-list/components/motion-export-dialog/motion-export-dialog.component.ts
+++ b/client/src/app/site/motions/modules/motion-list/components/motion-export-dialog/motion-export-dialog.component.ts
@@ -7,6 +7,7 @@ import { MotionCommentSectionRepositoryService } from 'app/core/repositories/mot
 import { LineNumberingMode, ChangeRecoMode } from 'app/site/motions/models/view-motion';
 import { InfoToExport } from 'app/site/motions/services/motion-pdf.service';
 import { ViewMotionCommentSection } from 'app/site/motions/models/view-motion-comment-section';
+import { motionImportExportHeaderOrder, noMetaData } from 'app/site/motions/motion-import-export-order';
 
 /**
  * Dialog component to determine exporting.
@@ -41,6 +42,11 @@ export class MotionExportDialogComponent implements OnInit {
      * Determine the default content to export.
      */
     private defaultContentToExport = ['text', 'reason'];
+
+    /**
+     * Determine the export order of the meta data
+     */
+    public metaInfoExportOrder: string[];
 
     /**
      * Determine the default meta info to export.
@@ -104,6 +110,10 @@ export class MotionExportDialogComponent implements OnInit {
     ) {
         this.defaultLnMode = this.configService.instant('motions_default_line_numbering');
         this.defaultCrMode = this.configService.instant('motions_recommendation_text_mode');
+        // Get the export order, exclude everything that does not count as meta-data
+        this.metaInfoExportOrder = motionImportExportHeaderOrder.filter(metaData => {
+            return !noMetaData.some(noMeta => metaData === noMeta);
+        });
         this.createForm();
     }
 
@@ -194,5 +204,25 @@ export class MotionExportDialogComponent implements OnInit {
      */
     public onCloseClick(): void {
         this.dialogRef.close();
+    }
+
+    /**
+     * Gets the untranslated label for metaData
+     */
+    public getLabelForMetadata(metaDataName: string): string {
+        switch (metaDataName) {
+            case 'polls': {
+                return 'Voting result';
+            }
+            case 'id': {
+                return 'Sequential number';
+            }
+            case 'motion_block': {
+                return 'Motion block';
+            }
+            default: {
+                return metaDataName.charAt(0).toUpperCase() + metaDataName.slice(1);
+            }
+        }
     }
 }

--- a/client/src/app/site/motions/modules/motion-list/components/motion-list/motion-list.component.ts
+++ b/client/src/app/site/motions/modules/motion-list/components/motion-list/motion-list.component.ts
@@ -260,8 +260,7 @@ export class MotionListComponent extends ListViewBaseComponent<ViewMotion, Motio
                         result.comments
                     );
                 } else if (result.format === 'csv') {
-                    const content = ['identifier', ...result.content, ...result.metaInfo];
-                    this.motionCsvExport.exportMotionList(data, content);
+                    this.motionCsvExport.exportMotionList(data, [...result.content, ...result.metaInfo]);
                 } else if (result.format === 'xlsx') {
                     this.motionXlsxExport.exportMotionList(data, result.metaInfo);
                 }

--- a/client/src/app/site/motions/motion-import-export-order.ts
+++ b/client/src/app/site/motions/motion-import-export-order.ts
@@ -4,20 +4,35 @@
 export const motionImportExportHeaderOrder: string[] = [
     'id',
     'identifier',
+    'submitters',
     'title',
     'text',
     'reason',
-    'submitters',
     'category',
-    'origin',
-    'motion_block',
     'tags',
     'recommendation',
-    'state'
+    'state',
+    'motion_block',
+    'origin'
 ];
+
+/**
+ * hints the metaData. This data will be excluded from the meta-data list in the export dialog.
+ * Order of this does not matter
+ */
+export const noMetaData: string[] = ['identifier', 'title', 'text', 'reason'];
 
 /**
  * Subset of {@link motionImportExportHeaderOrder} properties that are
  * restricted to export only due to database or workflow limitations
  */
 export const motionExportOnly: string[] = ['id', 'recommendation', 'state', 'tags'];
+
+/**
+ * reorders the exported properties according to motionImportExportHeaderOrder
+ *
+ * @param propertyList A list of motion properties to be ordered
+ */
+export function sortMotionPropertyList(propertyList: string[]): string[] {
+    return motionImportExportHeaderOrder.filter(property => propertyList.includes(property));
+}

--- a/client/src/app/site/motions/services/motion-csv-export.service.ts
+++ b/client/src/app/site/motions/services/motion-csv-export.service.ts
@@ -7,7 +7,7 @@ import {
     CsvColumnDefinitionProperty,
     CsvColumnDefinitionMap
 } from 'app/core/ui-services/csv-export.service';
-import { motionImportExportHeaderOrder } from '../motion-import-export-order';
+import { sortMotionPropertyList } from '../motion-import-export-order';
 import { MotionRepositoryService } from 'app/core/repositories/motions/motion-repository.service';
 import { ViewMotion } from '../models/view-motion';
 
@@ -37,11 +37,10 @@ export class MotionCsvExportService {
      * @param contentToExport content properties to export
      */
     public exportMotionList(motions: ViewMotion[], contentToExport: string[]): void {
-        // reorders the exported properties according to motionImportExportHeaderOrder
-        const propertyList = motionImportExportHeaderOrder.filter(property => contentToExport.includes(property));
+        const properties = sortMotionPropertyList(['identifier', 'title'].concat(contentToExport));
         const exportProperties: (
             | CsvColumnDefinitionProperty<ViewMotion>
-            | CsvColumnDefinitionMap<ViewMotion>)[] = propertyList.map(option => {
+            | CsvColumnDefinitionMap<ViewMotion>)[] = properties.map(option => {
             if (option === 'recommendation') {
                 return {
                     label: 'recommendation',

--- a/client/src/app/site/motions/services/motion-xlsx-export.service.ts
+++ b/client/src/app/site/motions/services/motion-xlsx-export.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 import { Workbook } from 'exceljs/dist/exceljs.min.js';
 
 import { InfoToExport } from './motion-pdf.service';
-import { motionImportExportHeaderOrder } from '../motion-import-export-order';
+import { sortMotionPropertyList } from '../motion-import-export-order';
 import { MotionRepositoryService } from 'app/core/repositories/motions/motion-repository.service';
 import { TranslateService } from '@ngx-translate/core';
 import { ViewMotion } from '../models/view-motion';
@@ -52,9 +52,8 @@ export class MotionXlsxExportService {
      */
     public exportMotionList(motions: ViewMotion[], infoToExport: InfoToExport[]): void {
         const workbook = new Workbook();
-        const propertyList = ['identifier', 'title'].concat(infoToExport);
-        // reorders the exported properties according to motionImportExportHeaderOrder
-        const properties = motionImportExportHeaderOrder.filter(property => propertyList.includes(property));
+        const properties = sortMotionPropertyList(['identifier', 'title'].concat(infoToExport));
+
         const worksheet = workbook.addWorksheet(this.translate.instant('Motions'), {
             pageSetup: {
                 paperSize: 9,


### PR DESCRIPTION
The order of the motion export dialog now fits to the `motionImportExportHeaderOrder`.
In case the order changes, the dialog form will update dynamically