### PR TITLE
Add sort service for amendments

### DIFF
--- a/client/src/app/core/core-services/relation-manager.service.ts
+++ b/client/src/app/core/core-services/relation-manager.service.ts
@@ -82,12 +82,18 @@ export class RelationManagerService {
                 );
                 viewModel['_' + relation.ownKey] = foreignViewModels;
                 this.sortByRelation(relation, viewModel);
+                if (relation.afterSetRelation) {
+                    relation.afterSetRelation(viewModel, foreignViewModels);
+                }
             } else if (relation.type === 'M2O') {
                 const foreignViewModel = this.viewModelStoreService.get(
                     relation.foreignViewModel,
                     model[relation.ownIdKey]
                 );
                 viewModel['_' + relation.ownKey] = foreignViewModel;
+                if (relation.afterSetRelation) {
+                    relation.afterSetRelation(viewModel, foreignViewModel);
+                }
             }
         } else if (isReverseRelationDefinition(relation) && !initialLoading) {
             if (relation.type === 'M2M') {
@@ -203,12 +209,19 @@ export class RelationManagerService {
                 ) {
                     const foreignViewModel = <any>this.viewModelStoreService.get(collection, changedId);
                     this.setForeingViewModelInOwnViewModelArray(foreignViewModel, ownViewModel, relation.ownKey);
+                    if (relation.afterDependencyChange) {
+                        relation.afterDependencyChange(ownViewModel, foreignViewModel);
+                    }
                     return true;
                 }
             } else if (relation.type === 'M2O') {
                 if (ownViewModel[relation.ownIdKey] === <any>changedId) {
                     // Check, if this is the matching foreign view model.
-                    ownViewModel['_' + relation.ownKey] = <any>this.viewModelStoreService.get(collection, changedId);
+                    const foreignViewModel = this.viewModelStoreService.get(collection, changedId);
+                    ownViewModel['_' + relation.ownKey] = <any>foreignViewModel;
+                    if (relation.afterDependencyChange) {
+                        relation.afterDependencyChange(ownViewModel, foreignViewModel);
+                    }
                     return true;
                 }
             }

--- a/client/src/app/core/definitions/relations.ts
+++ b/client/src/app/core/definitions/relations.ts
@@ -39,6 +39,8 @@ interface BaseNormalRelationDefinition<VForeign extends BaseViewModel> extends B
      * the model and view model. E.g. `category_id` in a motion.
      */
     ownIdKey: string;
+
+    afterDependencyChange?: (ownViewModel: BaseViewModel, foreignViewModel: BaseViewModel) => void;
 }
 
 /**
@@ -56,16 +58,19 @@ interface NormalM2MRelationDefinition<VForeign extends BaseViewModel>
     extends BaseNormalRelationDefinition<VForeign>,
         BaseOrderedRelation<VForeign> {
     type: 'M2M';
+    afterSetRelation?: (ownViewModel: BaseViewModel, foreignViewModels: BaseViewModel[]) => void;
 }
 
 interface NormalO2MRelationDefinition<VForeign extends BaseViewModel>
     extends BaseNormalRelationDefinition<VForeign>,
         BaseOrderedRelation<VForeign> {
     type: 'O2M';
+    afterSetRelation?: (ownViewModel: BaseViewModel, foreignViewModels: BaseViewModel[]) => void;
 }
 
 interface NormalM2ORelationDefinition<VForeign extends BaseViewModel> extends BaseNormalRelationDefinition<VForeign> {
     type: 'M2O';
+    afterSetRelation?: (ownViewModel: BaseViewModel, foreignViewModel: BaseViewModel | null) => void;
 }
 
 export type NormalRelationDefinition<VForeign extends BaseViewModel = BaseViewModel> =

--- a/client/src/app/core/ui-services/base-filter-list.service.ts
+++ b/client/src/app/core/ui-services/base-filter-list.service.ts
@@ -243,8 +243,6 @@ export abstract class BaseFilterListService<V extends BaseViewModel> {
 
             if (storedFilter && storedFilter.length && newDefinitions && newDefinitions.length) {
                 for (const newDef of newDefinitions) {
-                    console.log('set filter');
-
                     // for some weird angular bugs, newDef can actually be undefined
                     if (newDef) {
                         let count = 0;

--- a/client/src/app/shared/components/sort-filter-bar/sort-filter-bar.component.ts
+++ b/client/src/app/shared/components/sort-filter-bar/sort-filter-bar.component.ts
@@ -208,8 +208,9 @@ export class SortFilterBarComponent<V extends BaseViewModel> {
      * Retrieves the currently active icon for an option.
      * @param option
      */
-    public getSortIcon(option: OsSortingOption<V>): string {
-        return this.sortService.getSortIcon(option);
+    public getSortIcon(option: OsSortingOption<V>): string | null {
+        const icon = this.sortService.getSortIcon(option);
+        return icon ? icon : null;
     }
 
     /**

--- a/client/src/app/site/assignments/services/assignment-sort-list.service.ts
+++ b/client/src/app/site/assignments/services/assignment-sort-list.service.ts
@@ -15,9 +15,14 @@ import { ViewAssignment } from '../models/view-assignment';
 })
 export class AssignmentSortListService extends BaseSortListService<ViewAssignment> {
     /**
+     * set the storage key name
+     */
+    protected storageKey = 'AssignmentList';
+
+    /**
      * Define the sort options
      */
-    public sortOptions: OsSortingOption<ViewAssignment>[] = [
+    private assignmentSortOptions: OsSortingOption<ViewAssignment>[] = [
         { property: 'title', label: 'Name' },
         { property: 'phase', label: 'Phase' },
         { property: 'candidateAmount', label: 'Number of candidates' },
@@ -31,7 +36,14 @@ export class AssignmentSortListService extends BaseSortListService<ViewAssignmen
      * @param storage required by parent
      */
     public constructor(translate: TranslateService, storage: StorageService, OSStatus: OpenSlidesStatusService) {
-        super('Assignment', translate, storage, OSStatus);
+        super(translate, storage, OSStatus);
+    }
+
+    /**
+     * @override
+     */
+    protected getSortOptions(): OsSortingOption<ViewAssignment>[] {
+        return this.assignmentSortOptions;
     }
 
     /**

--- a/client/src/app/site/mediafiles/services/mediafiles-sort-list.service.ts
+++ b/client/src/app/site/mediafiles/services/mediafiles-sort-list.service.ts
@@ -14,7 +14,12 @@ import { ViewMediafile } from '../models/view-mediafile';
     providedIn: 'root'
 })
 export class MediafilesSortListService extends BaseSortListService<ViewMediafile> {
-    public sortOptions: OsSortingOption<ViewMediafile>[] = [
+    /**
+     * set the storage key name
+     */
+    protected storageKey = 'MediafileList';
+
+    private mediafilesSortOptions: OsSortingOption<ViewMediafile>[] = [
         { property: 'title' },
         {
             property: 'type',
@@ -33,7 +38,14 @@ export class MediafilesSortListService extends BaseSortListService<ViewMediafile
      * @param store required by parent
      */
     public constructor(translate: TranslateService, store: StorageService, OSStatus: OpenSlidesStatusService) {
-        super('Mediafiles', translate, store, OSStatus);
+        super(translate, store, OSStatus);
+    }
+
+    /**
+     * @override
+     */
+    protected getSortOptions(): OsSortingOption<ViewMediafile>[] {
+        return this.mediafilesSortOptions;
     }
 
     /**

--- a/client/src/app/site/motions/models/view-motion.ts
+++ b/client/src/app/site/motions/models/view-motion.ts
@@ -1,5 +1,6 @@
 import { _ } from 'app/core/translate/translation-marker';
 import { ConfigService } from 'app/core/ui-services/config.service';
+import { DiffLinesInParagraph } from 'app/core/ui-services/diff.service';
 import { SearchProperty, SearchRepresentation } from 'app/core/ui-services/search.service';
 import { Motion, MotionComment } from 'app/shared/models/motions/motion';
 import { PersonalNoteContent } from 'app/shared/models/users/personal-note';
@@ -76,6 +77,7 @@ export class ViewMotion extends BaseViewModelWithAgendaItemAndListOfSpeakers<Mot
     protected _parent?: ViewMotion;
     protected _amendments?: ViewMotion[];
     protected _changeRecommendations?: ViewMotionChangeRecommendation[];
+    protected _diffLines?: DiffLinesInParagraph[];
     public personalNote?: PersonalNoteContent;
 
     public get motion(): Motion {
@@ -340,6 +342,31 @@ export class ViewMotion extends BaseViewModelWithAgendaItemAndListOfSpeakers<Mot
      */
     public get stateCssColor(): string {
         return this.state ? this.state.css_class : '';
+    }
+
+    /**
+     * getter to access diff lines
+     */
+    public get diffLines(): DiffLinesInParagraph[] {
+        if (!this.parent_id) {
+            throw new Error('No parent No diff');
+        }
+        return this._diffLines;
+    }
+
+    public set diffLines(value: DiffLinesInParagraph[]) {
+        this._diffLines = value;
+    }
+
+    /**
+     * Get the number of the first diff line, in case a motion is an amendment
+     */
+    public get parentAndLineNumber(): string | null {
+        if (this.isParagraphBasedAmendment() && this.parent && this.diffLines && this.diffLines.length) {
+            return `${this.parent.identifier} ${this.diffLines[0].diffLineFrom}`;
+        } else {
+            return null;
+        }
     }
 
     // This is set by the repository

--- a/client/src/app/site/motions/modules/amendment-list/amendment-list.component.html
+++ b/client/src/app/site/motions/modules/amendment-list/amendment-list.component.html
@@ -18,7 +18,7 @@
 
 <os-list-view-table
     [repo]="motionRepo"
-    [sortService]="motionSortService"
+    [sortService]="amendmentSortService"
     [filterService]="amendmentFilterService"
     [columns]="tableColumnDefinition"
     [filterProps]="filterProps"
@@ -70,6 +70,7 @@
 
     <!-- Summary -->
     <div *pblNgridCellDef="'summary'; row as motion" class="cell-slot fill">
+        <a class="detail-link" [routerLink]="motion.getDetailStateURL()"></a>
         <div class="innerTable">
             <div class="motion-text" [innerHtml]="sanitizeText(getAmendmentSummary(motion))"></div>
         </div>

--- a/client/src/app/site/motions/services/amendment-sort-list.service.spec.ts
+++ b/client/src/app/site/motions/services/amendment-sort-list.service.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AmendmentSortListService } from './amendment-sort-list.service';
+
+describe('AmendmentSortListService', () => {
+    beforeEach(() => TestBed.configureTestingModule({}));
+
+    it('should be created', () => {
+        const service: AmendmentSortListService = TestBed.get(AmendmentSortListService);
+        expect(service).toBeTruthy();
+    });
+});

--- a/client/src/app/site/motions/services/amendment-sort-list.service.ts
+++ b/client/src/app/site/motions/services/amendment-sort-list.service.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@angular/core';
+
+import { TranslateService } from '@ngx-translate/core';
+
+import { OpenSlidesStatusService } from 'app/core/core-services/openslides-status.service';
+import { StorageService } from 'app/core/core-services/storage.service';
+import { OsSortingDefinition, OsSortingOption } from 'app/core/ui-services/base-sort-list.service';
+import { ConfigService } from 'app/core/ui-services/config.service';
+import { MotionSortListService } from './motion-sort-list.service';
+import { ViewMotion } from '../models/view-motion';
+
+@Injectable({
+    providedIn: 'root'
+})
+export class AmendmentSortListService extends MotionSortListService {
+    /**
+     * set the storage key name
+     */
+    protected storageKey = 'AmendmentList';
+
+    private amendmentSortOptions: OsSortingOption<ViewMotion>[] = [
+        {
+            property: 'parentAndLineNumber',
+            label: 'Main motion and line number'
+        }
+    ];
+
+    public constructor(
+        translate: TranslateService,
+        store: StorageService,
+        OSStatus: OpenSlidesStatusService,
+        config: ConfigService
+    ) {
+        super(translate, store, OSStatus, config);
+    }
+
+    protected getSortOptions(): OsSortingOption<ViewMotion>[] {
+        return this.amendmentSortOptions.concat(super.getSortOptions());
+    }
+
+    protected async getDefaultDefinition(): Promise<OsSortingDefinition<ViewMotion>> {
+        return {
+            sortProperty: 'parentAndLineNumber',
+            sortAscending: true
+        };
+    }
+}

--- a/client/src/app/site/motions/services/motion-block-sort.service.ts
+++ b/client/src/app/site/motions/services/motion-block-sort.service.ts
@@ -11,7 +11,12 @@ import { ViewMotionBlock } from '../models/view-motion-block';
     providedIn: 'root'
 })
 export class MotionBlockSortService extends BaseSortListService<ViewMotionBlock> {
-    public sortOptions: OsSortingOption<ViewMotionBlock>[] = [
+    /**
+     * set the storage key name
+     */
+    protected storageKey = 'MotionBlockList';
+
+    private MotionBlockSortOptions: OsSortingOption<ViewMotionBlock>[] = [
         { property: 'title' },
         {
             property: 'motions',
@@ -25,7 +30,14 @@ export class MotionBlockSortService extends BaseSortListService<ViewMotionBlock>
     ];
 
     public constructor(translate: TranslateService, store: StorageService, OSStatus: OpenSlidesStatusService) {
-        super('Motion block', translate, store, OSStatus);
+        super(translate, store, OSStatus);
+    }
+
+    /**
+     * @override
+     */
+    protected getSortOptions(): OsSortingOption<ViewMotionBlock>[] {
+        return this.MotionBlockSortOptions;
     }
 
     protected async getDefaultDefinition(): Promise<OsSortingDefinition<ViewMotionBlock>> {

--- a/client/src/app/site/motions/services/motion-sort-list.service.ts
+++ b/client/src/app/site/motions/services/motion-sort-list.service.ts
@@ -18,6 +18,11 @@ import { ViewMotion } from '../models/view-motion';
 })
 export class MotionSortListService extends BaseSortListService<ViewMotion> {
     /**
+     * set the storage key name
+     */
+    protected storageKey = 'MotionList';
+
+    /**
      * Hold the default motion sorting
      */
     private defaultMotionSorting: string;
@@ -30,7 +35,7 @@ export class MotionSortListService extends BaseSortListService<ViewMotion> {
     /**
      * Define the sort options
      */
-    public sortOptions: OsSortingOption<ViewMotion>[] = [
+    protected motionSortOptions: OsSortingOption<ViewMotion>[] = [
         { property: 'weight', label: 'Call list' },
         { property: 'identifier' },
         { property: 'title' },
@@ -53,16 +58,20 @@ export class MotionSortListService extends BaseSortListService<ViewMotion> {
         translate: TranslateService,
         store: StorageService,
         OSStatus: OpenSlidesStatusService,
-        private config: ConfigService
+        config: ConfigService
     ) {
-        super('Motion', translate, store, OSStatus);
+        super(translate, store, OSStatus);
 
-        this.config.get<string>('motions_motions_sorting').subscribe(defSortProp => {
+        config.get<string>('motions_motions_sorting').subscribe(defSortProp => {
             if (defSortProp) {
                 this.defaultMotionSorting = defSortProp;
                 this.defaultSortingLoaded.resolve();
             }
         });
+    }
+
+    protected getSortOptions(): OsSortingOption<ViewMotion>[] {
+        return this.motionSortOptions;
     }
 
     /**

--- a/client/src/app/site/users/services/user-sort-list.service.ts
+++ b/client/src/app/site/users/services/user-sort-list.service.ts
@@ -15,9 +15,14 @@ import { ViewUser } from '../models/view-user';
 })
 export class UserSortListService extends BaseSortListService<ViewUser> {
     /**
+     * set the storage key name
+     */
+    protected storageKey = 'UserList';
+
+    /**
      * Define the sort options
      */
-    public sortOptions: OsSortingOption<ViewUser>[] = [
+    private userSortOptions: OsSortingOption<ViewUser>[] = [
         { property: 'first_name', label: 'Given name' },
         { property: 'last_name', label: 'Surname' },
         { property: 'is_present', label: 'Presence' },
@@ -36,7 +41,14 @@ export class UserSortListService extends BaseSortListService<ViewUser> {
      * @param store requires by parent
      */
     public constructor(translate: TranslateService, store: StorageService, OSStatus: OpenSlidesStatusService) {
-        super('User', translate, store, OSStatus);
+        super(translate, store, OSStatus);
+    }
+
+    /**
+     * @override
+     */
+    protected getSortOptions(): OsSortingOption<ViewUser>[] {
+        return this.userSortOptions;
     }
 
     /**


### PR DESCRIPTION
Adds the posibility to sort amendments by the parents identifier
and line number.

Patches the amendment model by their diff lines in runtime

Currently has an issue.
After loading OS the first time, motions **with more than one** diff-line appear to be undefined in the viewModel
Works fine after reloading.

The reason for that is that the initial order of models how they appear from the web socket is flawed. That requires
- waiting for a specific model
- patching models *after* the initial loading was done and all models are present (prefered) @FinnStutzenstein 