### PR TITLE
Fixes decoding caused by exceeding stack size

### DIFF
--- a/client/src/app/core/core-services/websocket.service.ts
+++ b/client/src/app/core/core-services/websocket.service.ts
@@ -545,8 +545,10 @@ export class WebsocketService {
      * @param buffer - Buffer to convert
      * @returns String
      */
-    private arrayBufferToString(buffer: ArrayBuffer): string {
-        return String.fromCharCode.apply(null, Array.from(new Uint16Array(buffer)));
+    private arrayBufferToString(buffer: Uint8Array): string {
+        return Array.from(buffer)
+            .map(code => String.fromCharCode(code))
+            .join('');
     }
 
     /**


### PR DESCRIPTION
The custom decoding in `websocket.service.ts` causes an exceeding of the maximum stack size. This is happening by the maximum arguments of the method `String.fromCharCode(...)`.

See [StackOverflow](https://stackoverflow.com/questions/8936984/uint8array-to-string-in-javascript) for more information.