### PR TITLE
Adding a second optional redis for read only accesses

### DIFF
--- a/openslides/utils/locking.py
+++ b/openslides/utils/locking.py
@@ -37,6 +37,8 @@ class RedisLockProvider:
         """
         Returns True, when the lock is set. Else False.
         """
+        # Execute the lookup on the main redis server (no readonly) to avoid
+        # eventual consistency between the master and replicas
         async with get_connection() as redis:
             return await redis.get(f"{self.lock_prefix}{lock_name}")
 

--- a/openslides/utils/redis.py
+++ b/openslides/utils/redis.py
@@ -1,4 +1,3 @@
-import asyncio
 from typing import Any
 
 from django.conf import settings
@@ -12,49 +11,51 @@ try:
     import aioredis
 except ImportError:
     use_redis = False
+    use_read_only_redis = False
 else:
-    from channels_redis.core import ConnectionPool
+    from .redis_connection_pool import ConnectionPool
 
     # set use_redis to true, if there is a value for REDIS_ADDRESS in the settings
     redis_address = getattr(settings, "REDIS_ADDRESS", "")
     use_redis = bool(redis_address)
+
     if use_redis:
         logger.info(f"Redis address {redis_address}")
+        pool = ConnectionPool({"address": redis_address})
 
-    pool = ConnectionPool({"address": redis_address})
-    counter = 0
+        redis_read_only_address = getattr(settings, "REDIS_READ_ONLY_ADDRESS", "")
+        use_read_only_redis = bool(redis_read_only_address)
+        if use_read_only_redis:
+            logger.info(f"Redis read only address {redis_read_only_address}")
+            read_only_pool = ConnectionPool({"address": redis_read_only_address})
+    else:
+        logger.info("Redis is not configured.")
 
 
+# TODO: contextlib.asynccontextmanager can be used in python 3.7
 class RedisConnectionContextManager:
     """
     Async context manager for connections
     """
 
-    # TODO: contextlib.asynccontextmanager can be used in python 3.7
+    def __init__(self, read_only: bool) -> None:
+        self.pool = read_only_pool if read_only and use_read_only_redis else pool
 
     async def __aenter__(self) -> "aioredis.RedisConnection":
-        global counter
-        while counter > 100:
-            await asyncio.sleep(0.1)
-        counter += 1
-
-        self.conn = await pool.pop()
+        self.conn = await self.pool.pop()
         return self.conn
 
     async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
         if exc:
             logger.warn(f"Redis Exception: {exc}. Do not reuse connection...")
-            pool.conn_error(self.conn)
+            self.pool.conn_error(self.conn)
         else:
-            pool.push(self.conn)
+            self.pool.push(self.conn)
         self.conn = None
 
-        global counter
-        counter -= 1
 
-
-def get_connection() -> RedisConnectionContextManager:
+def get_connection(read_only: bool = False) -> RedisConnectionContextManager:
     """
     Returns contextmanager for a redis connection.
     """
-    return RedisConnectionContextManager()
+    return RedisConnectionContextManager(read_only)

--- a/openslides/utils/redis_connection_pool.py
+++ b/openslides/utils/redis_connection_pool.py
@@ -1,0 +1,42 @@
+import asyncio
+from typing import Any, Dict, List
+
+import aioredis
+from channels_redis.core import ConnectionPool as ChannelRedisConnectionPool
+from django.conf import settings
+
+from . import logging
+
+
+logger = logging.getLogger(__name__)
+connection_pool_limit = getattr(settings, "CONNECTION_POOL_LIMIT", 100)
+logger.info(f"CONNECTION_POOL_LIMIT={connection_pool_limit}")
+
+
+class ConnectionPool(ChannelRedisConnectionPool):
+    """ Adds a trivial, soft limit for the pool """
+
+    def __init__(self, host: Any) -> None:
+        self.counter = 0
+        super().__init__(host)
+
+    async def pop(
+        self, *args: List[Any], **kwargs: Dict[str, Any]
+    ) -> aioredis.commands.Redis:
+        while self.counter > connection_pool_limit:
+            await asyncio.sleep(0.1)
+        self.counter += 1
+
+        return await super().pop(*args, **kwargs)
+
+    def push(self, conn: aioredis.commands.Redis) -> None:
+        super().push(conn)
+        self.counter -= 1
+
+    def conn_error(self, conn: aioredis.commands.Redis) -> None:
+        super().conn_error(conn)
+        self.counter -= 1
+
+    def reset(self) -> None:
+        super().reset()
+        self.counter = 0


### PR DESCRIPTION
@gsiv There is a new settings.py option: `REDIS_READ_ONLY_ADDRESS` for a ro-redis-cluster.