### PR TITLE
last_email_sent display and resend email

### DIFF
--- a/client/src/app/core/repositories/users/user-repository.service.ts
+++ b/client/src/app/core/repositories/users/user-repository.service.ts
@@ -339,4 +339,18 @@ export class UserRepositoryService extends BaseRepository<ViewUser, User> {
             }
         });
     }
+
+    /**
+     * Get the date of the last invitation email.
+     *
+     * @param user
+     * @returns a localized string representation of the date/time the last email was sent;
+     * or an empty string
+     */
+    public lastSentEmailTimeString(user: ViewUser): string {
+        if (!user.user || !user.user.last_email_send) {
+            return '';
+        }
+        return new Date(user.user.last_email_send).toLocaleString(this.translate.currentLang);
+    }
 }

--- a/client/src/app/shared/models/users/user.ts
+++ b/client/src/app/shared/models/users/user.ts
@@ -27,7 +27,7 @@ export class User extends BaseModel<User> {
     public is_present: boolean;
     public is_committee: boolean;
     public email: string;
-    public last_email_send?: string;
+    public last_email_send?: string; // ISO datetime string
     public comment: string;
     public is_active: boolean;
     public default_password: string;

--- a/client/src/app/site/users/components/user-detail/user-detail.component.html
+++ b/client/src/app/site/users/components/user-detail/user-detail.component.html
@@ -31,11 +31,17 @@
             <mat-icon>security</mat-icon>
             <span translate>Change password</span>
         </button>
+        <!-- invitation email -->
+        <button mat-menu-item *ngIf="isAllowed('manage')" (click)="sendInvitationEmail()">
+            <mat-icon>mail</mat-icon>
+            <span translate>Send invitation email</span>
+        </button>
         <!-- PDF -->
         <button mat-menu-item *ngIf="isAllowed('manage')" (click)="onDownloadPdf()">
             <mat-icon>picture_as_pdf</mat-icon>
             <span translate>PDF</span>
         </button>
+        <!-- delete button -->
         <div *ngIf="isAllowed('delete')">
             <mat-divider></mat-divider>
             <button mat-menu-item class="red-warning-text" (click)="deleteUserButton()">
@@ -313,6 +319,15 @@
         <div *ngIf="user.comment">
             <h4 translate>Comment</h4>
             <span>{{ user.comment }}</span>
+        </div>
+    </div>
+
+    <div *ngIf="isAllowed('seePersonal') && user.is_last_email_send">
+        <div>
+            <h4 translate>
+                Last email sent
+            </h4>
+            <span>{{ getEmailSentTime() }}</span>
         </div>
     </div>
 </ng-template>

--- a/client/src/app/site/users/components/user-detail/user-detail.component.ts
+++ b/client/src/app/site/users/components/user-detail/user-detail.component.ts
@@ -430,4 +430,27 @@ export class UserDetailComponent extends BaseViewComponent implements OnInit {
     public sanitizedText(text: string): SafeHtml {
         return this.sanitizer.bypassSecurityTrustHtml(text);
     }
+
+    /**
+     * (Re)- send an invitation email for this user after confirmation
+     */
+    public async sendInvitationEmail(): Promise<void> {
+        const title = this.translate.instant('Sending an invitation email');
+        const content = this.translate.instant('Are you sure you want to send an invitation email to the user?');
+        if (await this.promptService.open(title, content)) {
+            this.repo.sendInvitationEmail([this.user]).then(this.raiseError, this.raiseError);
+        }
+    }
+
+    /**
+     * Fetches a localized string for the time the last email was sent.
+     *
+     * @returns a translated string with either the localized date/time; of 'No email sent'
+     */
+    public getEmailSentTime(): string {
+        if (!this.user.is_last_email_send) {
+            return this.translate.instant('No email sent');
+        }
+        return this.repo.lastSentEmailTimeString(this.user);
+    }
 }

--- a/client/src/app/site/users/components/user-list/user-list.component.html
+++ b/client/src/app/site/users/components/user-list/user-list.component.html
@@ -44,7 +44,7 @@
         <ng-container matColumnDef="name">
             <mat-header-cell *matHeaderCellDef mat-sort-header>Name</mat-header-cell>
             <mat-cell *matCellDef="let user">
-                {{ user.full_name }}
+                {{ user.short_name }}
             </mat-cell>
         </ng-container>
 
@@ -72,6 +72,19 @@
             <mat-header-cell *matHeaderCellDef></mat-header-cell>
             <mat-cell *matCellDef="let user">
                 <a [routerLink]="user.id" *ngIf="!isMultiSelect"></a>
+            </mat-cell>
+        </ng-container>
+
+        <!-- Infos column -->
+        <ng-container matColumnDef="infos">
+            <mat-header-cell *matHeaderCellDef mat-sort-header></mat-header-cell>
+            <mat-cell *matCellDef="let user" class="infoCell">
+                <div>
+                    <mat-icon inline *ngIf="user.is_last_email_send"
+                        matTooltip="{{ 'Email sent' | translate }} ({{ getEmailSentTime(user) }})">
+                        mail
+                    </mat-icon>
+                </div>
             </mat-cell>
         </ng-container>
 

--- a/client/src/app/site/users/components/user-list/user-list.component.scss
+++ b/client/src/app/site/users/components/user-list/user-list.component.scss
@@ -33,6 +33,10 @@
     }
 }
 
+.infoCell {
+    max-width: 25px;
+}
+
 .presentCell {
     align-content: left;
     padding-right: 50px;

--- a/client/src/app/site/users/components/user-list/user-list.component.ts
+++ b/client/src/app/site/users/components/user-list/user-list.component.ts
@@ -366,6 +366,19 @@ export class UserListComponent extends ListViewBaseComponent<ViewUser, User> imp
     }
 
     /**
+     * Get information about the last time an invitation email was sent to a user
+     *
+     * @param user
+     * @returns a string representation about the last time an email was sent to a user
+     */
+    public getEmailSentTime(user: ViewUser): string {
+        if (!user.is_last_email_send) {
+            return this.translate.instant('No email sent');
+        }
+        return this.repo.lastSentEmailTimeString(user);
+    }
+
+    /**
      * Handler for bulk setting new passwords. Needs multiSelect mode.
      */
     public async resetPasswordsSelected(): Promise<void> {
@@ -393,7 +406,7 @@ export class UserListComponent extends ListViewBaseComponent<ViewUser, User> imp
             columns = ['projector'].concat(columns);
         }
         if (this.operator.hasPerms('users.can_manage')) {
-            columns = columns.concat(['presence']);
+            columns = columns.concat(['infos', 'presence']);
         }
         if (this.isMultiSelect) {
             columns = ['selector'].concat(columns);


### PR DESCRIPTION
for direct discussion @emanuelschuetze :
- user list view: new small column with email icon (filled or not, depending on status) with tool tip about the last time sent
- user detail view: info about the last time the mail was sent (with permission 'can see personal info');
- user detail: resend email menu entry (permission: 'can change personal info'

