### PR TITLE
Use defineProperties for array functions

### DIFF
--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -151,28 +151,34 @@ export class AppComponent {
         };
 
         // intersect
-        Array.prototype.intersect = function<T>(other: T[]): T[] {
-            let a = this,
-                b = other;
-            // indexOf to loop over shorter
-            if (b.length > a.length) {
-                [a, b] = [b, a];
-            }
-            return a.filter(e => b.indexOf(e) > -1);
-        };
+        Object.defineProperty(Array.prototype, 'intersect', {
+            value: function<T>(other: T[]): T[] {
+                let a = this;
+                let b = other;
+                // indexOf to loop over shorter
+                if (b.length > a.length) {
+                    [a, b] = [b, a];
+                }
+                return a.filter(e => b.indexOf(e) > -1);
+            },
+            enumerable: false
+        });
 
         // mapToObject
-        Array.prototype.mapToObject = function<T>(f: (item: T) => { [key: string]: any }): { [key: string]: any } {
-            return this.reduce((aggr, item) => {
-                const res = f(item);
-                for (const key in res) {
-                    if (res.hasOwnProperty(key)) {
-                        aggr[key] = res[key];
+        Object.defineProperty(Array.prototype, 'mapToObject', {
+            value: function<T>(f: (item: T) => { [key: string]: any }): { [key: string]: any } {
+                return this.reduce((aggr, item) => {
+                    const res = f(item);
+                    for (const key in res) {
+                        if (res.hasOwnProperty(key)) {
+                            aggr[key] = res[key];
+                        }
                     }
-                }
-                return aggr;
-            }, {});
-        };
+                    return aggr;
+                }, {});
+            },
+            enumerable: false
+        });
     }
 
     /**

--- a/client/src/app/site/polls/components/poll-form/poll-form.component.ts
+++ b/client/src/app/site/polls/components/poll-form/poll-form.component.ts
@@ -162,7 +162,7 @@ export class PollFormComponent extends BaseViewComponent implements OnInit {
             pollmethod: ['', Validators.required],
             onehundred_percent_base: ['', Validators.required],
             majority_method: ['', Validators.required],
-            groups_id: [[], Validators.required]
+            groups_id: [[]]
         });
     }
 }


### PR DESCRIPTION
Replace hard Array.prototype with softer defineProperties
Fixes a bug which required analog votes to have groups