### PR TITLE
New email sender name and reply-to config options.

### DIFF
--- a/openslides/users/config_variables.py
+++ b/openslides/users/config_variables.py
@@ -108,10 +108,21 @@ def get_config_variables():
 
     yield ConfigVariable(
         name="users_email_sender",
-        default_value="noreply@example.com",
+        default_value="",
         input_type="string",
-        label="Email sender",
+        label="Sender name",
+        help_text="The sender address is defined in the OpenSlides server settings and should modified by administrator only.",
         weight=600,
+        group="Participants",
+        subgroup="Email",
+    )
+
+    yield ConfigVariable(
+        name="users_email_replyto",
+        default_value="",
+        input_type="string",
+        label="Reply address",
+        weight=601,
         group="Participants",
         subgroup="Email",
     )

--- a/openslides/users/models.py
+++ b/openslides/users/models.py
@@ -1,6 +1,7 @@
 import smtplib
 from random import choice
 
+from django.conf import settings
 from django.contrib.auth.hashers import make_password
 from django.contrib.auth.models import (
     AbstractBaseUser,
@@ -247,7 +248,11 @@ class User(RESTModelMixin, PermissionsMixin, AbstractBaseUser):
 
         # Create an email and send it.
         email = mail.EmailMessage(
-            subject, message, config["users_email_sender"], [self.email]
+            subject,
+            message,
+            config["users_email_sender"] + " <" + settings.DEFAULT_FROM_EMAIL + ">",
+            [self.email],
+            reply_to=[config["users_email_replyto"]],
         )
         try:
             count = connection.send_messages([email])

--- a/openslides/utils/settings.py.tpl
+++ b/openslides/utils/settings.py.tpl
@@ -47,6 +47,7 @@ EMAIL_HOST = 'localhost'
 EMAIL_PORT = 587
 EMAIL_HOST_USER = ''
 EMAIL_HOST_PASSWORD = ''
+DEFAULT_FROM_EMAIL = 'noreply@example.com'
 
 # Increasing Upload size to 100mb (default is 2.5mb)
 DATA_UPLOAD_MAX_MEMORY_SIZE = 104857600


### PR DESCRIPTION
You have to add `DEFAULT_FROM_EMAIL = 'noreply@example.com'` to your settings.py.
Default value (set by django): `webmaster@localhost`