### PR TITLE
Fixes some autocompleted inputs

### DIFF
--- a/client/src/app/shared/components/extension-field/extension-field.component.html
+++ b/client/src/app/shared/components/extension-field/extension-field.component.html
@@ -31,6 +31,7 @@
     <mat-form-field>
         <input
             matInput
+            autocomplete="off"
             osAutofocus
             [(ngModel)]="inputControl"
             placeholder="{{ extensionLabel }}"

--- a/client/src/app/site/login/components/reset-password-confirm/reset-password-confirm.component.html
+++ b/client/src/app/site/login/components/reset-password-confirm/reset-password-confirm.component.html
@@ -1,9 +1,10 @@
 <div class="form-wrapper">
-    <form [formGroup]="newPasswordForm" (ngSubmit)="submitNewPassword()">
+    <form [formGroup]="newPasswordForm" (ngSubmit)="submitNewPassword()" autocomplete="off">
         <h3 translate>Please enter your new password</h3>
         <mat-form-field>
             <input
                 matInput
+                autocomplete="off"
                 required
                 placeholder="{{ 'New password' | translate }}"
                 formControlName="password"

--- a/client/src/app/site/login/components/reset-password/reset-password.component.html
+++ b/client/src/app/site/login/components/reset-password/reset-password.component.html
@@ -1,8 +1,8 @@
 <div class="form-wrapper">
-    <form [formGroup]="resetPasswordForm" (ngSubmit)="resetPassword()">
+    <form [formGroup]="resetPasswordForm" (ngSubmit)="resetPassword()" autocomplete="off">
         <h3 translate>Enter your email to send the password reset link</h3>
         <mat-form-field>
-            <input matInput required placeholder="{{ 'Email' | translate }}" formControlName="email" type="email" />
+            <input matInput required placeholder="{{ 'Email' | translate }}" formControlName="email" type="email" autocomplete="off" />
             <mat-error *ngIf="resetPasswordForm.get('email').invalid" translate>
                 Please enter a valid email address!
             </mat-error>

--- a/client/src/app/site/users/components/password/password.component.html
+++ b/client/src/app/site/users/components/password/password.component.html
@@ -55,11 +55,15 @@
         <form [formGroup]="userPasswordForm" (keydown)="onKeyDown($event)">
             <mat-form-field>
                 <input
+                    [type]="hideOldPassword ? 'password' : 'text'"
                     matInput
                     formControlName="oldPassword"
                     placeholder="{{ 'Old password' | translate }}"
                     required
                 />
+                <mat-icon mat-button matSuffix mat-icon-button (click)="hideOldPassword = !hideOldPassword">
+                    {{ hideOldPassword ? 'visibility' : 'visibility_off' }}
+                </mat-icon>
             </mat-form-field><br>
             <mat-form-field>
                 <input

--- a/client/src/app/site/users/components/password/password.component.ts
+++ b/client/src/app/site/users/components/password/password.component.ts
@@ -50,6 +50,11 @@ export class PasswordComponent extends BaseViewComponent implements OnInit {
      */
     public hidePassword = true;
 
+    /**
+     * if the old password should be shown
+     */
+    public hideOldPassword = true;
+
     private urlUserId: number | null;
 
     /**

--- a/client/src/app/site/users/components/user-detail/user-detail.component.html
+++ b/client/src/app/site/users/components/user-detail/user-detail.component.html
@@ -105,6 +105,7 @@
                 <input
                     type="email"
                     matInput
+                    autocomplete="off"
                     placeholder="{{ 'Email' | translate }}"
                     name="email"
                     formControlName="email"
@@ -164,6 +165,7 @@
             <mat-form-field>
                 <input
                     matInput
+                    autocomplete="off"
                     placeholder="{{ 'Initial password' | translate }}"
                     formControlName="default_password"
                     [value]="user.default_password || ''"


### PR DESCRIPTION
- The inputs of the `extension-field`s won't be autocompleted
- The inputs for the passwords and emails, too
- The input of the 'old password' (for changing password) gets the type 'password' to hide the input