### PR TITLE
Client error handling

### DIFF
--- a/client/src/app/site/base/base-view.ts
+++ b/client/src/app/site/base/base-view.ts
@@ -58,10 +58,15 @@ export abstract class BaseViewComponent extends BaseComponent implements OnDestr
      * Opens an error snack bar with the given error message.
      * This is implemented as an arrow function to capture the called `this`. You can use this function
      * as callback (`.then(..., this.raiseError)`) instead of doing `this.raiseError.bind(this)`.
-     * @param message The message to show.
+     *
+     * @param message The message to show or an "real" error, which will be passed to the console.
      */
-    protected raiseError = (message: string): void => {
-        this.messageSnackBar = this.matSnackBar.open(message, this.translate.instant('OK'), {
+    protected raiseError = (message: string | Error): void => {
+        if (message instanceof Error) {
+            console.error(message);
+            message = this.translate.instant('A client error occured. Please contact your system administrator.');
+        }
+        this.messageSnackBar = this.matSnackBar.open(message as string, this.translate.instant('OK'), {
             duration: 0
         });
     };


### PR DESCRIPTION
@tsiegleauq There are situations (like errors in multiselect etc.) where we catch all errors and pass them to `raiseError`. Expected are strings given the message. When an `Error` object is passed here, it is an unwanted client error. This new message is a bit nicer and the information are passed to the console, so a dev can see the traceback.

Maybe we want to "save" this error, or send it via notify to an admin? We might think about "better" error handling to propagate erros to devs or so. E.g. we can also save them in the DB (or the last x ones), so a dev can see them. Whats your opinion for this?