### PR TITLE
Render lists in amendment overview PDF

### DIFF
--- a/client/src/app/site/motions/services/amendment-list-pdf.service.ts
+++ b/client/src/app/site/motions/services/amendment-list-pdf.service.ts
@@ -57,7 +57,8 @@ export class AmendmentListPdfService {
                 text: amendment.submittersAsUsers.toString()
             },
             {
-                text: this.renderDiffLines(amendment)
+                // requires stack cause this can be an array
+                stack: this.renderDiffLines(amendment)
             },
             {
                 text: recommendationText


### PR DESCRIPTION
Fixes an issue that lists where not sown in the amendment overview PDF