### PR TITLE
Fixed bug sending always all data to users, who get restricted data

### DIFF
--- a/openslides/utils/consumers.py
+++ b/openslides/utils/consumers.py
@@ -7,7 +7,7 @@ from ..utils.websocket import WEBSOCKET_CHANGE_ID_TOO_HIGH
 from . import logging
 from .auth import async_anonymous_is_enabled
 from .autoupdate import AutoupdateFormat
-from .cache import element_cache, split_element_id
+from .cache import ChangeIdTooLowError, element_cache, split_element_id
 from .utils import get_worker_id
 from .websocket import ProtocollAsyncJsonWebsocketConsumer
 
@@ -138,7 +138,7 @@ class SiteConsumer(ProtocollAsyncJsonWebsocketConsumer):
             changed_elements, deleted_element_ids = await element_cache.get_data_since(
                 user_id, change_id, max_change_id
             )
-        except RuntimeError:
+        except ChangeIdTooLowError:
             # The change_id is lower the the lowerst change_id in redis. Return all data
             changed_elements = await element_cache.get_all_data_list(user_id)
             all_data = True

--- a/tests/unit/utils/test_cache.py
+++ b/tests/unit/utils/test_cache.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List
 
 import pytest
 
-from openslides.utils.cache import ElementCache
+from openslides.utils.cache import ChangeIdTooLowError, ElementCache
 
 from .cache_provider import TTestCacheProvider, example_data, get_cachable_provider
 
@@ -156,7 +156,7 @@ async def test_get_data_since_change_id_lower_than_in_redis(element_cache):
     }
     element_cache.cache_provider.default_change_id = 2
     element_cache.cache_provider.change_id_data = {2: {"app/collection1:1"}}
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ChangeIdTooLowError):
         await element_cache.get_data_since(None, 1)
 
 
@@ -283,7 +283,7 @@ async def test_get_restricted_data_2(element_cache):
 async def test_get_restricted_data_change_id_lower_than_in_redis(element_cache):
     element_cache.cache_provider.default_change_id = 2
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ChangeIdTooLowError):
         await element_cache.get_data_since(0, 1)
 
 


### PR DESCRIPTION
Due to changes in an iterator, a RuntimeError was thrown but interpred al a too low change id. Fixed the bug and make a custom exception for this.