### PR TITLE
Fix location of change recommendation annotations

### DIFF
--- a/client/src/app/site/motions/modules/motion-detail/components/motion-detail-original-change-recommendations/motion-detail-original-change-recommendations.component.scss
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-detail-original-change-recommendations/motion-detail-original-change-recommendations.component.scss
@@ -1,7 +1,7 @@
 .change-recommendation-list {
     position: absolute;
     top: 0;
-    left: -25px;
+    left: -10px;
     width: 4px;
     list-style-type: none;
     padding: 0;


### PR DESCRIPTION
This positioning outside of the content box was probably not intentional:
![Bildschirmfoto 2019-09-12 um 10 47 30](https://user-images.githubusercontent.com/533440/64769060-e7841500-d54a-11e9-9b0d-a460dd9720f0.png)
