### PR TITLE
Fixes python3.7 tests

### DIFF
--- a/openslides/agenda/signals.py
+++ b/openslides/agenda/signals.py
@@ -22,8 +22,8 @@ def listen_to_related_object_post_save(sender, instance, created, **kwargs):
     skip_autoupdate in the agenda_item_update_information container.
     """
     instance_inform_changed_data = (
-        False
-    )  # evaluates, if the related_object has to be send again.
+        False  # evaluates, if the related_object has to be send again.
+    )
     # This is the case, if it was newly created and the autoupdate is not skipped with
     # agenda_item_skip_autoupdate or List_of_speakers_skip_autoupdate. If the related_object is
     # related to agenda items and list of speakers, the autoupdate is skipped, if one of the given

--- a/openslides/global_settings.py
+++ b/openslides/global_settings.py
@@ -54,8 +54,8 @@ TEMPLATES = [
 
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 EMAIL_TIMEOUT = (
-    5
-)  # Timeout in seconds for blocking operations like the connection attempt
+    5  # Timeout in seconds for blocking operations like the connection attempt
+)
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.10/topics/i18n/

--- a/openslides/motions/models.py
+++ b/openslides/motions/models.py
@@ -308,7 +308,10 @@ class Motion(RESTModelMixin, AgendaItemWithListOfSpeakersMixin, models.Model):
                 # Identifier is already used.
                 if hasattr(self, "_identifier_prefix"):
                     # Calculate a new one and try again.
-                    self.identifier_number, self.identifier = self.increment_identifier_number(
+                    (
+                        self.identifier_number,
+                        self.identifier,
+                    ) = self.increment_identifier_number(
                         self.identifier_number, self._identifier_prefix
                     )
                 else:

--- a/openslides/utils/cache.py
+++ b/openslides/utils/cache.py
@@ -303,7 +303,10 @@ class ElementCache:
                 f"change_id {change_id} is lower then the lowest change_id in redis {lowest_change_id}."
             )
 
-        raw_changed_elements, deleted_elements = await self.cache_provider.get_data_since(
+        (
+            raw_changed_elements,
+            deleted_elements,
+        ) = await self.cache_provider.get_data_since(
             change_id, max_change_id=max_change_id
         )
         changed_elements = {

--- a/openslides/utils/projector.py
+++ b/openslides/utils/projector.py
@@ -33,7 +33,7 @@ def register_projector_slide(name: str, slide: ProjectorSlide) -> None:
 
 
 async def get_projector_data(
-    projector_ids: List[int] = None
+    projector_ids: List[int] = None,
 ) -> Dict[int, List[Dict[str, Any]]]:
     """
     Calculates and returns the data for one or all projectors.

--- a/openslides/utils/websocket.py
+++ b/openslides/utils/websocket.py
@@ -202,7 +202,7 @@ Saves all websocket client message object ordered by there identifier.
 
 
 def register_client_message(
-    websocket_client_message: BaseWebsocketClientMessage
+    websocket_client_message: BaseWebsocketClientMessage,
 ) -> None:
     """
     Registers one websocket client message class.

--- a/tests/integration/motions/test_viewset.py
+++ b/tests/integration/motions/test_viewset.py
@@ -519,7 +519,7 @@ class RetrieveMotion(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_user_without_can_see_user_permission_to_see_motion_and_submitter_data(
-        self
+        self,
     ):
         admin = get_user_model().objects.get(username="admin")
         Submitter.objects.add(admin, self.motion)


### PR DESCRIPTION
Since travis uses the latest version of `black`, the python3.7 tests fail. This should fix it.

(Also done in the `development`-branch.)