### PR TITLE
export final text in csv

### DIFF
--- a/client/src/app/site/motions/services/motion-csv-export.service.ts
+++ b/client/src/app/site/motions/services/motion-csv-export.service.ts
@@ -56,6 +56,11 @@ export class MotionCsvExportService {
                     label: 'Motion block',
                     map: motion => (motion.motion_block ? motion.motion_block.getTitle() : '')
                 };
+            } else if (option === 'text') {
+                return {
+                    label: 'Final text',
+                    map: motion => (motion.modified_final_version ? motion.modified_final_version : motion.text)
+                };
             } else {
                 return { property: option } as CsvColumnDefinitionProperty<ViewMotion>;
             }


### PR DESCRIPTION
I'm unsure if it may be that simple what you requested, @emanuelschuetze :

If there is a 'modified final version', export this in the csv text instead of the 'raw' csv text.

If not, I cannot help you at the moment, I don't know enough about the change/amendment parts
