### PR TITLE
Drag/Drop multiselect

### DIFF
--- a/client/src/app/shared/components/sorting-list/sorting-list.component.html
+++ b/client/src/app/shared/components/sorting-list/sorting-list.component.html
@@ -2,18 +2,29 @@
     <div class="line" *ngIf="!array.length">
         <span translate>No data</span>
     </div>
-    <div class="line" *ngFor="let item of array; let i = index" cdkDrag>
-        <div class="section-one backgroundColorLight" cdkDragHandle *ngIf="enable">
+    <div
+        [ngClass]="isSelectedRow(i) ? 'backgroundColorSelected line' : 'backgroundColorLight line'"
+        *ngFor="let item of array; let i = index"
+        cdkDrag
+        (click)="onItemClick($event, i)"
+        (cdkDragStarted)="dragStarted(i)"
+    >
+        <div class="section-one " cdkDragHandle *ngIf="enable">
             <mat-icon>drag_indicator</mat-icon>
         </div>
-        <div class="section-two backgroundColorLight">
+        <div class="section-two">
             <!-- {number}. {item.getTitle()} -->
             <span *ngIf="count">{{ i + 1 }}.&nbsp;</span>
             <span>{{ item.getTitle() }}</span>
         </div>
-        <div class="section-three backgroundColorLight">
+        <div class="section-three">
             <!-- Extra controls slot using implicit template references -->
             <ng-template [ngTemplateOutlet]="templateRef" [ngTemplateOutletContext]="{ $implicit: item }"></ng-template>
+        </div>
+        <div class="line" *cdkDragPreview>
+            <div class="spacer.left-10" *ngIf="multiSelectedIndex.length > 0">
+                {{ multiSelectedIndex.length }}&nbsp;<span translate>items selected</span>
+            </div>
         </div>
     </div>
 </div>

--- a/client/src/assets/styles/global-components-style.scss
+++ b/client/src/assets/styles/global-components-style.scss
@@ -80,6 +80,11 @@
         color: mat-color($accent, default-contrast) !important;
     }
 
+    .backgroundColorSelected {
+        background-color: rgba(0, 0, 0, 0.155);
+        color: mat-color($foreground, text) !important;
+    }
+
     .backgroundColorLight {
         background-color: mat-color($background, hover);
         color: mat-color($foreground, text) !important;


### PR DESCRIPTION
Item drag-drop (not nested) lists now allow for items to be multiselected (ctrl+ click) and moved in bulk.

(example: assignment candidates, motions in  'sort motions in category' view)

This obviously still needs layout, just making the functionality reviewable. @emanuelschuetze 

