### PR TITLE
Fix untranslated searchable values

### DIFF
--- a/client/src/app/shared/components/search-value-selector/search-value-selector.component.ts
+++ b/client/src/app/shared/components/search-value-selector/search-value-selector.component.ts
@@ -152,13 +152,8 @@ export class SearchValueSelectorComponent implements OnDestroy {
                 if (foundId) {
                     return true;
                 }
-
-                return (
-                    item
-                        .toString()
-                        .toLowerCase()
-                        .indexOf(this.searchValue) > -1
-                );
+                const searchableString = this.translate.instant(item.getTitle()).toLowerCase();
+                return searchableString.indexOf(this.searchValue) > -1;
             });
         }
     }


### PR DESCRIPTION
Fixes a bug where the search value selector was not always filtering
for translated values.
Uses getTitle() in SearchValue selector rather than toString,
to allow enhance compatibility with custom values