### PR TITLE
Fix PDF TOC header

### DIFF
--- a/client/src/app/site/motions/services/motion-pdf-catalog.service.ts
+++ b/client/src/app/site/motions/services/motion-pdf-catalog.service.ts
@@ -132,7 +132,7 @@ export class MotionPdfCatalogService {
                             body: [
                                 [
                                     {
-                                        text: category.getTitle(),
+                                        text: category.nameWithParentAbove,
                                         style: !!category.parent ? 'tocSubcategoryTitle' : 'tocCategoryTitle'
                                     }
                                 ]
@@ -158,7 +158,12 @@ export class MotionPdfCatalogService {
                     }
 
                     catTocBody.push(
-                        this.pdfService.createTocTableDef(tocBody, StyleType.CATEGORY_SECTION, layout, header)
+                        this.pdfService.createTocTableDef(
+                            tocBody,
+                            StyleType.CATEGORY_SECTION,
+                            layout,
+                            header ? JSON.parse(JSON.stringify(header)) : null
+                        )
                     );
 
                     catTocBody.push(this.pdfService.getPageBreak());


### PR DESCRIPTION
Fixes an error where the PDF TOC header could not be repeated.
PDFmake seems to ignore soft references to objects. It will print them exactly once and then ignore them.

Also Adds the name of a parent category in a TOC-Table