### PR TITLE
Move big mode requirements to production.txt

### DIFF
--- a/DEVELOPMENT.rst
+++ b/DEVELOPMENT.rst
@@ -119,11 +119,6 @@ installer is required even on a 64-bit Windows system. If you use the 64-bit
 installer, step d. of the instruction might fail unless you installed some
 packages manually.
 
-In some cases you have to install `MS Visual C++ 2015 build tools
-<https://www.microsoft.com/en-us/download/details.aspx?id=48159>`_ before you
-install the required python packages for OpenSlides (unfortunately Twisted
-needs it).
-
 To setup and activate the virtual environment in step c. use::
 
     > .virtualenv\Scripts\activate.bat

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,5 @@ include LICENSE
 include README.rst
 include SETTINGS.rst
 include requirements/production.txt
-include requirements/big_mode.txt
 recursive-include openslides *.*
 exclude openslides/__pycache__/*

--- a/README.rst
+++ b/README.rst
@@ -116,11 +116,6 @@ installer is required even on a 64-bit Windows system. If you use the 64-bit
 installer, step 1c of the instruction might fail unless you installed some
 packages manually.
 
-In some cases you have to install `MS Visual C++ 2015 build tools
-<https://www.microsoft.com/en-us/download/details.aspx?id=48159>`_ before you
-install the required python packages for OpenSlides (unfortunately Twisted
-needs it).
-
 To setup and activate the virtual environment in step 1b use::
 
     > .virtualenv\Scripts\activate.bat
@@ -165,7 +160,7 @@ Used software
 
 OpenSlides uses the following projects or parts of them:
 
-* Several Python packages (see ``requirements/production.txt`` and ``requirements/big_mode.txt``).
+* Several Python packages (see ``requirements/production.txt``).
 
 * Several JavaScript packages (see ``client/package.json``)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 # Requirements for OpenSlides in production
 -r requirements/production.txt
--r requirements/big_mode.txt
 
 # Requirements for development and tests in alphabetical order
 -r requirements/development.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -15,3 +15,13 @@ PyPDF2>=1.26,<1.27
 roman>=2.0,<3.2
 setuptools>=29.0,<42.0
 typing_extensions>=3.6.6,<3.8
+
+# Requirements for Redis and PostgreSQL support
+channels-redis>=2.2,<2.4
+django-redis-sessions>=0.6.1,<0.7
+psycopg2-binary>=2.7.3.2,<2.9
+aioredis>=1.1.0,<1.3
+
+# Requirements for fast asgi server
+gunicorn>=19.9.0,<20
+uvicorn>=0.3.2,<1.1

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,6 @@ with open('README.rst') as readme:
 with open('requirements/production.txt') as requirements_production:
     install_requires = requirements_production.readlines()
 
-with open('requirements/big_mode.txt') as requirements_big_mode:
-    extras_requires = requirements_big_mode.readlines()
-
 setup(
     name='openslides',
     author=openslides_author,
@@ -41,5 +38,4 @@ setup(
     packages=find_packages(exclude=['tests', 'tests.*']),
     include_package_data=True,
     install_requires=install_requires,
-    extras_require={'big_mode': extras_requires},
     entry_points={'console_scripts': ['openslides = openslides.__main__:main']})


### PR DESCRIPTION
OpenSlides required already channels-redis and websockets in 'small production mode'. So we should use only one production file which is also easier for pypi package installations.

BTW: pip install ... on Windows 10 works now without additional installation of Visual C++