### PR TITLE
Adjust workflow state naming

### DIFF
--- a/client/src/app/core/translate/marked-translations.ts
+++ b/client/src/app/core/translate/marked-translations.ts
@@ -267,7 +267,7 @@ _('Recommendation label');
 _('Allow support');
 _('Allow create poll');
 _('Allow submitter edit');
-_('Set identifier');
+_('Do not set identifier');
 _('Show state extension field');
 _('Show recommendation extension field');
 _('Show amendment in parent motion');

--- a/client/src/app/site/motions/modules/motion-workflow/components/workflow-detail/workflow-detail.component.ts
+++ b/client/src/app/site/motions/modules/motion-workflow/components/workflow-detail/workflow-detail.component.ts
@@ -106,7 +106,7 @@ export class WorkflowDetailComponent extends BaseViewComponent implements OnInit
         { name: 'Allow support', selector: 'allow_support', type: 'check' },
         { name: 'Allow create poll', selector: 'allow_create_poll', type: 'check' },
         { name: 'Allow submitter edit', selector: 'allow_submitter_edit', type: 'check' },
-        { name: 'Set identifier', selector: 'dont_set_identifier', type: 'check' },
+        { name: 'Do not set identifier', selector: 'dont_set_identifier', type: 'check' },
         { name: 'Show state extension field', selector: 'show_state_extension_field', type: 'check' },
         {
             name: 'Show recommendation extension field',


### PR DESCRIPTION
Changes "set identifier" to "do not set identifier"
requires an update of the translations