### PR TITLE
Show errors during PDF generation

### DIFF
--- a/client/src/app/core/ui-services/pdf-document.service.ts
+++ b/client/src/app/core/ui-services/pdf-document.service.ts
@@ -9,6 +9,19 @@ import { ConfigService } from './config.service';
 import { HttpService } from '../core-services/http.service';
 
 /**
+ * Custom PDF error class to handle errors in a safer way
+ */
+export class PdfError extends Error {
+    public __proto__: PdfError;
+
+    public constructor(public message: string) {
+        super(message);
+        const trueProto = new.target.prototype;
+        this.__proto__ = trueProto;
+    }
+}
+
+/**
  * Provides the general document structure for PDF documents, such as page margins, header, footer and styles.
  * Also provides general purpose open and download functions.
  *

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.ts
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.ts
@@ -1315,12 +1315,7 @@ export class MotionDetailComponent extends BaseViewComponent implements OnInit, 
      * Click handler for the pdf button
      */
     public onDownloadPdf(): void {
-        // TODO: apparently statue amendments never have line numbers and are always in crMode
-        if (this.motion.isStatuteAmendment()) {
-            this.pdfExport.exportSingleMotion(this.motion, LineNumberingMode.None, ChangeRecoMode.Diff);
-        } else {
-            this.pdfExport.exportSingleMotion(this.motion, this.lnMode, this.crMode);
-        }
+        this.pdfExport.exportSingleMotion(this.motion, this.lnMode, this.crMode);
     }
 
     /**

--- a/client/src/app/site/motions/modules/motion-list/components/motion-list/motion-list.component.ts
+++ b/client/src/app/site/motions/modules/motion-list/components/motion-list/motion-list.component.ts
@@ -30,6 +30,7 @@ import { MotionMultiselectService } from 'app/site/motions/services/motion-multi
 import { MotionXlsxExportService } from 'app/site/motions/services/motion-xlsx-export.service';
 import { LocalPermissionsService } from 'app/site/motions/services/local-permissions.service';
 import { StorageService } from 'app/core/core-services/storage.service';
+import { PdfError } from 'app/core/ui-services/pdf-document.service';
 
 /**
  * Interface to describe possible values and changes for
@@ -251,14 +252,22 @@ export class MotionListComponent extends ListViewBaseComponent<ViewMotion, Motio
             if (result && result.format) {
                 const data = this.isMultiSelect ? this.selectedRows : this.dataSource.filteredData;
                 if (result.format === 'pdf') {
-                    this.pdfExport.exportMotionCatalog(
-                        data,
-                        result.lnMode,
-                        result.crMode,
-                        result.content,
-                        result.metaInfo,
-                        result.comments
-                    );
+                    try {
+                        this.pdfExport.exportMotionCatalog(
+                            data,
+                            result.lnMode,
+                            result.crMode,
+                            result.content,
+                            result.metaInfo,
+                            result.comments
+                        );
+                    } catch (err) {
+                        if (err instanceof PdfError) {
+                            this.raiseError(err.message);
+                        } else {
+                            throw err;
+                        }
+                    }
                 } else if (result.format === 'csv') {
                     const content = ['identifier', ...result.content, ...result.metaInfo];
                     this.motionCsvExport.exportMotionList(data, content);

--- a/client/src/app/site/motions/services/motion-pdf-catalog.service.ts
+++ b/client/src/app/site/motions/services/motion-pdf-catalog.service.ts
@@ -6,6 +6,7 @@ import { ViewMotion, LineNumberingMode, ChangeRecoMode } from '../models/view-mo
 import { MotionPdfService, InfoToExport } from './motion-pdf.service';
 import { ConfigService } from 'app/core/ui-services/config.service';
 import { ViewCategory } from '../models/view-category';
+import { PdfError } from 'app/core/ui-services/pdf-document.service';
 
 /**
  * Service to export a list of motions.
@@ -64,22 +65,30 @@ export class MotionPdfCatalogService {
         const motionDocList = [];
 
         for (let motionIndex = 0; motionIndex < motions.length; ++motionIndex) {
-            const motionDocDef: any = this.motionPdfService.motionToDocDef(
-                motions[motionIndex],
-                lnMode,
-                crMode,
-                contentToExport,
-                infoToExport,
-                commentsToExport
-            );
+            try {
+                const motionDocDef: any = this.motionPdfService.motionToDocDef(
+                    motions[motionIndex],
+                    lnMode,
+                    crMode,
+                    contentToExport,
+                    infoToExport,
+                    commentsToExport
+                );
 
-            // add id field to the first page of a motion to make it findable over TOC
-            motionDocDef[0].id = `${motions[motionIndex].id}`;
+                // add id field to the first page of a motion to make it findable over TOC
+                motionDocDef[0].id = `${motions[motionIndex].id}`;
 
-            motionDocList.push(motionDocDef);
+                motionDocList.push(motionDocDef);
 
-            if (motionIndex < motions.length - 1) {
-                motionDocList.push(this.pageBreak);
+                if (motionIndex < motions.length - 1) {
+                    motionDocList.push(this.pageBreak);
+                }
+            } catch (err) {
+                const errorText = `${this.translate.instant('Error during PDF creation of motion:')} ${
+                    motions[motionIndex].identifierOrTitle
+                }`;
+                console.error(`${errorText}\nDebugInfo:\n`, err);
+                throw new PdfError(errorText);
             }
         }
 

--- a/client/src/app/site/motions/services/motion-pdf.service.ts
+++ b/client/src/app/site/motions/services/motion-pdf.service.ts
@@ -90,6 +90,12 @@ export class MotionPdfService {
     ): object {
         let motionPdfContent = [];
 
+        // Enforces that statutes should always have Diff Mode and no line numbers
+        if (motion.isStatuteAmendment()) {
+            lnMode = LineNumberingMode.None;
+            crMode = ChangeRecoMode.Diff;
+        }
+
         // determine the default lnMode if not explicitly given
         if (!lnMode) {
             lnMode = this.configService.instant('motions_default_line_numbering');


### PR DESCRIPTION
A lot of PDF-Errors are resolvable by the users themselves.
This helps users to show them, which of their motions have
malformed HTML.

Also fixes an issue during PDF generation of statute amendments