### PR TITLE
Remove option for inline line number PDF

### DIFF
--- a/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.ts
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.ts
@@ -1352,7 +1352,7 @@ export class MotionDetailComponent extends BaseViewComponent implements OnInit, 
      */
     public onDownloadPdf(): void {
         this.pdfExport.exportSingleMotion(this.motion, {
-            lnMode: this.lnMode,
+            lnMode: this.lnMode === this.LineNumberingMode.Inside ? this.LineNumberingMode.Outside : this.lnMode,
             crMode: this.crMode,
             comments: this.motion.commentSectionIds.concat([PERSONAL_NOTE_ID]) // export all comment fields as well as personal note
         });

--- a/client/src/app/site/motions/modules/shared-motion/motion-export-dialog/motion-export-dialog.component.html
+++ b/client/src/app/site/motions/modules/shared-motion/motion-export-dialog/motion-export-dialog.component.html
@@ -16,7 +16,6 @@
             <p class="toggle-group-head" translate>Line numbering</p>
             <mat-button-toggle-group class="smaller-buttons" formControlName="lnMode">
                 <mat-button-toggle [value]="lnMode.None"> <span translate>None</span> </mat-button-toggle>
-                <mat-button-toggle [value]="lnMode.Inside"> <span translate>Inline</span> </mat-button-toggle>
                 <mat-button-toggle [value]="lnMode.Outside"> <span translate>Outside</span> </mat-button-toggle>
             </mat-button-toggle-group>
         </div>


### PR DESCRIPTION
- removes the option to export PDF as inline, since it's not working atm
- motions that would be exported with inline line number would be exported with outside line numbers