### PR TITLE
fix number array filter options

### DIFF
--- a/client/src/app/core/ui-services/base-filter-list.service.ts
+++ b/client/src/app/core/ui-services/base-filter-list.service.ts
@@ -209,7 +209,12 @@ export abstract class BaseFilterListService<V extends BaseViewModel> {
                         }
                         if (matchingStoreFilter && matchingStoreFilter.options) {
                             const storedOption = matchingStoreFilter.options.find(
-                                o => typeof o !== 'string' && o.condition === option.condition
+                                o =>
+                                    typeof o !== 'string' &&
+                                    (o.condition === option.condition ||
+                                        (Array.isArray(o.condition) &&
+                                            Array.isArray(option.condition) &&
+                                            o.label === option.label))
                             ) as OsFilterOption;
                             if (storedOption) {
                                 option.isActive = storedOption.isActive;


### PR DESCRIPTION
Fixes the 'done/not done' filter in workflow states being reset on an auto update

I've been told that this is outdated legacy code, though, so I didn't dig deeper on why this array suddenly changes