### PR TITLE
Add more option to motion export

### DIFF
--- a/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.ts
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.ts
@@ -1389,7 +1389,11 @@ export class MotionDetailComponent extends BaseViewComponent implements OnInit, 
      * Click handler for the pdf button
      */
     public onDownloadPdf(): void {
-        this.pdfExport.exportSingleMotion(this.motion, this.lnMode, this.crMode);
+        this.pdfExport.exportSingleMotion(this.motion, {
+            lnMode: this.lnMode,
+            crMode: this.crMode,
+            comments: this.motion.commentSectionIds
+        });
     }
 
     /**

--- a/client/src/app/site/motions/modules/motion-list/components/motion-export-dialog/motion-export-dialog.component.html
+++ b/client/src/app/site/motions/modules/motion-list/components/motion-export-dialog/motion-export-dialog.component.html
@@ -6,9 +6,9 @@
         <div>
             <p class="toggle-group-head" translate>Format</p>
             <mat-button-toggle-group class="smaller-buttons" formControlName="format">
-                <mat-button-toggle value="pdf">PDF</mat-button-toggle>
-                <mat-button-toggle value="csv">CSV</mat-button-toggle>
-                <mat-button-toggle value="xlsx">XLSX</mat-button-toggle>
+                <mat-button-toggle [value]="fileFormat.PDF">PDF</mat-button-toggle>
+                <mat-button-toggle [value]="fileFormat.CSV">CSV</mat-button-toggle>
+                <mat-button-toggle [value]="fileFormat.XLSX">XLSX</mat-button-toggle>
             </mat-button-toggle-group>
         </div>
 
@@ -54,7 +54,16 @@
                 </mat-button-toggle>
             </mat-button-toggle-group>
         </div>
-        <div *ngIf="commentsToExport.length && exportForm.get('format').value === 'pdf'">
+        <div>
+            <p class="toggle-group-head" translate>PDF options</p>
+            <mat-button-toggle-group class="smaller-buttons" multiple formControlName="pdfOptions">
+                <mat-button-toggle value="toc"> <span translate>Table of Contents</span> </mat-button-toggle>
+                <mat-button-toggle value="page"> <span translate>Page number</span> </mat-button-toggle>
+                <mat-button-toggle value="date"> <span translate>Current date</span> </mat-button-toggle>
+            </mat-button-toggle-group>
+        </div>
+
+        <div *ngIf="commentsToExport.length">
             <p class="toggle-group-head" translate>Comments</p>
             <mat-button-toggle-group class="smaller-buttons" multiple formControlName="comments">
                 <mat-button-toggle *ngFor="let comment of commentsToExport" [value]="comment.id">

--- a/client/src/app/site/motions/services/motion-pdf-catalog.service.ts
+++ b/client/src/app/site/motions/services/motion-pdf-catalog.service.ts
@@ -5,11 +5,12 @@ import { TranslateService } from '@ngx-translate/core';
 
 import { CategoryRepositoryService } from 'app/core/repositories/motions/category-repository.service';
 import { ConfigService } from 'app/core/ui-services/config.service';
-import { MotionPdfService, InfoToExport } from './motion-pdf.service';
+import { MotionPdfService } from './motion-pdf.service';
 import { MotionRepositoryService } from 'app/core/repositories/motions/motion-repository.service';
 import { PdfError, PdfDocumentService, StyleType, BorderType } from 'app/core/ui-services/pdf-document.service';
 import { ViewCategory } from '../models/view-category';
-import { ViewMotion, LineNumberingMode, ChangeRecoMode } from '../models/view-motion';
+import { ViewMotion } from '../models/view-motion';
+import { ExportFormData } from '../modules/motion-list/components/motion-export-dialog/motion-export-dialog.component';
 
 /**
  * Service to export a list of motions.
@@ -55,27 +56,13 @@ export class MotionPdfCatalogService {
      * @param commentsToExport
      * @returns pdfmake doc definition as object
      */
-    public motionListToDocDef(
-        motions: ViewMotion[],
-        lnMode?: LineNumberingMode,
-        crMode?: ChangeRecoMode,
-        contentToExport?: string[],
-        infoToExport?: InfoToExport[],
-        commentsToExport?: number[]
-    ): object {
+    public motionListToDocDef(motions: ViewMotion[], exportInfo: ExportFormData): object {
         let doc = [];
         const motionDocList = [];
 
         for (let motionIndex = 0; motionIndex < motions.length; ++motionIndex) {
             try {
-                const motionDocDef: any = this.motionPdfService.motionToDocDef(
-                    motions[motionIndex],
-                    lnMode,
-                    crMode,
-                    contentToExport,
-                    infoToExport,
-                    commentsToExport
-                );
+                const motionDocDef: any = this.motionPdfService.motionToDocDef(motions[motionIndex], exportInfo);
 
                 // add id field to the first page of a motion to make it findable over TOC
                 motionDocDef[0].id = `${motions[motionIndex].id}`;
@@ -95,7 +82,7 @@ export class MotionPdfCatalogService {
         }
 
         // print extra data (title, preamble, categories, toc) only if there are more than 1 motion
-        if (motions.length > 1) {
+        if (motions.length > 1 && (!exportInfo.pdfOptions || exportInfo.pdfOptions.includes('toc'))) {
             doc.push(
                 this.pdfService.createTitle('motions_export_title'),
                 this.pdfService.createPreamble('motions_export_preamble'),

--- a/client/src/app/site/motions/services/motion-pdf-export.service.ts
+++ b/client/src/app/site/motions/services/motion-pdf-export.service.ts
@@ -2,13 +2,14 @@ import { Injectable } from '@angular/core';
 
 import { TranslateService } from '@ngx-translate/core';
 
-import { MotionPdfService, InfoToExport } from './motion-pdf.service';
+import { MotionPdfService } from './motion-pdf.service';
 import { PdfDocumentService } from 'app/core/ui-services/pdf-document.service';
-import { ViewMotion, LineNumberingMode, ChangeRecoMode } from '../models/view-motion';
+import { ViewMotion } from '../models/view-motion';
 import { ConfigService } from 'app/core/ui-services/config.service';
 import { MotionPdfCatalogService } from './motion-pdf-catalog.service';
 import { PersonalNoteContent } from 'app/shared/models/users/personal-note';
 import { ViewMotionCommentSection } from '../models/view-motion-comment-section';
+import { ExportFormData } from '../modules/motion-list/components/motion-export-dialog/motion-export-dialog.component';
 
 /**
  * Export service to handle various kind of exporting necessities.
@@ -40,8 +41,8 @@ export class MotionPdfExportService {
      * @param lnMode the desired line numbering mode
      * @param crMode the desired change recomendation mode
      */
-    public exportSingleMotion(motion: ViewMotion, lnMode?: LineNumberingMode, crMode?: ChangeRecoMode): void {
-        const doc = this.motionPdfService.motionToDocDef(motion, lnMode, crMode);
+    public exportSingleMotion(motion: ViewMotion, exportInfo?: ExportFormData): void {
+        const doc = this.motionPdfService.motionToDocDef(motion, exportInfo);
         const filename = `${this.translate.instant('Motion')} ${motion.identifierOrTitle}`;
         const metadata = {
             title: filename
@@ -59,27 +60,13 @@ export class MotionPdfExportService {
      * @param infoToExport Determine the meta info to export
      * @param commentsToExport Comments (by id) to export
      */
-    public exportMotionCatalog(
-        motions: ViewMotion[],
-        lnMode?: LineNumberingMode,
-        crMode?: ChangeRecoMode,
-        contentToExport?: string[],
-        infoToExport?: InfoToExport[],
-        commentsToExport?: number[]
-    ): void {
-        const doc = this.pdfCatalogService.motionListToDocDef(
-            motions,
-            lnMode,
-            crMode,
-            contentToExport,
-            infoToExport,
-            commentsToExport
-        );
+    public exportMotionCatalog(motions: ViewMotion[], exportInfo: ExportFormData): void {
+        const doc = this.pdfCatalogService.motionListToDocDef(motions, exportInfo);
         const filename = this.translate.instant(this.configService.instant<string>('motions_export_title'));
         const metadata = {
             title: filename
         };
-        this.pdfDocumentService.download(doc, filename, metadata);
+        this.pdfDocumentService.download(doc, filename, metadata, exportInfo);
     }
 
     /**

--- a/client/src/app/site/motions/services/motion-pdf.service.ts
+++ b/client/src/app/site/motions/services/motion-pdf.service.ts
@@ -17,6 +17,7 @@ import { PdfDocumentService } from 'app/core/ui-services/pdf-document.service';
 import { ViewMotionAmendedParagraph } from '../models/view-motion-amended-paragraph';
 import { ViewMotionChangeRecommendation } from '../models/view-motion-change-recommendation';
 import { ViewUnifiedChange, ViewUnifiedChangeType } from 'app/shared/models/motions/view-unified-change';
+import { ExportFormData } from '../modules/motion-list/components/motion-export-dialog/motion-export-dialog.component';
 
 /**
  * Type declaring which strings are valid options for metainfos to be exported into a pdf
@@ -91,14 +92,13 @@ export class MotionPdfService {
      * @param commentsToExport comments to chose for export. If 'allcomments' is set in infoToExport, this selection will be ignored and all comments exported
      * @returns doc def for the motion
      */
-    public motionToDocDef(
-        motion: ViewMotion,
-        lnMode?: LineNumberingMode,
-        crMode?: ChangeRecoMode,
-        contentToExport?: string[],
-        infoToExport?: InfoToExport[],
-        commentsToExport?: number[]
-    ): object {
+    public motionToDocDef(motion: ViewMotion, exportInfo?: ExportFormData): object {
+        let lnMode = exportInfo && exportInfo.lnMode ? exportInfo.lnMode : null;
+        let crMode = exportInfo && exportInfo.crMode ? exportInfo.crMode : null;
+        const infoToExport = exportInfo ? exportInfo.metaInfo : null;
+        const contentToExport = exportInfo ? exportInfo.content : null;
+        let commentsToExport = exportInfo ? exportInfo.comments : null;
+
         // get the line length from the config
         const lineLength = this.configService.instant<number>('motions_line_length');
         // whether to append checkboxes to follow the recommendation or not
@@ -178,7 +178,13 @@ export class MotionPdfService {
         const changedTitle = this.changeRecoRepo.getTitleWithChanges(motion.title, titleChange, crMode);
 
         const identifier = motion.identifier ? ' ' + motion.identifier : '';
-        const title = `${this.translate.instant('Motion')} ${identifier}: ${changedTitle}`;
+        const pageSize = this.configService.instant('general_export_pdf_pagesize');
+        let title = '';
+        if (pageSize === 'A4') {
+            title += `${this.translate.instant('Motion')} `;
+        }
+
+        title += `${identifier}: ${changedTitle}`;
 
         return {
             text: title,


### PR DESCRIPTION
Add optional TOC, date and page numbers to the motion export dialog.
Save and restore the last selected entries in the dialog

Changes various things. Requires some testing.