### PR TITLE
Bugfix: missing text in PDF-exported diff view

### DIFF
--- a/client/src/app/core/repositories/motions/motion-repository.service.ts
+++ b/client/src/app/core/repositories/motions/motion-repository.service.ts
@@ -537,39 +537,38 @@ export class MotionRepositoryService extends BaseIsAgendaItemAndListOfSpeakersCo
                     return this.diff.getTextWithChanges(targetMotion.text, changes, lineLength, highlightLine);
                 case ChangeRecoMode.Diff:
                     let text = '';
-                    changes
-                        .filter(change => {
-                            return change.showInDiffView();
-                        })
-                        .forEach((change: ViewUnifiedChange, idx: number) => {
-                            if (idx === 0) {
-                                text += this.diff.extractMotionLineRange(
-                                    targetMotion.text,
-                                    {
-                                        from: 1,
-                                        to: change.getLineFrom()
-                                    },
-                                    true,
-                                    lineLength,
-                                    highlightLine
-                                );
-                            } else if (changes[idx - 1].getLineTo() < change.getLineFrom()) {
-                                text += this.diff.extractMotionLineRange(
-                                    targetMotion.text,
-                                    {
-                                        from: changes[idx - 1].getLineTo(),
-                                        to: change.getLineFrom()
-                                    },
-                                    true,
-                                    lineLength,
-                                    highlightLine
-                                );
-                            }
-                            text += this.diff.getChangeDiff(targetMotion.text, change, lineLength, highlightLine);
-                        });
+                    const changesToShow = changes.filter(change => {
+                        return change.showInDiffView();
+                    });
+                    changesToShow.forEach((change: ViewUnifiedChange, idx: number) => {
+                        if (idx === 0) {
+                            text += this.diff.extractMotionLineRange(
+                                targetMotion.text,
+                                {
+                                    from: 1,
+                                    to: change.getLineFrom()
+                                },
+                                true,
+                                lineLength,
+                                highlightLine
+                            );
+                        } else if (changes[idx - 1].getLineTo() < change.getLineFrom()) {
+                            text += this.diff.extractMotionLineRange(
+                                targetMotion.text,
+                                {
+                                    from: changes[idx - 1].getLineTo(),
+                                    to: change.getLineFrom()
+                                },
+                                true,
+                                lineLength,
+                                highlightLine
+                            );
+                        }
+                        text += this.diff.getChangeDiff(targetMotion.text, change, lineLength, highlightLine);
+                    });
                     text += this.diff.getTextRemainderAfterLastChange(
                         targetMotion.text,
-                        changes,
+                        changesToShow,
                         lineLength,
                         highlightLine
                     );

--- a/client/src/app/site/motions/services/motion-pdf.service.ts
+++ b/client/src/app/site/motions/services/motion-pdf.service.ts
@@ -612,7 +612,6 @@ export class MotionPdfService {
             motionText = this.motionRepo.formatStatuteAmendment(statutes, motion, lineLength);
         } else {
             // lead motion or normal amendments
-            // TODO: Consider tile change recommendation
 
             const changes = this.getUnifiedChanges(motion, lineLength);
             const textChanges = changes.filter(change => !change.isTitleChange());


### PR DESCRIPTION
The call to . this.diff.getTextRemainderAfterLastChange took the unfiltered `changes`, which lead to a too short text if there were unpublished changes.