### PR TITLE
Enhance update service

### DIFF
--- a/client/src/app/app-routing.module.ts
+++ b/client/src/app/app-routing.module.ts
@@ -23,7 +23,11 @@ const routes: Routes = [
             { path: 'privacypolicy', component: LoginPrivacyPolicyComponent }
         ]
     },
-    { path: 'projector', loadChildren: './fullscreen-projector/fullscreen-projector.module#FullscreenProjectorModule' },
+    {
+        path: 'projector',
+        loadChildren: './fullscreen-projector/fullscreen-projector.module#FullscreenProjectorModule',
+        data: { noInterruption: true }
+    },
     { path: '', loadChildren: './site/site.module#SiteModule' },
     { path: '**', redirectTo: '' }
 ];

--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -12,7 +12,6 @@ import { OperatorService } from './core/core-services/operator.service';
 import { ServertimeService } from './core/core-services/servertime.service';
 import { ThemeService } from './core/ui-services/theme.service';
 import { DataStoreUpgradeService } from './core/core-services/data-store-upgrade.service';
-import { UpdateService } from './core/ui-services/update.service';
 import { PrioritizeService } from './core/core-services/prioritize.service';
 import { PingService } from './core/core-services/ping.service';
 import { SpinnerService } from './core/ui-services/spinner.service';
@@ -44,7 +43,6 @@ export class AppComponent {
      * @param configService to call the constructor of the ConfigService
      * @param loadFontService to call the constructor of the LoadFontService
      * @param dataStoreUpgradeService
-     * @param update Service Worker Updates
      */
     public constructor(
         translate: TranslateService,
@@ -60,7 +58,6 @@ export class AppComponent {
         configService: ConfigService,
         loadFontService: LoadFontService,
         dataStoreUpgradeService: DataStoreUpgradeService, // to start it.
-        update: UpdateService,
         prioritizeService: PrioritizeService,
         pingService: PingService
     ) {

--- a/client/src/app/core/ui-services/update.service.ts
+++ b/client/src/app/core/ui-services/update.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@angular/core';
 
-import { SwUpdate } from '@angular/service-worker';
-import { MatSnackBar } from '@angular/material';
+import { SwUpdate, UpdateAvailableEvent } from '@angular/service-worker';
 import { NotifyService } from '../core-services/notify.service';
+import { Observable } from 'rxjs';
 
 /**
  * Handle Service Worker updates using the SwUpdate service form angular.
@@ -14,30 +14,32 @@ export class UpdateService {
     private static NOTIFY_NAME = 'swCheckForUpdate';
 
     /**
+     * @returns the updateSubscription
+     */
+    public get updateObservable(): Observable<UpdateAvailableEvent> {
+        return this.swUpdate.available;
+    }
+
+    /**
      * Constructor.
      * Listens to available updates
      *
      * @param swUpdate Service Worker update service
      * @param matSnackBar Currently to show that an update is available
      */
-    public constructor(private swUpdate: SwUpdate, matSnackBar: MatSnackBar, private notify: NotifyService) {
-        swUpdate.available.subscribe(() => {
-            // TODO: Find a better solution OR make an update-bar like for history mode
-            const ref = matSnackBar.open('A new update is available!', 'Refresh', {
-                duration: 0
-            });
-
-            // Enforces an update
-            ref.onAction().subscribe(() => {
-                this.swUpdate.activateUpdate().then(() => {
-                    document.location.reload();
-                });
-            });
-        });
-
+    public constructor(private swUpdate: SwUpdate, private notify: NotifyService) {
         // Listen on requests from other users to check for updates.
         this.notify.getMessageObservable(UpdateService.NOTIFY_NAME).subscribe(() => {
             this.checkForUpdate();
+        });
+    }
+
+    /**
+     * Manually applies the update if one was found
+     */
+    public applyUpdate(): void {
+        this.swUpdate.activateUpdate().then(() => {
+            document.location.reload();
         });
     }
 

--- a/client/src/app/site/common/components/start/start.component.html
+++ b/client/src/app/site/common/components/start/start.component.html
@@ -7,6 +7,7 @@
 <mat-card class="os-card">
     <div class="app-content" translate>
         <h1>{{ welcomeTitle | translate }}</h1>
+
         <div [innerHTML]="welcomeText | translate"></div>
     </div>
 </mat-card>


### PR DESCRIPTION
Updates will be observed from site component
(Makes pure projectors ignore updates, unless the user manually navigates to a projector)

Updates can now be delayed using the `noInterruption` route data.
If the `noInterruption` route data was set, update notifications
will not be shown.
The update notification will appear, after the user navigates
to a view without `noInterruption` flag.