### PR TITLE
Allow stored filter without options

### DIFF
--- a/client/src/app/core/ui-services/base-filter-list.service.ts
+++ b/client/src/app/core/ui-services/base-filter-list.service.ts
@@ -150,12 +150,7 @@ export abstract class BaseFilterListService<V extends BaseViewModel> {
             return storedFilter.every(filter => {
                 // Interfaces do not exist at runtime. Manually check if the
                 // Required information of the interface are present
-                return (
-                    filter.hasOwnProperty('options') &&
-                    filter.hasOwnProperty('property') &&
-                    filter.options.length &&
-                    !!filter.property
-                );
+                return filter.hasOwnProperty('options') && filter.hasOwnProperty('property') && !!filter.property;
             });
         } else {
             return false;


### PR DESCRIPTION
Fixes an issue where stored filters where considered to be wrong if
their set of options was empty

@emanuelschuetze I expect firefox to read and load filters correctly using this fix