### PR TITLE
Use npm package text-encoding to fix IE11/Edge login.

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -61,6 +61,7 @@
         "pdfmake": "^0.1.53",
         "po2json": "^1.0.0-alpha",
         "rxjs": "^6.5.1",
+        "text-encoding": "^0.7.0",
         "tinymce": "^4.9.2",
         "uuid": "^3.3.2",
         "zone.js": "~0.8.26"

--- a/client/src/app/core/core-services/websocket.service.ts
+++ b/client/src/app/core/core-services/websocket.service.ts
@@ -6,6 +6,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { Observable, Subject } from 'rxjs';
 import { take } from 'rxjs/operators';
 import { compress, decompress } from 'lz4js';
+import { TextDecoder, TextEncoder } from 'text-encoding';
 
 import { formatQueryParams, QueryParams } from '../query-params';
 import { OpenSlidesStatusService } from './openslides-status.service';
@@ -281,7 +282,7 @@ export class WebsocketService {
                     1024} KB uncompressed), ratio ${decompressedBuffer.byteLength / compressedSize}`
             );
             const textDecoder = new TextDecoder();
-            data = textDecoder.decode(decompressedBuffer);
+            data = textDecoder.decode(decompressedBuffer) as string;
         }
 
         const message: IncommingWebsocketMessage = JSON.parse(data);


### PR DESCRIPTION
IE11/Edge does not support TextDecoder/TextEncoder.
Solved by using the npm package 'text-encoding'.

@FinnStutzenstein Please review carefully if this is desired for all other browsers!