### PR TITLE
Remove restrictions for filters

### DIFF
--- a/client/src/app/site/motions/services/motion-filter-list.service.ts
+++ b/client/src/app/site/motions/services/motion-filter-list.service.ts
@@ -212,10 +212,9 @@ export class MotionFilterListService extends BaseFilterListService<ViewMotion> {
                         });
 
                         for (const state of workflow.states) {
-                            if (
-                                this.operator.hasPerms('motions.can_manage', 'motions.can_manage_metadata') &&
-                                state.restriction
-                            ) {
+                            // get the restriction array, but remove the is_submitter condition, if present
+                            const restrictions = state.restriction.filter(r => r !== 'is_submitter');
+                            if (!restrictions.length || this.operator.hasPerms(...restrictions)) {
                                 // sort final and non final states
                                 state.isFinalState ? finalStates.push(state.id) : nonFinalStates.push(state.id);
 


### PR DESCRIPTION
Removes the restictions for filters

Fixes an issue where users without managing right could not access the state filter.

Not entirely sure what was required here. Since the server handles which motions to deliver to the users by their permissions, I removed the restrictions for filters.

comparing the restrictions with the groups will usually not work, since 'is_submitter' can appear as a restriction, which is not a group.