### PR TITLE
Add speakers-filter to motion list

### DIFF
--- a/client/src/app/site/motions/models/view-motion.ts
+++ b/client/src/app/site/motions/models/view-motion.ts
@@ -329,6 +329,10 @@ export class ViewMotion extends BaseViewModelWithAgendaItemAndListOfSpeakers<Mot
         return !!this.personalNote && !!this.personalNote.note;
     }
 
+    public get hasSpeakers(): boolean {
+        return this.speakerAmount > 0;
+    }
+
     /**
      * Translate the state's css class into a color
      *

--- a/client/src/app/site/motions/services/motion-filter-list.service.ts
+++ b/client/src/app/site/motions/services/motion-filter-list.service.ts
@@ -88,6 +88,15 @@ export class MotionFilterListService extends BaseFilterListService<ViewMotion> {
         options: []
     };
 
+    public hasSpeakerOptions: OsFilter = {
+        property: 'hasSpeakers',
+        label: 'Speakers',
+        options: [
+            { condition: true, label: this.translate.instant('Has speakers') },
+            { condition: false, label: this.translate.instant('Has no speakers') }
+        ]
+    };
+
     public personalNoteFilterOptions = [
         {
             property: 'star',
@@ -211,6 +220,11 @@ export class MotionFilterListService extends BaseFilterListService<ViewMotion> {
             this.motionCommentFilterOptions,
             this.tagFilterOptions
         ];
+
+        // only add the filter if the user has the correct permission
+        if (this.operator.hasPerms('agenda.can_see_list_of_speakers')) {
+            filterDefinitions.push(this.hasSpeakerOptions);
+        }
 
         if (!this.operator.isAnonymous) {
             filterDefinitions = filterDefinitions.concat(this.personalNoteFilterOptions);


### PR DESCRIPTION
The motion list (and the amendment list) now have an option to filter if speakers are present on the corresponding LOS-object to the displayed motions