### PR TITLE
Fixed mediafiles

### DIFF
--- a/client/src/app/shared/components/media-upload-content/media-upload-content.component.html
+++ b/client/src/app/shared/components/media-upload-content/media-upload-content.component.html
@@ -54,7 +54,10 @@
                 <th mat-header-cell *matHeaderCellDef><span translate>File information</span></th>
                 <td mat-cell *matCellDef="let file">
                     <div class="file-info-cell">
-                        <span> <mat-icon [inline]="true">insert_drive_file</mat-icon> {{ file.mediafile.type }} </span>
+                        <span>
+                            <mat-icon [inline]="true">insert_drive_file</mat-icon>
+                            {{ getFiletype(file.mediafile) | translate }}
+                        </span>
                         <span>
                             <mat-icon [inline]="true">data_usage</mat-icon>
                             {{ getReadableSize(file.mediafile.size) }}

--- a/client/src/app/shared/components/media-upload-content/media-upload-content.component.ts
+++ b/client/src/app/shared/components/media-upload-content/media-upload-content.component.ts
@@ -158,14 +158,27 @@ export class MediaUploadContentComponent implements OnInit {
     }
 
     /**
-     * Converts a file size in bit into human readable format
+     * Returns the filetype from the file or a generic "File", if the type could
+     * not be determinated.
      *
-     * @param bits file size in bits
+     * @param file The file to get the type from.
+     */
+    public getFiletype(file: File): string {
+        return file.type || 'File';
+    }
+
+    /**
+     * Converts a file size in byte into human readable format
+     *
+     * @param bytes file size in bytes
      * @returns a readable file size representation
      */
-    public getReadableSize(bits: number): string {
-        const unitLevel = Math.floor(Math.log(bits) / Math.log(1024));
-        const bytes = +(bits / Math.pow(1024, unitLevel)).toFixed(2);
+    public getReadableSize(bytes: number): string {
+        if (bytes === 0) {
+            return '0 B';
+        }
+        const unitLevel = Math.floor(Math.log(bytes) / Math.log(1024));
+        bytes = +(bytes / Math.pow(1024, unitLevel)).toFixed(2);
         return `${bytes} ${['B', 'kB', 'MB', 'GB', 'TB'][unitLevel]}`;
     }
 

--- a/client/src/app/site/mediafiles/components/mediafile-list/mediafile-list.component.html
+++ b/client/src/app/site/mediafiles/components/mediafile-list/mediafile-list.component.html
@@ -111,7 +111,7 @@
                 {{ mediafile.filename }}
             </div>
             <div class="info-text" *ngIf="!mediafile.is_directory">
-                <span> {{ getDateFromTimestamp(mediafile.timestamp) }} · {{ mediafile.size }} </span>
+                <span> {{ getDateFromTimestamp(mediafile.timestamp) }} · {{ mediafile.filesize }} </span>
             </div>
         </div>
     </div>

--- a/tests/integration/mediafiles/test_viewset.py
+++ b/tests/integration/mediafiles/test_viewset.py
@@ -70,7 +70,35 @@ class TestCreation(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertFalse(Mediafile.objects.exists())
 
-    def test_mediafile_twice(self):
+    def test_no_extension(self):
+        file = SimpleUploadedFile("no_extension", b"some content.")
+        response = self.client.post(
+            reverse("mediafile-list"),
+            {"title": "test_title_vai8oDogohheideedie4", "mediafile": file},
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        mediafile = Mediafile.objects.get()
+        self.assertEqual(mediafile.title, "test_title_vai8oDogohheideedie4")
+
+    def test_mediafile_twice_different_title(self):
+        file1 = SimpleUploadedFile("file.ext", b"some content.")
+        file2 = SimpleUploadedFile("file.ext", b"some content.")
+        response = self.client.post(
+            reverse("mediafile-list"),
+            {"title": "test_title_Zeicheipeequie3ohfid", "mediafile": file1},
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        mediafile = Mediafile.objects.get()
+        self.assertEqual(mediafile.title, "test_title_Zeicheipeequie3ohfid")
+
+        response = self.client.post(
+            reverse("mediafile-list"),
+            {"title": "test_title_aiChaetohs0quicee9eb", "mediafile": file2},
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(Mediafile.objects.count(), 1)
+
+    def test_directory_twice(self):
         title = "test_title_kFJq83fjmqo2babfqk3f"
         Mediafile.objects.create(is_directory=True, title=title)
         response = self.client.post(


### PR DESCRIPTION
original_filename must be unique for files. Some little fixes in the client showing `NaN` and `undefined`.