### PR TITLE
Recover-strategy to detect an updated server without a reload

### DIFF
--- a/client/src/app/core/core-services/autoupdate.service.ts
+++ b/client/src/app/core/core-services/autoupdate.service.ts
@@ -166,6 +166,7 @@ export class AutoupdateService {
      * Does a full update: Requests all data from the server and sets the DS to the fresh data.
      */
     public async doFullUpdate(): Promise<void> {
+        const oldChangeId = this.DS.maxChangeId;
         const response = await this.websocketService.sendAndGetResponse<{}, AutoupdateFormat>('getElements', {});
 
         const updateSlot = await this.DSUpdateManager.getNewUpdateSlot(this.DS);
@@ -180,5 +181,7 @@ export class AutoupdateService {
 
         await this.DS.set(allModels, response.to_change_id);
         this.DSUpdateManager.commit(updateSlot);
+
+        console.log(`Full update done from ${oldChangeId} to ${response.to_change_id}`);
     }
 }

--- a/client/src/app/core/core-services/ping.service.ts
+++ b/client/src/app/core/core-services/ping.service.ts
@@ -55,7 +55,7 @@ export class PingService {
 
         // Connects the ping-pong mechanism to the opening and closing of the connection.
         this.websocketService.closeEvent.subscribe(() => this.stopPing());
-        this.websocketService.connectEvent.subscribe(() => this.startPing());
+        this.websocketService.generalConnectEvent.subscribe(() => this.startPing());
         if (this.websocketService.isConnected) {
             this.startPing();
         }

--- a/client/src/app/core/core-services/projector-data.service.ts
+++ b/client/src/app/core/core-services/projector-data.service.ts
@@ -51,7 +51,7 @@ export class ProjectorDataService {
             });
         });
 
-        this.websocketService.connectEvent.subscribe(() => this.updateProjectorDataSubscription());
+        this.websocketService.generalConnectEvent.subscribe(() => this.updateProjectorDataSubscription());
     }
 
     /**

--- a/client/src/app/core/core-services/websocket.service.ts
+++ b/client/src/app/core/core-services/websocket.service.ts
@@ -91,15 +91,28 @@ export class WebsocketService {
     }
 
     /**
+     * Subjects that will be called, if connect took place, but not a retry reconnect.
+     * THis is the complement from the generalConnectEvent to the retryReconnectEvent.
+     */
+    private readonly _noRetryConnectEvent: EventEmitter<void> = new EventEmitter<void>();
+
+    /**
+     * Getter for the no-retry connect event.
+     */
+    public get noRetryConnectEvent(): EventEmitter<void> {
+        return this._noRetryConnectEvent;
+    }
+
+    /**
      * Listeners will be nofitied, if the wesocket connection is establiched.
      */
-    private readonly _connectEvent: EventEmitter<void> = new EventEmitter<void>();
+    private readonly _generalConnectEvent: EventEmitter<void> = new EventEmitter<void>();
 
     /**
      * Getter for the connect event.
      */
-    public get connectEvent(): EventEmitter<void> {
-        return this._connectEvent;
+    public get generalConnectEvent(): EventEmitter<void> {
+        return this._generalConnectEvent;
     }
 
     /**
@@ -234,12 +247,14 @@ export class WebsocketService {
                     return;
                 }
 
+                this._connectionOpen = true;
                 if (retry) {
                     this.dismissConnectionErrorNotice();
                     this._retryReconnectEvent.emit();
+                } else {
+                    this._noRetryConnectEvent.emit();
                 }
-                this._connectionOpen = true;
-                this._connectEvent.emit();
+                this._generalConnectEvent.emit();
                 this.sendQueueWhileNotConnected.forEach(entry => {
                     this.websocket.send(entry);
                 });

--- a/openslides/core/config_variables.py
+++ b/openslides/core/config_variables.py
@@ -401,3 +401,12 @@ def get_config_variables():
         weight=1000,
         group="Custom translations",
     )
+
+    # Config version
+    yield ConfigVariable(
+        name="config_version",
+        input_type="integer",
+        default_value=1,
+        group="Version",
+        hidden=True,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,9 +55,10 @@ def pytest_collection_modifyitems(items):
 
 
 @pytest.fixture(autouse=True)
-def constants(request):
+def constants(request, reset_cache):
     """
-    Resets the constants on every test.
+    Resets the constants on every test. The filled cache is needed to
+    build the constants, because some of them depends on the config.
 
     Uses fake constants, if the db is not in use.
     """


### PR DESCRIPTION
@emanuelschuetze This should allow the client to fetch new data, if the server was restarted and updated(migrated).