### PR TITLE
config to show/hide motion sequential numbers

### DIFF
--- a/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.html
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.html
@@ -113,9 +113,12 @@
 
         <!-- Sequential number -->
         <span class="main-nav-color title-font">
-            <span translate>Sequential number</span>&nbsp;{{ motion.id }}
+            <span *ngIf="showSequential">
+                <span translate>Sequential number</span>
+                &nbsp;{{ motion.id }}
+            </span>
+            <span *ngIf="showSequential && motion.parent_id">&#xb7;&nbsp;</span>
             <span *ngIf="motion.parent_id">
-                &#xb7;
                 <span>
                     <span translate>Amendment to</span>&nbsp;<a [routerLink]="motion.parent.getDetailStateURL()">{{
                         motion.parent.identifier || motion.parent.title

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.ts
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.ts
@@ -164,6 +164,11 @@ export class MotionDetailComponent extends BaseViewComponent implements OnInit, 
     public statutesEnabled: boolean;
 
     /**
+     * Value of the config variable `motions_show_sequential_numbers`
+     */
+    public showSequential: boolean;
+
+    /**
      * Value of the config variable `motions_reason_required`
      */
     public reasonRequired: boolean;
@@ -493,7 +498,9 @@ export class MotionDetailComponent extends BaseViewComponent implements OnInit, 
         this.configService
             .get<ChangeRecoMode>('motions_recommendation_text_mode')
             .subscribe(mode => (this.crMode = mode));
-
+        this.configService
+            .get<boolean>('motions_show_sequential_numbers')
+            .subscribe(shown => (this.showSequential = shown));
         // disable the selector for attachments if there are none
         this.mediafilesObserver.subscribe(() => {
             if (this.contentForm) {

--- a/client/src/app/site/motions/modules/motion-list/components/motion-list/motion-list.component.html
+++ b/client/src/app/site/motions/modules/motion-list/components/motion-list/motion-list.component.html
@@ -90,7 +90,7 @@
                 <!-- Submitters -->
                 <div class="submitters-line ellipsis-overflow" *ngIf="motion.submitters.length">
                     <span translate>by</span> {{ motion.submitters }}
-                    <span *osPerms="'motions.can_manage'">
+                    <span *ngIf="showSequential">
                         &middot;
                         <span translate>Sequential number</span>
                         {{ motion.id }}

--- a/client/src/app/site/motions/modules/motion-list/components/motion-list/motion-list.component.ts
+++ b/client/src/app/site/motions/modules/motion-list/components/motion-list/motion-list.component.ts
@@ -116,6 +116,12 @@ export class MotionListComponent extends ListViewBaseComponent<ViewMotion> imple
      * @TODO replace by direct access to config variable, once it's available from the templates
      */
     public statutesEnabled: boolean;
+
+    /**
+     * Value of the config variable `motions_show_sequential_numbers`
+     */
+    public showSequential: boolean;
+
     public recommendationEnabled: boolean;
 
     public tags: ViewTag[] = [];
@@ -212,6 +218,9 @@ export class MotionListComponent extends ListViewBaseComponent<ViewMotion> imple
         this.configService.get<string>('motions_recommendations_by').subscribe(recommender => {
             this.recommendationEnabled = !!recommender;
         });
+        this.configService
+            .get<boolean>('motions_show_sequential_numbers')
+            .subscribe(show => (this.showSequential = show));
         this.motionBlockRepo.getViewModelListObservable().subscribe(mBs => {
             this.motionBlocks = mBs;
         });

--- a/openslides/motions/config_variables.py
+++ b/openslides/motions/config_variables.py
@@ -190,6 +190,16 @@ def get_config_variables():
         subgroup="General",
     )
 
+    yield ConfigVariable(
+        name="motions_show_sequential_numbers",
+        default_value=True,
+        input_type="boolean",
+        label="Show the sequential number for a motion",
+        weight=336,
+        group="Motions",
+        subgroup="General",
+    )
+
     # Amendments
 
     yield ConfigVariable(


### PR DESCRIPTION
Sequential numbers display is now toggled by a config (instead of can_manage rights) in list and detail view. Other sequential number stuff (export; sorting) is not affected

@emanuelschuetze feel free to change/adapt config placement and wording