### PR TITLE
Fixed readding last speaker

### DIFF
--- a/openslides/agenda/views.py
+++ b/openslides/agenda/views.py
@@ -535,12 +535,12 @@ class ListOfSpeakersViewSet(
         list_of_speakers = self.get_object()
 
         # Retrieve speaker which spoke last and next speaker
-        ordered_speakers = list_of_speakers.speakers.order_by("-end_time")
-        if len(ordered_speakers) == 0:
-            raise ValidationError({"detail": "There is no last speaker at the moment."})
-
-        last_speaker = ordered_speakers[0]
-        if last_speaker.end_time is None:
+        last_speaker = (
+            list_of_speakers.speakers.exclude(end_time=None)
+            .order_by("-end_time")
+            .first()
+        )
+        if not last_speaker:
             raise ValidationError({"detail": "There is no last speaker at the moment."})
 
         next_speaker = list_of_speakers.get_next_speaker()

--- a/tests/integration/agenda/test_viewset.py
+++ b/tests/integration/agenda/test_viewset.py
@@ -497,7 +497,7 @@ class ManageSpeaker(TestCase):
             username="test_user_KLGHjkHJKBhjJHGGJKJn",
             password="test_password_JHt678VbhjuGhj76hjGA",
         )
-        Speaker.objects.add(user2, self.list_of_speakers)
+        speaker2 = Speaker.objects.add(user2, self.list_of_speakers)
 
         response = self.client.post(
             reverse(
@@ -511,6 +511,7 @@ class ManageSpeaker(TestCase):
             and speaker.end_time is None
             and speaker.weight is not None
         )
+        self.assertTrue(speaker.weight < speaker2.weight)
 
     def test_readd_last_speaker_no_admin(self):
         self.util_add_user_as_last_speaker()


### PR DESCRIPTION
It is not given, that null values are sorted last in the `order_by("-end_time")`
statement. This did not happens in the tests, but in a productive environment.
See https://docs.djangoproject.com/en/2.2/ref/models/querysets/#order-by for a
`.asc()`/`.desc()` option `nulls_last`. I choose another approach to just
exclude these values.