### PR TITLE
Add better change detection to MediaFiles

### DIFF
--- a/client/src/app/shared/components/list-view-table/list-view-table.component.ts
+++ b/client/src/app/shared/components/list-view-table/list-view-table.component.ts
@@ -268,11 +268,11 @@ export class ListViewTableComponent<V extends BaseViewModel, M extends BaseModel
         private operator: OperatorService,
         vp: ViewportService,
         private store: StorageService,
-        private ref: ChangeDetectorRef
+        private cd: ChangeDetectorRef
     ) {
         vp.isMobileSubject.subscribe(mobile => {
             if (mobile !== this.isMobile) {
-                this.ref.markForCheck();
+                this.cd.markForCheck();
             }
             this.isMobile = mobile;
         });

--- a/client/src/app/site/common/components/global-spinner/global-spinner.component.ts
+++ b/client/src/app/site/common/components/global-spinner/global-spinner.component.ts
@@ -39,12 +39,12 @@ export class GlobalSpinnerComponent implements OnInit, OnDestroy {
      *
      * @param spinnerService Reference to the service for this spinner.
      * @param translate Service to get translations for the messages.
-     * @param detector Service to manual initiate a change of the UI.
+     * @param cd Service to manual initiate a change of the UI.
      */
     public constructor(
         private spinnerService: SpinnerService,
         protected translate: TranslateService,
-        private detector: ChangeDetectorRef
+        private cd: ChangeDetectorRef
     ) {}
 
     /**
@@ -59,7 +59,7 @@ export class GlobalSpinnerComponent implements OnInit, OnDestroy {
                 if (!this.text) {
                     this.text = this.LOADING;
                 }
-                this.detector.detectChanges();
+                this.cd.detectChanges();
             });
     }
 

--- a/client/src/app/site/config/components/config-field/config-field.component.ts
+++ b/client/src/app/site/config/components/config-field/config-field.component.ts
@@ -97,7 +97,7 @@ export class ConfigFieldComponent extends BaseComponent implements OnInit {
      * @param titleService Title
      * @param translate TranslateService
      * @param formBuilder FormBuilder
-     * @param cdRef ChangeDetectorRef
+     * @param cd ChangeDetectorRef
      * @param repo ConfigRepositoryService
      * @param dateTimeAdapter DateTimeAdapter
      */
@@ -105,7 +105,7 @@ export class ConfigFieldComponent extends BaseComponent implements OnInit {
         protected titleService: Title,
         protected translate: TranslateService,
         private formBuilder: FormBuilder,
-        private cdRef: ChangeDetectorRef,
+        private cd: ChangeDetectorRef,
         public repo: ConfigRepositoryService
     ) {
         super(titleService, translate);
@@ -160,7 +160,7 @@ export class ConfigFieldComponent extends BaseComponent implements OnInit {
         this.debounceTimeout = <any>setTimeout(() => {
             this.update(value);
         }, this.configItem.getDebouncingTimeout());
-        this.cdRef.detectChanges();
+        this.cd.detectChanges();
     }
 
     /**
@@ -194,22 +194,22 @@ export class ConfigFieldComponent extends BaseComponent implements OnInit {
         this.updateSuccessIconTimeout = <any>setTimeout(() => {
             this.updateSuccessIcon = false;
             if (!this.wasViewDestroyed()) {
-                this.cdRef.detectChanges();
+                this.cd.detectChanges();
             }
         }, 2000);
         this.updateSuccessIcon = true;
         if (!this.wasViewDestroyed()) {
-            this.cdRef.detectChanges();
+            this.cd.detectChanges();
         }
     }
 
     /**
-     * @returns true, if the veiw was destroyed. Note: This
+     * @returns true, if the view was destroyed. Note: This
      * needs to access internal attributes from the change detection
      * reference.
      */
     private wasViewDestroyed(): boolean {
-        return (<any>this.cdRef).destroyed;
+        return (<any>this.cd).destroyed;
     }
 
     /**
@@ -218,7 +218,7 @@ export class ConfigFieldComponent extends BaseComponent implements OnInit {
     private setError(error: string): void {
         this.error = error;
         this.form.setErrors({ error: true });
-        this.cdRef.detectChanges();
+        this.cd.detectChanges();
     }
 
     /**

--- a/client/src/app/site/mediafiles/components/mediafile-list/mediafile-list.component.ts
+++ b/client/src/app/site/mediafiles/components/mediafile-list/mediafile-list.component.ts
@@ -5,7 +5,8 @@ import {
     TemplateRef,
     OnDestroy,
     ViewEncapsulation,
-    ChangeDetectionStrategy
+    ChangeDetectionStrategy,
+    ChangeDetectorRef
 } from '@angular/core';
 import { BehaviorSubject, Subscription } from 'rxjs';
 import { FormGroup, Validators, FormBuilder } from '@angular/forms';
@@ -188,7 +189,8 @@ export class MediafileListComponent extends BaseViewComponent implements OnInit,
         private dialog: MatDialog,
         private fb: FormBuilder,
         private formBuilder: FormBuilder,
-        private groupRepo: GroupRepositoryService
+        private groupRepo: GroupRepositoryService,
+        private cd: ChangeDetectorRef
     ) {
         super(titleService, translate, matSnackBar);
 
@@ -255,6 +257,7 @@ export class MediafileListComponent extends BaseViewComponent implements OnInit,
                 this.dataSource = createDS<ViewMediafile>()
                     .onTrigger(() => mediafiles)
                     .create();
+                this.cd.detectChanges();
             }
         });
 


### PR DESCRIPTION
There was a chance that the file browser did not update after creating or renaming a folder.
Also unified the naming of the `ChangeDetectorRef` to `cd` (as it is on most angular examples, tutorials, projects)