### PR TITLE
Support other text versions in CSV

### DIFF
--- a/client/src/app/site/motions/modules/motion-list/components/motion-list/motion-list.component.ts
+++ b/client/src/app/site/motions/modules/motion-list/components/motion-list/motion-list.component.ts
@@ -278,7 +278,7 @@ export class MotionListComponent extends ListViewBaseComponent<ViewMotion, Motio
                         }
                     }
                 } else if (result.format === 'csv') {
-                    this.motionCsvExport.exportMotionList(data, [...result.content, ...result.metaInfo]);
+                    this.motionCsvExport.exportMotionList(data, [...result.content, ...result.metaInfo], result.crMode);
                 } else if (result.format === 'xlsx') {
                     this.motionXlsxExport.exportMotionList(data, result.metaInfo);
                 }


### PR DESCRIPTION
Alternative to #4714 . Should support the same methods as in the PDF export for motions, although it returns plain HTML, which still is awkward in combination with CSV.
The "liberalization" of the motion-export-dialog needs to be done separately