### PR TITLE
Updates karma to prevent cancelling tests because of timeout

### DIFF
--- a/client/karma.conf.js
+++ b/client/karma.conf.js
@@ -1,7 +1,7 @@
 // Karma configuration file, see link for more information
 // https://karma-runner.github.io/1.0/config/configuration-file.html
 
-module.exports = function(config) {
+module.exports = function (config) {
     config.set({
         basePath: '',
         frameworks: ['jasmine', '@angular-devkit/build-angular'],
@@ -13,7 +13,10 @@ module.exports = function(config) {
             require('@angular-devkit/build-angular/plugins/karma')
         ],
         client: {
-            clearContext: false // leave Jasmine Spec Runner output visible in browser
+            clearContext: false, // leave Jasmine Spec Runner output visible in browser
+            jasmine: {
+                timeoutInterval: 10000
+            }
         },
         coverageIstanbulReporter: {
             dir: require('path').join(__dirname, '../coverage'),


### PR DESCRIPTION
This will set the `DEFAULT_TIMEOUT_INTERVAL` of jasmine up to `10000ms`. Hopping, that this won't be the reason for failing tests anymore.