### PR TITLE
Enhance amendment list and routing logic

### DIFF
--- a/client/src/app/core/ui-services/base-filter-list.service.ts
+++ b/client/src/app/core/ui-services/base-filter-list.service.ts
@@ -241,28 +241,33 @@ export abstract class BaseFilterListService<V extends BaseViewModel> {
                 storedFilter = await this.store.get<OsFilter[]>('filter_' + this.storageKey);
             }
 
-            if (!!storedFilter) {
+            if (storedFilter && storedFilter.length && newDefinitions && newDefinitions.length) {
                 for (const newDef of newDefinitions) {
-                    let count = 0;
-                    const matchingExistingFilter = storedFilter.find(oldDef => oldDef.property === newDef.property);
-                    for (const option of newDef.options) {
-                        if (typeof option === 'object') {
-                            if (matchingExistingFilter && matchingExistingFilter.options) {
-                                const existingOption = matchingExistingFilter.options.find(
-                                    o =>
-                                        typeof o !== 'string' &&
-                                        JSON.stringify(o.condition) === JSON.stringify(option.condition)
-                                ) as OsFilterOption;
-                                if (existingOption) {
-                                    option.isActive = existingOption.isActive;
-                                }
-                                if (option.isActive) {
-                                    count++;
+                    console.log('set filter');
+
+                    // for some weird angular bugs, newDef can actually be undefined
+                    if (newDef) {
+                        let count = 0;
+                        const matchingExistingFilter = storedFilter.find(oldDef => oldDef.property === newDef.property);
+                        for (const option of newDef.options) {
+                            if (typeof option === 'object') {
+                                if (matchingExistingFilter && matchingExistingFilter.options) {
+                                    const existingOption = matchingExistingFilter.options.find(
+                                        o =>
+                                            typeof o !== 'string' &&
+                                            JSON.stringify(o.condition) === JSON.stringify(option.condition)
+                                    ) as OsFilterOption;
+                                    if (existingOption) {
+                                        option.isActive = existingOption.isActive;
+                                    }
+                                    if (option.isActive) {
+                                        count++;
+                                    }
                                 }
                             }
                         }
+                        newDef.count = count;
                     }
-                    newDef.count = count;
                 }
             }
 

--- a/client/src/app/core/ui-services/routing-state.service.ts
+++ b/client/src/app/core/ui-services/routing-state.service.ts
@@ -31,7 +31,7 @@ export class RoutingStateService {
         if (this._previousUrl) {
             return !this.unsafeUrls.some(unsafeUrl => this._previousUrl.includes(unsafeUrl));
         } else {
-            return false;
+            return true;
         }
     }
 

--- a/client/src/app/site/motions/modules/amendment-list/amendment-list.component.ts
+++ b/client/src/app/site/motions/modules/amendment-list/amendment-list.component.ts
@@ -30,7 +30,11 @@ import { ViewMotion } from '../../models/view-motion';
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class AmendmentListComponent extends BaseListViewComponent<ViewMotion> implements OnInit {
+    /**
+     * Has the id of the parent motion if passed through the constructor
+     */
     private parentMotionId: number;
+
     /**
      * Hold item visibility
      */
@@ -95,6 +99,11 @@ export class AmendmentListComponent extends BaseListViewComponent<ViewMotion> im
         super.setTitle('Amendments');
         this.canMultiSelect = true;
         this.parentMotionId = parseInt(route.snapshot.params.id, 10);
+        if (this.parentMotionId) {
+            this.amendmentFilterService.parentMotionId = this.parentMotionId;
+        } else {
+            this.amendmentFilterService.parentMotionId = undefined;
+        }
     }
 
     /**
@@ -106,10 +115,7 @@ export class AmendmentListComponent extends BaseListViewComponent<ViewMotion> im
         });
 
         if (!!this.parentMotionId) {
-            this.amendmentFilterService.clearAllFilters();
-            this.amendmentFilterService.parentMotionId = this.parentMotionId;
-        } else {
-            this.amendmentFilterService.parentMotionId = 0;
+            // this.amendmentFilterService.clearAllFilters();
         }
     }
 

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.html
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.html
@@ -2,7 +2,6 @@
     [mainButton]="perms.isAllowed('can_create_amendments', motion)"
     mainActionTooltip="New amendment"
     [prevUrl]="getPrevUrl()"
-    [goBack]="routingStateService.isSafePrevUrl"
     [nav]="false"
     [editMode]="editMotion"
     [isSaveButtonEnabled]="contentForm.valid"
@@ -441,12 +440,11 @@
         <!-- Ammendments -->
         <div *ngIf="!editMotion && amendments && amendments.length > 0">
             <h4 translate>Amendments</h4>
-            <a *ngIf="amendments.length === 1" [routerLink]="['/motions/amendments', motion.id]">
-                {{ amendments.length }} <span translate>Amendment</span>
+            <a [routerLink]="['/motions/amendments', motion.id]">
+                {{ amendments.length }}
+                <span *ngIf="amendments.length === 1" translate>Amendment</span>
+                <span *ngIf="amendments.length > 1" translate>Amendments</span>
             </a>
-            <a *ngIf="amendments.length > 1" [routerLink]="['/motions/amendments', motion.id]">
-                {{ amendments.length }} <span translate>Amendments</span></a
-            >
         </div>
 
         <!-- motion polls -->

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.ts
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.ts
@@ -447,7 +447,7 @@ export class MotionDetailComponent extends BaseViewComponent implements OnInit, 
         private itemRepo: ItemRepositoryService,
         private motionSortService: MotionSortListService,
         private motionFilterService: MotionFilterListService,
-        public routingStateService: RoutingStateService
+        private routingStateService: RoutingStateService
     ) {
         super(title, translate, matSnackBar);
     }
@@ -1557,7 +1557,15 @@ export class MotionDetailComponent extends BaseViewComponent implements OnInit, 
     public getPrevUrl(): string {
         if (this.motion && this.motion.parent_id) {
             if (this.routingStateService.previousUrl && this.routingStateService.isSafePrevUrl) {
-                return this.routingStateService.previousUrl;
+                if (
+                    (this.previousMotion &&
+                        this.routingStateService.previousUrl === this.previousMotion.getDetailStateURL()) ||
+                    (this.nextMotion && this.routingStateService.previousUrl === this.nextMotion.getDetailStateURL())
+                ) {
+                    return '../..';
+                } else {
+                    return this.routingStateService.previousUrl;
+                }
             } else {
                 return this.motion.parent.getDetailStateURL();
             }

--- a/client/src/app/site/motions/services/amendment-filter-list.service.ts
+++ b/client/src/app/site/motions/services/amendment-filter-list.service.ts
@@ -26,25 +26,34 @@ export class AmendmentFilterListService extends MotionFilterListService {
     /**
      * Private accessor for an amendment id
      */
-    private _parentMotionId: number;
+    public _parentMotionId: number;
 
     /**
      * set the storage key nae
      */
-    protected storageKey = 'AmendmentList';
+    protected storageKey: string;
+
+    /**
+     * The sorage key prefix to identify the parent id
+     */
+    private keyPrefix = 'AmendmentList';
+
+    /**
+     * Filters by motion parent id
+     */
+    private motionFilterOptions: OsFilter = {
+        property: 'parent_id',
+        label: 'Motion',
+        options: []
+    };
 
     /**
      * publicly get an amendment id
      */
     public set parentMotionId(id: number) {
         this._parentMotionId = id;
+        this.updateStorageKey();
     }
-
-    private motionFilterOptions: OsFilter = {
-        property: 'parent_id',
-        label: 'Motion',
-        options: []
-    };
 
     public constructor(
         store: StorageService,
@@ -78,9 +87,20 @@ export class AmendmentFilterListService extends MotionFilterListService {
     }
 
     /**
+     * Function to define a new storage key by parent id
+     */
+    private updateStorageKey(): void {
+        if (!!this._parentMotionId) {
+            this.storageKey = `${this.keyPrefix}_parentId_${this._parentMotionId}`;
+        } else {
+            this.storageKey = this.keyPrefix;
+        }
+    }
+
+    /**
      * @override from base filter list service
      *
-     * @returns the list of Motions which only contains view motions
+     * @returns the only motons with a parentId
      */
     protected preFilter(motions: ViewMotion[]): ViewMotion[] {
         return motions.filter(motion => {
@@ -96,6 +116,8 @@ export class AmendmentFilterListService extends MotionFilterListService {
      * Currently, no filters for the amendment list, except the pre-filter
      */
     protected getFilterDefinitions(): OsFilter[] {
-        return [this.motionFilterOptions].concat(super.getFilterDefinitions());
+        if (this.motionFilterOptions) {
+            return [this.motionFilterOptions].concat(super.getFilterDefinitions());
+        }
     }
 }


### PR DESCRIPTION
- ~~After navigation to the amendment list from a motion detail view
  set the correct filter~~
- ~~only use the main amendment filter component for all amendment-list purposes~~
- ~~clears the filter if the routing state changes~~
- enhance the routing state back logic again, going back after creating
  a new amendment will bring you to the old motion

Had some incredible nasty side effects. I suppose there is a serious bug in angular, that allows to execute functions in services even before the constructor of a service was called.
Enhance the current features of own views to filter amendments

(still) not covered here:
- sort by line number
- multiselect