### PR TITLE
Scroll to previous offset rather than index

### DIFF
--- a/client/src/app/site/agenda/components/agenda-list/agenda-list.component.html
+++ b/client/src/app/site/agenda/components/agenda-list/agenda-list.component.html
@@ -29,12 +29,7 @@
 >
     <!-- Title column -->
     <div *pblNgridCellDef="'title'; row as item; rowContext as rowContext" class="cell-slot fill">
-        <a
-            class="detail-link"
-            (click)="saveScrollIndex('agenda', rowContext.identity)"
-            [routerLink]="getDetailUrl(item)"
-            *ngIf="!isMultiSelect"
-        ></a>
+        <a class="detail-link" [routerLink]="getDetailUrl(item)" *ngIf="!isMultiSelect"></a>
         <div [ngStyle]="{ 'margin-left': item.level * 25 + 'px' }" class="innerTable">
             <os-icon-container [noWrap]="true" [icon]="item.closed ? 'check' : null" size="large">
                 <div class="ellipsis-overflow">

--- a/client/src/app/site/assignments/components/assignment-list/assignment-list.component.html
+++ b/client/src/app/site/assignments/components/assignment-list/assignment-list.component.html
@@ -33,12 +33,7 @@
 >
     <!-- Title -->
     <div *pblNgridCellDef="'title'; row as assignment; rowContext as rowContext" class="cell-slot fill">
-        <a
-            class="detail-link"
-            (click)="saveScrollIndex('assignments', rowContext.identity)"
-            [routerLink]="assignment.id"
-            *ngIf="!isMultiSelect"
-        ></a>
+        <a class="detail-link" [routerLink]="assignment.id" *ngIf="!isMultiSelect"></a>
         <div>
             <div class="title-line ellipsis-overflow">
                 {{ assignment.getListTitle() }}

--- a/client/src/app/site/base/base-list-view.ts
+++ b/client/src/app/site/base/base-list-view.ts
@@ -106,14 +106,4 @@ export abstract class BaseListViewComponent<V extends BaseViewModel> extends Bas
     public get isMultiSelect(): boolean {
         return this._multiSelectMode;
     }
-
-    /**
-     * Saves the scroll index in the storage
-     *
-     * @param key
-     * @param index
-     */
-    public saveScrollIndex(key: string, index: number): void {
-        this.storage.set(`scroll_${key}`, index);
-    }
 }

--- a/client/src/app/site/motions/modules/category/components/category-list/category-list.component.html
+++ b/client/src/app/site/motions/modules/category/components/category-list/category-list.component.html
@@ -25,11 +25,7 @@
 >
     <!-- Title -->
     <div *pblNgridCellDef="'title'; row as category; rowContext as rowContext" class="cell-slot fill">
-        <a
-            class="detail-link"
-            [routerLink]="category.id"
-            (click)="saveScrollIndex('category', rowContext.identity)"
-        ></a>
+        <a class="detail-link" [routerLink]="category.id"></a>
         <div [style.margin-left]="getMargin(category)">{{ category.prefixedName }}</div>
     </div>
 

--- a/client/src/app/site/motions/modules/motion-block/components/motion-block-list/motion-block-list.component.html
+++ b/client/src/app/site/motions/modules/motion-block/components/motion-block-list/motion-block-list.component.html
@@ -18,14 +18,14 @@
 >
     <!-- Title column -->
     <div *pblNgridCellDef="'title'; value as title; row as block; rowContext as rowContext" class="cell-slot fill">
-        <a
-            class="detail-link"
-            (click)="saveScrollIndex('motionBlock', rowContext.identity)"
-            [routerLink]="block.id"
-            *ngIf="!isMultiSelect"
-        ></a>
+        <a class="detail-link" [routerLink]="block.id" *ngIf="!isMultiSelect"></a>
         <div class="innerTable">
-            <os-icon-container [noWrap]="true" [icon]="block.internal ? 'lock' : null" size="large" [matTooltip]="Internal">
+            <os-icon-container
+                [noWrap]="true"
+                [icon]="block.internal ? 'lock' : null"
+                size="large"
+                [matTooltip]="Internal"
+            >
                 <div class="ellipsis-overflow">
                     {{ title }}
                 </div>

--- a/client/src/app/site/motions/modules/motion-list/components/motion-list/motion-list.component.html
+++ b/client/src/app/site/motions/modules/motion-list/components/motion-list/motion-list.component.html
@@ -63,12 +63,7 @@
 
         <!-- Title -->
         <div *pblNgridCellDef="'title'; row as motion; rowContext as rowContext" class="cell-slot fill">
-            <a
-                class="detail-link"
-                (click)="saveScrollIndex('motion', rowContext.identity)"
-                [routerLink]="motion.id"
-                *ngIf="!isMultiSelect"
-            ></a>
+            <a class="detail-link" [routerLink]="motion.id" *ngIf="!isMultiSelect"></a>
             <div class="column-title innerTable">
                 <div class="title-line ellipsis-overflow">
                     <!-- Is Favorite -->

--- a/client/src/app/site/motions/modules/motion-workflow/components/workflow-list/workflow-list.component.html
+++ b/client/src/app/site/motions/modules/motion-workflow/components/workflow-list/workflow-list.component.html
@@ -15,12 +15,7 @@
 >
     <!-- Name column -->
     <div *pblNgridCellDef="'name'; value as name; row as workflow; rowContext as rowContext" class="cell-slot fill">
-        <a
-            class="detail-link"
-            (click)="saveScrollIndex('workflow', rowContext.identity)"
-            [routerLink]="workflow.id"
-            *ngIf="!isMultiSelect"
-        ></a>
+        <a class="detail-link" [routerLink]="workflow.id" *ngIf="!isMultiSelect"></a>
         <div>{{ name | translate }}</div>
     </div>
 

--- a/client/src/app/site/users/components/user-list/user-list.component.html
+++ b/client/src/app/site/users/components/user-list/user-list.component.html
@@ -29,12 +29,7 @@
 >
     <!-- Name column -->
     <div *pblNgridCellDef="'short_name'; value as name; row as user; rowContext as rowContext" class="cell-slot fill">
-        <a
-            class="detail-link"
-            (click)="saveScrollIndex('user', rowContext.identity)"
-            [routerLink]="user.id"
-            *ngIf="!isMultiSelect"
-        ></a>
+        <a class="detail-link" [routerLink]="user.id" *ngIf="!isMultiSelect"></a>
         <div class="nameCell">
             <span>{{ name }}</span>
         </div>
@@ -89,7 +84,9 @@
                 comment
             </mat-icon>
 
-            <os-icon-container *ngIf="user.isSamlUser" icon="device_hub"><span translate>Is SAML user</span></os-icon-container>
+            <os-icon-container *ngIf="user.isSamlUser" icon="device_hub"
+                ><span translate>Is SAML user</span></os-icon-container
+            >
         </div>
     </div>
 


### PR DESCRIPTION
Changes some auto scrolling behavior in our virtual scrolling tables.
Save the scroll offset before any navigation attempt, rather than
saving the index on click.
Should work for every possible navigation action.