### PR TITLE
Readded default sorting for agenda

### DIFF
--- a/client/src/app/core/repositories/agenda/item-repository.service.ts
+++ b/client/src/app/core/repositories/agenda/item-repository.service.ts
@@ -56,6 +56,8 @@ export class ItemRepositoryService extends BaseRepository<ViewItem, Item> {
             Motion,
             MotionBlock
         ]);
+
+        this.setSortFunction((a, b) => a.weight - b.weight);
     }
 
     public getVerboseName = (plural: boolean = false) => {


### PR DESCRIPTION
Default sorting were removed here: https://github.com/OpenSlides/OpenSlides/pull/4671/files#diff-c72ce8d0c2c339385819bf10c685c276L128
Readded it now in the repository, so the agenda is always well sorted.