### PR TITLE
Split client production builds in travis (closes #4849)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -132,7 +132,7 @@ matrix:
         - ng build
 
     - language: node_js
-      name: "Client: Production Build"
+      name: "Client: Production Build (ES5)"
       node_js:
         - "10.9"
       cache:
@@ -142,6 +142,24 @@ matrix:
         - npm install -g @angular/cli@~8.0.6
         - ng --version
         - cd client
+        - sed -i '/\"target\"/c\\"target\":\"es5\",' tsconfig.json
+      install:
+        - npm install
+      script:
+        - npm run ng-high-memory -- build --prod --aot
+
+    - language: node_js
+      name: "Client: Production Build (ES2015)"
+      node_js:
+        - "10.9"
+      cache:
+        directories:
+          - node_modules
+      before_install:
+        - npm install -g @angular/cli@~8.0.6
+        - ng --version
+        - cd client
+        - echo "Firefox ESR" > browserslist
       install:
         - npm install
       script:


### PR DESCRIPTION
A good read to understand this: https://angular.io/guide/deployment#configuring-differential-loading

For the pure ES5 build just setting the target to `es5` is enough. To only compile to ES2015, the browserlist is cleared to just contain browsers with ES2015 support, so the `ES5 browserlist result` (See the nice table in the angular docs) is `disabled`. This is done by just allowing firefox ESR, because it does support ES2015.