### PR TITLE
Major cache rewrite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
         - pip freeze
       script:
         - mypy openslides/ tests/
-        - pytest --cov --cov-fail-under=76
+        - pytest --cov --cov-fail-under=75
 
     - language: python
       name: "Server: Tests Python 3.7"
@@ -36,7 +36,7 @@ matrix:
         - isort --check-only --diff --recursive openslides tests
         - black --check --diff --target-version py36 openslides tests
         - mypy openslides/ tests/
-        - pytest --cov --cov-fail-under=76
+        - pytest --cov --cov-fail-under=75
 
     - language: python
       name: "Server: Tests Startup Routine Python 3.7"

--- a/client/package.json
+++ b/client/package.json
@@ -24,8 +24,8 @@
         "po2json-tempfix": "./node_modules/.bin/po2json -f mf src/assets/i18n/de.po /dev/stdout | sed -f sed_replacements > src/assets/i18n/de.json && ./node_modules/.bin/po2json -f mf src/assets/i18n/cs.po /dev/stdout | sed -f sed_replacements > src/assets/i18n/cs.json",
         "prettify-check": "prettier --config ./.prettierrc --list-different \"src/{app,environments}/**/*{.ts,.js,.json,.css,.scss}\"",
         "prettify-write": "prettier --config ./.prettierrc --write \"src/{app,environments}/**/*{.ts,.js,.json,.css,.scss}\"",
-        "cleanup": "npm run lint-write; npm run prettify-write",
-        "cleanup-win": "npm run lint-write & npm run prettify-write"
+        "cleanup": "npm run prettify-write; npm run lint-write",
+        "cleanup-win": "npm run prettify-write & npm run lint-write"
     },
     "dependencies": {
         "@angular/animations": "^8.0.3",

--- a/client/src/app/core/core-services/autoupdate.service.ts
+++ b/client/src/app/core/core-services/autoupdate.service.ts
@@ -96,7 +96,10 @@ export class AutoupdateService {
         Object.keys(autoupdate.changed).forEach(collection => {
             elements = elements.concat(this.mapObjectsToBaseModels(collection, autoupdate.changed[collection]));
         });
+
+        const updateSlot = await this.DSUpdateManager.getNewUpdateSlot(this.DS);
         await this.DS.set(elements, autoupdate.to_change_id);
+        this.DSUpdateManager.commit(updateSlot);
     }
 
     /**
@@ -107,7 +110,7 @@ export class AutoupdateService {
         const maxChangeId = this.DS.maxChangeId;
 
         if (autoupdate.from_change_id <= maxChangeId && autoupdate.to_change_id <= maxChangeId) {
-            console.log('ignore');
+            console.log(`Ignore. Clients change id: ${maxChangeId}`);
             return; // Ignore autoupdates, that lay full behind our changeid.
         }
 

--- a/client/src/app/core/core-services/constants.service.ts
+++ b/client/src/app/core/core-services/constants.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 
-import { Observable, of, Subject } from 'rxjs';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { filter } from 'rxjs/operators';
 
 import { WebsocketService } from './websocket.service';
 
@@ -28,17 +29,12 @@ export class ConstantsService {
     /**
      * The constants
      */
-    private constants: Constants;
-
-    /**
-     * Flag, if constants are requested, but the server hasn't send them yet.
-     */
-    private pending = false;
+    private constants: Constants = {};
 
     /**
      * Pending requests will be notified by these subjects, one per key.
      */
-    private pendingSubject: { [key: string]: Subject<any> } = {};
+    private subjects: { [key: string]: BehaviorSubject<any> } = {};
 
     /**
      * @param websocketService
@@ -47,29 +43,16 @@ export class ConstantsService {
         // The hook for recieving constants.
         websocketService.getOberservable<Constants>('constants').subscribe(constants => {
             this.constants = constants;
-            if (this.pending) {
-                // send constants to subscribers that await constants.
-                this.pending = false;
-                this.informSubjects();
-            }
+            Object.keys(this.subjects).forEach(key => {
+                this.subjects[key].next(this.constants[key]);
+            });
         });
 
         // We can request constants, if the websocket connection opens.
         // On retries, the `refresh()` method is called by the OpenSlidesService, so
         // here we do not need to take care about this.
         websocketService.noRetryConnectEvent.subscribe(() => {
-            if (this.pending) {
-                this.websocketService.send('constants', {});
-            }
-        });
-    }
-
-    /**
-     * Inform subjects about changes.
-     */
-    private informSubjects(): void {
-        Object.keys(this.pendingSubject).forEach(key => {
-            this.pendingSubject[key].next(this.constants[key]);
+            this.refresh();
         });
     }
 
@@ -78,32 +61,19 @@ export class ConstantsService {
      * @param key The constant to get.
      */
     public get<T>(key: string): Observable<T> {
-        if (this.constants) {
-            return of(this.constants[key]);
-        } else {
-            // we have to request constants.
-            if (!this.pending) {
-                this.pending = true;
-                // if the connection is open, we directly can send the request.
-                if (this.websocketService.isConnected) {
-                    this.websocketService.send('constants', {});
-                }
-            }
-            if (!this.pendingSubject[key]) {
-                this.pendingSubject[key] = new Subject<any>();
-            }
-            return this.pendingSubject[key].asObservable() as Observable<T>;
+        if (!this.subjects[key]) {
+            this.subjects[key] = new BehaviorSubject<any>(this.constants[key]);
         }
+        return this.subjects[key].asObservable().pipe(filter(x => !!x));
     }
 
     /**
      * Refreshed the constants
      */
-    public async refresh(): Promise<void> {
+    public refresh(): Promise<void> {
         if (!this.websocketService.isConnected) {
             return;
         }
-        this.constants = await this.websocketService.sendAndGetResponse('constants', {});
-        this.informSubjects();
+        this.websocketService.send('constants', {});
     }
 }

--- a/client/src/app/core/core-services/websocket.service.ts
+++ b/client/src/app/core/core-services/websocket.service.ts
@@ -183,6 +183,11 @@ export class WebsocketService {
     private retryCounter = 0;
 
     /**
+     * The timeout in the onClose-handler for the next reconnect retry.
+     */
+    private retryTimeout: any = null;
+
+    /**
      * Constructor that handles the router
      * @param matSnackBar
      * @param zone
@@ -385,9 +390,17 @@ export class WebsocketService {
 
             // A random retry timeout between 2000 and 5000 ms.
             const timeout = Math.floor(Math.random() * 3000 + 2000);
-            setTimeout(() => {
+            this.retryTimeout = setTimeout(() => {
+                this.retryTimeout = null;
                 this.connect({ enableAutoupdates: true }, true);
             }, timeout);
+        }
+    }
+
+    public cancelReconnectenRetry(): void {
+        if (this.retryTimeout) {
+            clearTimeout(this.retryTimeout);
+            this.retryTimeout = null;
         }
     }
 

--- a/openslides/core/config.py
+++ b/openslides/core/config.py
@@ -49,7 +49,7 @@ class ConfigHandler:
         if not self.exists(key):
             raise ConfigNotFound(f"The config variable {key} was not found.")
 
-        return async_to_sync(element_cache.get_element_full_data)(
+        return async_to_sync(element_cache.get_element_data)(
             self.get_collection_string(), self.get_key_to_id()[key]
         )["value"]
 
@@ -85,7 +85,7 @@ class ConfigHandler:
             if self.key_to_id is not None:
                 return
 
-        config_full_data = await element_cache.get_collection_full_data(
+        config_full_data = await element_cache.get_collection_data(
             self.get_collection_string()
         )
         elements = config_full_data.values()

--- a/openslides/core/config_variables.py
+++ b/openslides/core/config_variables.py
@@ -1,3 +1,5 @@
+import uuid
+
 from django.core.validators import MaxLengthValidator
 
 from openslides.core.config import ConfigVariable
@@ -394,11 +396,18 @@ def get_config_variables():
         group="Custom translations",
     )
 
-    # Config version
+    # Config version and DB id
     yield ConfigVariable(
         name="config_version",
         input_type="integer",
         default_value=1,
+        group="Version",
+        hidden=True,
+    )
+    yield ConfigVariable(
+        name="db_id",
+        input_type="string",
+        default_value=uuid.uuid4().hex,
         group="Version",
         hidden=True,
     )

--- a/openslides/core/models.py
+++ b/openslides/core/models.py
@@ -287,7 +287,7 @@ class HistoryManager(models.Manager):
         instances = None
         if self.all().count() == 0:
             elements = []
-            all_full_data = async_to_sync(element_cache.get_all_full_data)()
+            all_full_data = async_to_sync(element_cache.get_all_data_list)()
             for collection_string, data in all_full_data.items():
                 for full_data in data:
                     elements.append(

--- a/openslides/core/views.py
+++ b/openslides/core/views.py
@@ -608,7 +608,7 @@ class HistoryDataView(utils_views.APIView):
         )
         missing_keys = all_current_config_keys - all_old_config_keys
         if missing_keys:
-            config_full_data = async_to_sync(element_cache.get_collection_full_data)(
+            config_full_data = async_to_sync(element_cache.get_collection_data)(
                 "core/config"
             )
             key_to_id = config.get_key_to_id()

--- a/openslides/core/websocket.py
+++ b/openslides/core/websocket.py
@@ -5,11 +5,9 @@ from ..utils.constants import get_constants
 from ..utils.projector import get_projector_data
 from ..utils.stats import WebsocketLatencyLogger
 from ..utils.websocket import (
-    WEBSOCKET_CHANGE_ID_TOO_HIGH,
     WEBSOCKET_NOT_AUTHORIZED,
     BaseWebsocketClientMessage,
     ProtocollAsyncJsonWebsocketConsumer,
-    get_element_data,
 )
 
 
@@ -116,18 +114,7 @@ class GetElementsWebsocketClientMessage(BaseWebsocketClientMessage):
         self, consumer: "ProtocollAsyncJsonWebsocketConsumer", content: Any, id: str
     ) -> None:
         requested_change_id = content.get("change_id", 0)
-        try:
-            element_data = await get_element_data(
-                consumer.scope["user"]["id"], requested_change_id
-            )
-        except ValueError as error:
-            await consumer.send_error(
-                code=WEBSOCKET_CHANGE_ID_TOO_HIGH, message=str(error), in_response=id
-            )
-        else:
-            await consumer.send_json(
-                type="autoupdate", content=element_data, in_response=id
-            )
+        await consumer.send_autoupdate(requested_change_id, in_response=id)
 
 
 class AutoupdateWebsocketClientMessage(BaseWebsocketClientMessage):

--- a/openslides/utils/access_permissions.py
+++ b/openslides/utils/access_permissions.py
@@ -86,16 +86,14 @@ class RequiredUsers:
         user_ids: Set[int] = set()
 
         for collection_string in collection_strings:
-            collection_full_data = await element_cache.get_collection_full_data(
-                collection_string
-            )
+            collection_data = await element_cache.get_collection_data(collection_string)
             # Get the callable for the collection_string
             get_user_ids = self.callables.get(collection_string)
-            if not (get_user_ids and collection_full_data):
+            if not (get_user_ids and collection_data):
                 # if the collection_string is unknown or it has no data, do nothing
                 continue
 
-            for element in collection_full_data.values():
+            for element in collection_data.values():
                 user_ids.update(get_user_ids(element))
 
         return user_ids

--- a/openslides/utils/auth.py
+++ b/openslides/utils/auth.py
@@ -67,14 +67,14 @@ async def async_has_perm(user_id: int, perm: str) -> bool:
         has_perm = False
     elif not user_id:
         # Use the permissions from the default group.
-        default_group = await element_cache.get_element_full_data(
+        default_group = await element_cache.get_element_data(
             group_collection_string, GROUP_DEFAULT_PK
         )
         if default_group is None:
             raise RuntimeError("Default Group does not exist.")
         has_perm = perm in default_group["permissions"]
     else:
-        user_data = await element_cache.get_element_full_data(
+        user_data = await element_cache.get_element_data(
             user_collection_string, user_id
         )
         if user_data is None:
@@ -87,7 +87,7 @@ async def async_has_perm(user_id: int, perm: str) -> bool:
             # permission. If the user has no groups, then use the default group.
             group_ids = user_data["groups_id"] or [GROUP_DEFAULT_PK]
             for group_id in group_ids:
-                group = await element_cache.get_element_full_data(
+                group = await element_cache.get_element_data(
                     group_collection_string, group_id
                 )
                 if group is None:
@@ -131,7 +131,7 @@ async def async_in_some_groups(user_id: int, groups: List[int]) -> bool:
         # Use the permissions from the default group.
         in_some_groups = GROUP_DEFAULT_PK in groups
     else:
-        user_data = await element_cache.get_element_full_data(
+        user_data = await element_cache.get_element_data(
             user_collection_string, user_id
         )
         if user_data is None:
@@ -167,7 +167,7 @@ async def async_anonymous_is_enabled() -> bool:
     """
     from ..core.config import config
 
-    element = await element_cache.get_element_full_data(
+    element = await element_cache.get_element_data(
         config.get_collection_string(),
         (await config.async_get_key_to_id())["general_system_enable_anonymous"],
     )

--- a/openslides/utils/cache.py
+++ b/openslides/utils/cache.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 import logging
 from collections import defaultdict
@@ -7,42 +6,54 @@ from time import sleep
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
 from asgiref.sync import async_to_sync
-from django.conf import settings
+from django.apps import apps
 
 from .cache_providers import (
     Cachable,
     ElementCacheProvider,
     MemmoryCacheProvider,
     RedisCacheProvider,
-    get_all_cachables,
 )
 from .redis import use_redis
+from .schema_version import SchemaVersion, schema_version_handler
 from .utils import get_element_id, split_element_id
 
 
 logger = logging.getLogger(__name__)
 
 
+def get_all_cachables() -> List[Cachable]:
+    """
+    Returns all element of OpenSlides.
+    """
+    out: List[Cachable] = []
+    for app in apps.get_app_configs():
+        try:
+            # Get the method get_startup_elements() from an app.
+            # This method has to return an iterable of Cachable objects.
+            get_startup_elements = app.get_startup_elements
+        except AttributeError:
+            # Skip apps that do not implement get_startup_elements.
+            continue
+        out.extend(get_startup_elements())
+    return out
+
+
 class ElementCache:
     """
     Cache for the elements.
 
-    Saves the full_data and if enabled the restricted data.
+    Saves the full_data
 
-    There is one redis Hash (simular to python dict) for the full_data and one
-    Hash for every user.
+    There is one redis Hash (simular to python dict) for the full_data
 
     The key of the Hashes is COLLECTIONSTRING:ID where COLLECTIONSTRING is the
     collection_string of a collection and id the id of an element.
 
-    All elements have to be in the cache. If one element is missing, the cache
-    is invalid, but this can not be detected. When a plugin with a new
-    collection is added to OpenSlides, then the cache has to be rebuild manualy.
-
     There is an sorted set in redis with the change id as score. The values are
     COLLETIONSTRING:ID for the elements that have been changed with that change
-    id. With this key it is possible, to get all elements as full_data or as
-    restricted_data that are newer then a specific change id.
+    id. With this key it is possible, to get all elements as full_data
+    that are newer then a specific change id.
 
     All method of this class are async. You either have to call them with
     await in an async environment or use asgiref.sync.async_to_sync().
@@ -50,36 +61,34 @@ class ElementCache:
 
     def __init__(
         self,
-        use_restricted_data_cache: bool = False,
         cache_provider_class: Type[ElementCacheProvider] = RedisCacheProvider,
         cachable_provider: Callable[[], List[Cachable]] = get_all_cachables,
-        start_time: int = None,
+        default_change_id: Optional[int] = None,
     ) -> None:
         """
         Initializes the cache.
-
-        When restricted_data_cache is false, no restricted data is saved.
         """
-        self.use_restricted_data_cache = use_restricted_data_cache
-        self.cache_provider = cache_provider_class()
+        self.cache_provider = cache_provider_class(self.async_ensure_cache)
         self.cachable_provider = cachable_provider
         self._cachables: Optional[Dict[str, Cachable]] = None
+        self.set_default_change_id(default_change_id)
 
-        # Start time is used as first change_id if there is non in redis
-        if start_time is None:
+    def set_default_change_id(self, default_change_id: Optional[int] = None) -> None:
+        """
+        Sets the default change id for the cache. Needs to update, if the cache gets generated.
+        """
+        # The current time is used as the first change_id if there is non in redis
+        if default_change_id is None:
             # Use the miliseconds (rounted) since the 2016-02-29.
-            start_time = (
+            default_change_id = (
                 int((datetime.utcnow() - datetime(2016, 2, 29)).total_seconds()) * 1000
             )
-        self.start_time = start_time
-
-        # Tells if self.ensure_cache was called.
-        self.ensured = False
+        self.default_change_id = default_change_id
 
     @property
     def cachables(self) -> Dict[str, Cachable]:
         """
-        Returns all Cachables as a dict where the key is the collection_string of the cachable.
+        Returns all cachables as a dict where the key is the collection_string of the cachable.
         """
         # This method is neccessary to lazy load the cachables
         if self._cachables is None:
@@ -89,45 +98,71 @@ class ElementCache:
             }
         return self._cachables
 
-    def ensure_cache(self, reset: bool = False) -> None:
+    def ensure_cache(
+        self, reset: bool = False, default_change_id: Optional[int] = None
+    ) -> None:
         """
-        Makes sure that the cache exist.
-
-        Builds the cache if not. If reset is True, it will be reset in any case.
-
-        This method is sync, so it can be run when OpenSlides starts.
+        Ensures the existance of the cache; see async_ensure_cache for more info.
         """
-        cache_exists = async_to_sync(self.cache_provider.data_exists)()
+        async_to_sync(self.async_ensure_cache)(reset, default_change_id)
+
+    async def async_ensure_cache(
+        self, reset: bool = False, default_change_id: Optional[int] = None
+    ) -> None:
+        """
+        Makes sure that the cache exist. Builds the cache if not or reset is given as True.
+        """
+        cache_exists = await self.cache_provider.data_exists()
 
         if reset or not cache_exists:
-            lock_name = "ensure_cache"
-            # Set a lock so only one process builds the cache
-            if async_to_sync(self.cache_provider.set_lock)(lock_name):
-                logger.info("Building up the cache data...")
-                try:
-                    mapping = {}
-                    for collection_string, cachable in self.cachables.items():
-                        for element in cachable.get_elements():
-                            mapping.update(
-                                {
-                                    get_element_id(
-                                        collection_string, element["id"]
-                                    ): json.dumps(element)
-                                }
-                            )
-                    logger.info("Done building the cache data.")
-                    logger.info("Saving cache data into the cache...")
-                    async_to_sync(self.cache_provider.reset_full_cache)(mapping)
-                    logger.info("Done saving the cache data.")
-                finally:
-                    async_to_sync(self.cache_provider.del_lock)(lock_name)
-            else:
-                logger.info("Wait for another process to build up the cache...")
-                while async_to_sync(self.cache_provider.get_lock)(lock_name):
-                    sleep(0.01)
-                logger.info("Cache is ready (built by another process).")
+            await self.build_cache(default_change_id)
 
-        self.ensured = True
+    def ensure_schema_version(self) -> None:
+        async_to_sync(self.async_ensure_schema_version)()
+
+    async def async_ensure_schema_version(self) -> None:
+        cache_schema_version = await self.cache_provider.get_schema_version()
+        schema_changed = not schema_version_handler.compare(cache_schema_version)
+        schema_version_handler.log_current()
+
+        cache_exists = await self.cache_provider.data_exists()
+        if schema_changed or not cache_exists:
+            await self.build_cache(schema_version=schema_version_handler.get())
+
+    async def build_cache(
+        self,
+        default_change_id: Optional[int] = None,
+        schema_version: Optional[SchemaVersion] = None,
+    ) -> None:
+        lock_name = "build_cache"
+        # Set a lock so only one process builds the cache
+        if await self.cache_provider.set_lock(lock_name):
+            logger.info("Building up the cache data...")
+            try:
+                mapping = {}
+                for collection_string, cachable in self.cachables.items():
+                    for element in cachable.get_elements():
+                        mapping.update(
+                            {
+                                get_element_id(
+                                    collection_string, element["id"]
+                                ): json.dumps(element)
+                            }
+                        )
+                logger.info("Done building the cache data.")
+                logger.info("Saving cache data into the cache...")
+                self.set_default_change_id(default_change_id=default_change_id)
+                await self.cache_provider.reset_full_cache(mapping)
+                if schema_version:
+                    await self.cache_provider.set_schema_version(schema_version)
+                logger.info("Done saving the cache data.")
+            finally:
+                await self.cache_provider.del_lock(lock_name)
+        else:
+            logger.info("Wait for another process to build up the cache...")
+            while await self.cache_provider.get_lock(lock_name):
+                sleep(0.01)
+            logger.info("Cache is ready (built by another process).")
 
     async def change_elements(
         self, elements: Dict[str, Optional[Dict[str, Any]]]
@@ -135,16 +170,12 @@ class ElementCache:
         """
         Changes elements in the cache.
 
-        elements is a list of the changed elements as dict. When the value is None,
-        it is interpreded as deleted. The key has to be an element_id.
+        elements is a dict with element_id <-> changed element. When the value is None,
+        it is interpreded as deleted.
 
         Returns the new generated change_id.
         """
-        if not self.ensured:
-            raise RuntimeError(
-                "Call element_cache.ensure_cache before changing elements."
-            )
-
+        # Split elements into changed and deleted.
         deleted_elements = []
         changed_elements = []
         for element_id, data in elements.items():
@@ -155,47 +186,90 @@ class ElementCache:
             else:
                 deleted_elements.append(element_id)
 
-        if changed_elements:
-            await self.cache_provider.add_elements(changed_elements)
-        if deleted_elements:
-            await self.cache_provider.del_elements(deleted_elements)
-
         return await self.cache_provider.add_changed_elements(
-            self.start_time + 1, elements.keys()
+            changed_elements, deleted_elements, self.default_change_id + 1
         )
 
-    async def get_all_full_data(self) -> Dict[str, List[Dict[str, Any]]]:
+    async def get_all_data_list(
+        self, user_id: Optional[int] = None
+    ) -> Dict[str, List[Dict[str, Any]]]:
         """
-        Returns all full_data.
+        Returns all data with a list per collection:
+        {
+            <collection>: [<element>, <element>, ...]
+        }
+        If the user id is given the data will be restricted for this user.
+        """
+        all_data: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+        for element_id, data in (await self.cache_provider.get_all_data()).items():
+            collection_string, _ = split_element_id(element_id)
+            all_data[collection_string].append(json.loads(data.decode()))
 
-        The returned value is a dict where the key is the collection_string and
-        the value is a list of data.
-        """
-        all_data = await self.get_all_full_data_ordered()
-        out: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
-        for collection_string, collection_data in all_data.items():
-            for data in collection_data.values():
-                out[collection_string].append(data)
-        return dict(out)
+        if user_id is not None:
+            for collection_string in all_data.keys():
+                restricter = self.cachables[collection_string].restrict_elements
+                all_data[collection_string] = await restricter(
+                    user_id, all_data[collection_string]
+                )
+        return dict(all_data)
 
-    async def get_all_full_data_ordered(self) -> Dict[str, Dict[int, Dict[str, Any]]]:
+    async def get_all_data_dict(self) -> Dict[str, Dict[int, Dict[str, Any]]]:
         """
-        Like get_all_full_data but orders the element of one collection by there
-        id.
+        Returns all data with a dict (id <-> element) per collection:
+        {
+            <collection>: {
+                <id>: <element>
+            }
+        }
         """
-        out: Dict[str, Dict[int, Dict[str, Any]]] = defaultdict(dict)
-        full_data = await self.cache_provider.get_all_data()
-        for element_id, data in full_data.items():
+        all_data: Dict[str, Dict[int, Dict[str, Any]]] = defaultdict(dict)
+        for element_id, data in (await self.cache_provider.get_all_data()).items():
             collection_string, id = split_element_id(element_id)
-            out[collection_string][id] = json.loads(data.decode())
-        return dict(out)
+            all_data[collection_string][id] = json.loads(data.decode())
+        return dict(all_data)
 
-    async def get_full_data(
-        self, change_id: int = 0, max_change_id: int = -1
+    async def get_collection_data(
+        self, collection_string: str
+    ) -> Dict[int, Dict[str, Any]]:
+        """
+        Returns the data for one collection as dict: {id: <element>}
+        """
+        encoded_collection_data = await self.cache_provider.get_collection_data(
+            collection_string
+        )
+        collection_data = {}
+        for id in encoded_collection_data.keys():
+            collection_data[id] = json.loads(encoded_collection_data[id].decode())
+        return collection_data
+
+    async def get_element_data(
+        self, collection_string: str, id: int, user_id: Optional[int] = None
+    ) -> Optional[Dict[str, Any]]:
+        """
+        Returns one element or None, if the element does not exist.
+        If the user id is given the data will be restricted for this user.
+        """
+        encoded_element = await self.cache_provider.get_element_data(
+            get_element_id(collection_string, id)
+        )
+
+        if encoded_element is None:
+            return None
+        element = json.loads(encoded_element.decode())  # type: ignore
+
+        if user_id is not None:
+            restricter = self.cachables[collection_string].restrict_elements
+            restricted_elements = await restricter(user_id, [element])
+            element = restricted_elements[0] if restricted_elements else None
+        return element
+
+    async def get_data_since(
+        self, user_id: Optional[int] = None, change_id: int = 0, max_change_id: int = -1
     ) -> Tuple[Dict[str, List[Dict[str, Any]]], List[str]]:
         """
-        Returns all full_data since change_id until max_change_id (including).
-        max_change_id -1 means the highest change_id.
+        Returns all data since change_id until max_change_id (included).
+        max_change_id -1 means the highest change_id. If the user id is given the
+        data will be restricted for this user.
 
         Returns two values inside a tuple. The first value is a dict where the
         key is the collection_string and the value is a list of data. The second
@@ -210,7 +284,7 @@ class ElementCache:
         that the cache does not know about.
         """
         if change_id == 0:
-            return (await self.get_all_full_data(), [])
+            return (await self.get_all_data_list(user_id), [])
 
         # This raises a Runtime Exception, if there is no change_id
         lowest_change_id = await self.get_lowest_change_id()
@@ -226,245 +300,39 @@ class ElementCache:
         raw_changed_elements, deleted_elements = await self.cache_provider.get_data_since(
             change_id, max_change_id=max_change_id
         )
-        return (
-            {
-                collection_string: [json.loads(value.decode()) for value in value_list]
-                for collection_string, value_list in raw_changed_elements.items()
-            },
-            deleted_elements,
-        )
+        changed_elements = {
+            collection_string: [json.loads(value.decode()) for value in value_list]
+            for collection_string, value_list in raw_changed_elements.items()
+        }
 
-    async def get_collection_full_data(
-        self, collection_string: str
-    ) -> Dict[int, Dict[str, Any]]:
-        full_data = await self.cache_provider.get_collection_data(collection_string)
-        out = {}
-        for element_id, data in full_data.items():
-            returned_collection_string, id = split_element_id(element_id)
-            if returned_collection_string == collection_string:
-                out[id] = json.loads(data.decode())
-        return out
-
-    async def get_element_full_data(
-        self, collection_string: str, id: int
-    ) -> Optional[Dict[str, Any]]:
-        """
-        Returns one element as full data.
-
-        Returns None if the element does not exist.
-        """
-        element = await self.cache_provider.get_element(
-            get_element_id(collection_string, id)
-        )
-
-        if element is None:
-            return None
-        return json.loads(element.decode())
-
-    async def exists_restricted_data(self, user_id: int) -> bool:
-        """
-        Returns True, if the restricted_data exists for the user.
-        """
-        if not self.use_restricted_data_cache:
-            return False
-
-        return await self.cache_provider.data_exists(user_id)
-
-    async def del_user(self, user_id: int) -> None:
-        """
-        Removes one user from the resticted_data_cache.
-        """
-        await self.cache_provider.del_restricted_data(user_id)
-
-    async def update_restricted_data(self, user_id: int) -> None:
-        """
-        Updates the restricted data for an user from the full_data_cache.
-        """
-        # TODO: When elements are changed at the same time then this method run
-        #       this could make the cache invalid.
-        #       This could be fixed when get_full_data would be used with a
-        #       max change_id.
-        if not self.use_restricted_data_cache:
-            # If the restricted_data_cache is not used, there is nothing to do
-            return
-
-        if not self.ensured:
-            raise RuntimeError(
-                "Call element_cache.ensure_cache before updating restricted data."
-            )
-
-        # Try to write a special key.
-        # If this succeeds, there is noone else currently updating the cache.
-        # TODO: Make a timeout. Else this could block forever
-        lock_name = f"restricted_data_{user_id}"
-        if await self.cache_provider.set_lock(lock_name):
-            # Get change_id for this user
-            value = await self.cache_provider.get_change_id_user(user_id)
-            # If the change id is not in the cache yet, use -1 to get all data since 0
-            user_change_id = int(value) if value else -1
-            change_id = await self.get_current_change_id()
-            if change_id > user_change_id:
-                try:
-                    full_data_elements, deleted_elements = await self.get_full_data(
-                        user_change_id + 1
-                    )
-                except RuntimeError:
-                    # The user_change_id is lower then the lowest change_id in the cache.
-                    # The whole restricted_data for that user has to be recreated.
-                    full_data_elements = await self.get_all_full_data()
-                    deleted_elements = []
-                    await self.cache_provider.del_restricted_data(user_id)
-
-                mapping = {}
-                for collection_string, full_data in full_data_elements.items():
-                    restricter = self.cachables[collection_string].restrict_elements
-                    restricted_elements = await restricter(user_id, full_data)
-
-                    # find all elements the user can not see at all
-                    full_data_ids = set(element["id"] for element in full_data)
-                    restricted_data_ids = set(
-                        element["id"] for element in restricted_elements
-                    )
-                    for item_id in full_data_ids - restricted_data_ids:
-                        deleted_elements.append(
-                            get_element_id(collection_string, item_id)
-                        )
-
-                    for element in restricted_elements:
-                        # The user can see the element
-                        mapping.update(
-                            {
-                                get_element_id(
-                                    collection_string, element["id"]
-                                ): json.dumps(element)
-                            }
-                        )
-                mapping["_config:change_id"] = str(change_id)
-                await self.cache_provider.update_restricted_data(user_id, mapping)
-                # Remove deleted elements
-                if deleted_elements:
-                    await self.cache_provider.del_elements(deleted_elements, user_id)
-            # Unset the lock
-            await self.cache_provider.del_lock(lock_name)
-        else:
-            # Wait until the update if finshed
-            while await self.cache_provider.get_lock(lock_name):
-                await asyncio.sleep(0.01)
-
-    async def get_all_restricted_data(
-        self, user_id: int
-    ) -> Dict[str, List[Dict[str, Any]]]:
-        """
-        Like get_all_full_data but with restricted_data for an user.
-        """
-        if not self.use_restricted_data_cache:
-            all_restricted_data = {}
-            for collection_string, full_data in (
-                await self.get_all_full_data()
-            ).items():
+        if user_id is not None:
+            for collection_string, elements in changed_elements.items():
                 restricter = self.cachables[collection_string].restrict_elements
-                elements = await restricter(user_id, full_data)
-                all_restricted_data[collection_string] = elements
-            return all_restricted_data
-
-        await self.update_restricted_data(user_id)
-
-        out: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
-        restricted_data = await self.cache_provider.get_all_data(user_id)
-        for element_id, data in restricted_data.items():
-            if element_id.decode().startswith("_config"):
-                continue
-            collection_string, __ = split_element_id(element_id)
-            out[collection_string].append(json.loads(data.decode()))
-        return dict(out)
-
-    async def get_restricted_data(
-        self, user_id: int, change_id: int = 0, max_change_id: int = -1
-    ) -> Tuple[Dict[str, List[Dict[str, Any]]], List[str]]:
-        """
-        Like get_full_data but with restricted_data for an user.
-        """
-        if change_id == 0:
-            # Return all data
-            return (await self.get_all_restricted_data(user_id), [])
-
-        if not self.use_restricted_data_cache:
-            changed_elements, deleted_elements = await self.get_full_data(
-                change_id, max_change_id
-            )
-            restricted_data = {}
-            for collection_string, full_data in changed_elements.items():
-                restricter = self.cachables[collection_string].restrict_elements
-                elements = await restricter(user_id, full_data)
+                restricted_elements = await restricter(user_id, elements)
 
                 # Add removed objects (through restricter) to deleted elements.
-                full_data_ids = set([data["id"] for data in full_data])
-                restricted_data_ids = set([data["id"] for data in elements])
-                for id in full_data_ids - restricted_data_ids:
+                element_ids = set([element["id"] for element in elements])
+                restricted_element_ids = set(
+                    [element["id"] for element in restricted_elements]
+                )
+                for id in element_ids - restricted_element_ids:
                     deleted_elements.append(get_element_id(collection_string, id))
 
-                if elements:
-                    restricted_data[collection_string] = elements
-            return restricted_data, deleted_elements
+                if not restricted_elements:
+                    del changed_elements[collection_string]
+                else:
+                    changed_elements[collection_string] = restricted_elements
 
-        lowest_change_id = await self.get_lowest_change_id()
-        if change_id < lowest_change_id:
-            # When change_id is lower then the lowest change_id in redis, we can
-            # not inform the user about deleted elements.
-            raise RuntimeError(
-                f"change_id {change_id} is lower then the lowest change_id in redis {lowest_change_id}. "
-                "Catch this exception and rerun the method with change_id=0."
-            )
-
-        # If another coroutine or another daphne server also updates the restricted
-        # data, this waits until it is done.
-        await self.update_restricted_data(user_id)
-
-        raw_changed_elements, deleted_elements = await self.cache_provider.get_data_since(
-            change_id, user_id, max_change_id
-        )
-        return (
-            {
-                collection_string: [json.loads(value.decode()) for value in value_list]
-                for collection_string, value_list in raw_changed_elements.items()
-            },
-            deleted_elements,
-        )
-
-    async def get_element_restricted_data(
-        self, user_id: int, collection_string: str, id: int
-    ) -> Optional[Dict[str, Any]]:
-        """
-        Returns the restricted_data of one element.
-
-        Returns None, if the element does not exists or the user has no permission to see it.
-        """
-        if not self.use_restricted_data_cache:
-            full_data = await self.get_element_full_data(collection_string, id)
-            if full_data is None:
-                return None
-            restricter = self.cachables[collection_string].restrict_elements
-            restricted_data = await restricter(user_id, [full_data])
-            return restricted_data[0] if restricted_data else None
-
-        await self.update_restricted_data(user_id)
-
-        out = await self.cache_provider.get_element(
-            get_element_id(collection_string, id), user_id
-        )
-        return json.loads(out.decode()) if out else None
+        return (changed_elements, deleted_elements)
 
     async def get_current_change_id(self) -> int:
         """
         Returns the current change id.
 
-        Returns start_time if there is no change id yet.
+        Returns default_change_id if there is no change id yet.
         """
         value = await self.cache_provider.get_current_change_id()
-        if not value:
-            return self.start_time
-        # Return the score (second element) of the first (and only) element
-        return value[0][1]
+        return value if value is not None else self.default_change_id
 
     async def get_lowest_change_id(self) -> int:
         """
@@ -479,7 +347,7 @@ class ElementCache:
         return value
 
 
-def load_element_cache(restricted_data: bool = True) -> ElementCache:
+def load_element_cache() -> ElementCache:
     """
     Generates an element cache instance.
     """
@@ -488,12 +356,8 @@ def load_element_cache(restricted_data: bool = True) -> ElementCache:
     else:
         cache_provider_class = MemmoryCacheProvider
 
-    return ElementCache(
-        cache_provider_class=cache_provider_class,
-        use_restricted_data_cache=restricted_data,
-    )
+    return ElementCache(cache_provider_class=cache_provider_class)
 
 
 # Set the element_cache
-use_restricted_data = getattr(settings, "RESTRICTED_DATA_CACHE", True)
-element_cache = load_element_cache(restricted_data=use_restricted_data)
+element_cache = load_element_cache()

--- a/openslides/utils/middleware.py
+++ b/openslides/utils/middleware.py
@@ -54,7 +54,7 @@ async def get_user(scope: Dict[str, Any]) -> Dict[str, Any]:
         pass
     else:
         if backend_path in settings.AUTHENTICATION_BACKENDS:
-            user = await element_cache.get_element_full_data("users/user", user_id)
+            user = await element_cache.get_element_data("users/user", user_id)
             if user:
                 # Verify the session
                 session_hash = session.get(HASH_SESSION_KEY)

--- a/openslides/utils/projector.py
+++ b/openslides/utils/projector.py
@@ -67,7 +67,7 @@ async def get_projector_data(
     if projector_ids is None:
         projector_ids = []
 
-    all_data = await element_cache.get_all_full_data_ordered()
+    all_data = await element_cache.get_all_data_dict()
     projector_data: Dict[int, List[Dict[str, Any]]] = {}
 
     for projector_id, projector in all_data.get("core/projector", {}).items():

--- a/openslides/utils/rest_api.py
+++ b/openslides/utils/rest_api.py
@@ -253,10 +253,11 @@ class ListModelMixin(_ListModelMixin):
             # The corresponding queryset does not support caching.
             response = super().list(request, *args, **kwargs)
         else:
+            # TODO
             # This loads all data from the cache, not only the requested data.
             # If we would use the rest api, we should add a method
             # element_cache.get_collection_restricted_data
-            all_restricted_data = async_to_sync(element_cache.get_all_restricted_data)(
+            all_restricted_data = async_to_sync(element_cache.get_all_data_list)(
                 request.user.pk or 0
             )
             response = Response(all_restricted_data.get(collection_string, []))
@@ -278,8 +279,8 @@ class RetrieveModelMixin(_RetrieveModelMixin):
         else:
             lookup_url_kwarg = self.lookup_url_kwarg or self.lookup_field
             user_id = request.user.pk or 0
-            content = async_to_sync(element_cache.get_element_restricted_data)(
-                user_id, collection_string, self.kwargs[lookup_url_kwarg]
+            content = async_to_sync(element_cache.get_element_data)(
+                collection_string, self.kwargs[lookup_url_kwarg], user_id
             )
             if content is None:
                 raise Http404

--- a/openslides/utils/schema_version.py
+++ b/openslides/utils/schema_version.py
@@ -1,0 +1,84 @@
+import logging
+from typing import Optional
+
+from django.db.models import Max
+from mypy_extensions import TypedDict
+
+
+logger = logging.getLogger(__name__)
+SchemaVersion = TypedDict("SchemaVersion", {"migration": int, "config": int, "db": str})
+
+
+class SchemaVersionHandler:
+    """
+    Handler for the schema version of this running OpenSlides instance.
+    What is a schema version? This is an indictor of the current schema of the data
+    in the database, config variables, and the database itself. E.b. with a migration,
+    new/changed config variables or with a database change, the schema of the data changes.
+
+    To detect this is needed to reset the cache, so it does not hold any old data. This
+    affects the server cache, but also the client uses this technique to flush the cache.
+
+    Get the current schema with `get`. The schema version is built just once. After a change
+    in the schema, all workers needs a restart!
+    """
+
+    def __init__(self) -> None:
+        self._schema_version: Optional[SchemaVersion] = None
+
+    def get(self) -> SchemaVersion:
+        if self._schema_version is not None:
+            return self._schema_version
+
+        from django.db.migrations.recorder import MigrationRecorder
+
+        migration = MigrationRecorder.Migration.objects.aggregate(Max("id"))["id__max"]
+
+        from openslides.core.config import ConfigStore
+
+        try:
+            config = ConfigStore.objects.get(key="config_version").value
+        except ConfigStore.DoesNotExist:
+            config = 0
+        try:
+            db = ConfigStore.objects.get(key="db_id").value
+        except ConfigStore.DoesNotExist:
+            db = ""
+
+        self._schema_version = {"migration": migration, "config": config, "db": db}
+        return self._schema_version
+
+    def compare(self, other: Optional[SchemaVersion]) -> bool:
+        current = self.get()
+
+        if not other:
+            logger.info("No old schema version")
+            return False
+
+        equal = True
+        if current["db"] != other["db"]:
+            other_db = other["db"] or "<empty>"
+            logger.info(f"DB changed from {other_db} to {current['db']}")
+            equal = False
+        if current["config"] != other["config"]:
+            other_config = other["config"] or "<empty>"
+            logger.info(f"Config changed from {other_config} to {current['config']}")
+            equal = False
+        if current["migration"] != other["migration"]:
+            logger.info(
+                f"Migration changed from {other['migration']} to {current['migration']}"
+            )
+            equal = False
+        return equal
+
+    def log_current(self) -> None:
+        current = self.get()
+        logger.info(
+            f"""Schema version:
+    DB:        {current["db"]}
+    migration: {current["migration"]}
+    config:    {current["config"]}"""
+        )
+
+
+schema_version_handler = SchemaVersionHandler()

--- a/openslides/utils/settings.py.tpl
+++ b/openslides/utils/settings.py.tpl
@@ -100,11 +100,6 @@ if use_redis:
     # or a unix domain socket path string — "/path/to/redis.sock".
     REDIS_ADDRESS = "redis://127.0.0.1"
 
-    # When use_redis is True, the restricted data cache caches the data individuel
-    # for each user. This requires a lot of memory if there are a lot of active
-    # users.
-    RESTRICTED_DATA_CACHE = True
-
     # Session backend
 
     # Redis configuration for django-redis-sessions.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,5 +82,5 @@ def reset_cache(request):
         async_to_sync(element_cache.cache_provider.clear_cache)()
         element_cache.ensure_cache(reset=True)
 
-    # Set constant start_time
-    element_cache.start_time = 1
+    # Set constant default change_id
+    element_cache.set_default_change_id(1)

--- a/tests/integration/websocket.py
+++ b/tests/integration/websocket.py
@@ -23,3 +23,16 @@ class WebsocketCommunicator(ChannelsWebsocketCommunicator):
 
         assert isinstance(text_data, str), "JSON data is not a text frame"
         return json.loads(text_data)
+
+    async def assert_receive_error(self, timeout=1, in_response=None, **kwargs):
+        response = await self.receive_json_from(timeout)
+        assert response["type"] == "error"
+
+        content = response.get("content")
+        if kwargs:
+            assert content
+        for key, value in kwargs.items():
+            assert content.get(key) == value
+
+        if in_response:
+            assert response["in_response"] == in_response


### PR DESCRIPTION
- Removed the restricted data cache (it wasn't used since OS 3.0)
- unify functions for restricted and full data: Just one function, which
  accteps an optional user_id: If it is None, full data is returned, and
  with a user id given, the restricted data
- More atomic access to redis, especially for:
- Check for data-existance in redis and do an auto-ensure-cache.
- Speedup through hashing of scripts and redis' script cache.
- Save schema version into the redis cache and rebuild, if the version
  changed