### PR TITLE
fixing multiselect sort in sorting lists

### DIFF
--- a/client/src/app/shared/components/sorting-list/sorting-list.component.ts
+++ b/client/src/app/shared/components/sorting-list/sorting-list.component.ts
@@ -188,7 +188,9 @@ export class SortingListComponent implements OnInit, OnDestroy {
                         } else if (dropBehind === true) {
                             before.push(this.array[i]);
                         } else {
-                            event.currentIndex < 1 ? behind.push(this.array[i]) : before.push(this.array[i]);
+                            Math.min(...this.multiSelectedIndex) < i
+                                ? before.push(this.array[i])
+                                : behind.push(this.array[i]);
                         }
                     }
                 } else {


### PR DESCRIPTION
This should fix the odd sorting for multiselected items in sorting-lists.

(please review carefully, I'm very confused here and probably messed up things)
