### PR TITLE
Enhances the autoupdate of projector by change-id

### DIFF
--- a/openslides/core/websocket.py
+++ b/openslides/core/websocket.py
@@ -179,9 +179,7 @@ class ListenToProjectors(BaseWebsocketClientMessage):
             for projector_id, data in projector_data.items():
                 consumer.projector_hash[projector_id] = hash(str(data))
 
-            await consumer.send_json(
-                type="projector", content=projector_data, in_response=id
-            )
+            await consumer.send_projector_data(projector_data, in_response=id)
 
 
 class PingPong(BaseWebsocketClientMessage):

--- a/openslides/utils/autoupdate.py
+++ b/openslides/utils/autoupdate.py
@@ -217,7 +217,12 @@ def handle_changed_elements(elements: Iterable[Element]) -> None:
         # Send projector
         channel_layer = get_channel_layer()
         await channel_layer.group_send(
-            "projector", {"type": "projector_changed", "data": projector_data}
+            "projector",
+            {
+                "type": "projector_changed",
+                "data": projector_data,
+                "change_id": change_id,
+            },
         )
 
     if elements:

--- a/tests/integration/utils/test_consumers.py
+++ b/tests/integration/utils/test_consumers.py
@@ -565,12 +565,15 @@ async def test_listen_to_projector(communicator, set_config):
     content = response.get("content")
     assert type == "projector"
     assert content == {
-        "1": [
-            {
-                "data": {"name": "slide1", "event_name": "OpenSlides"},
-                "element": {"id": 1, "name": "test/slide1"},
-            }
-        ]
+        "change_id": 3,
+        "data": {
+            "1": [
+                {
+                    "data": {"name": "slide1", "event_name": "OpenSlides"},
+                    "element": {"id": 1, "name": "test/slide1"},
+                }
+            ]
+        },
     }
 
 
@@ -595,12 +598,15 @@ async def test_update_projector(communicator, set_config):
     content = response.get("content")
     assert type == "projector"
     assert content == {
-        "1": [
-            {
-                "data": {"name": "slide1", "event_name": "Test Event"},
-                "element": {"id": 1, "name": "test/slide1"},
-            }
-        ]
+        "change_id": 4,
+        "data": {
+            "1": [
+                {
+                    "data": {"name": "slide1", "event_name": "Test Event"},
+                    "element": {"id": 1, "name": "test/slide1"},
+                }
+            ]
+        },
     }
 
 


### PR DESCRIPTION
The `projector-data.service` compares the sent change-id of an update with the current one. If the current one is higher, nothing happens.