### PR TITLE
More voting UI improvements

### DIFF
--- a/client/src/app/core/pdf-services/base-poll-pdf-service.ts
+++ b/client/src/app/core/pdf-services/base-poll-pdf-service.ts
@@ -71,6 +71,7 @@ export abstract class PollPdfService {
      * @returns the amount of ballots, depending on the config settings
      */
     protected getBallotCount(): number {
+        // TODO: seems to be broken
         switch (this.ballotCountSelection) {
             case 'NUMBER_OF_ALL_PARTICIPANTS':
                 return this.userRepo.getViewModelList().length;

--- a/client/src/app/shared/models/poll/base-poll.ts
+++ b/client/src/app/shared/models/poll/base-poll.ts
@@ -52,6 +52,22 @@ export abstract class BasePoll<T = any, O extends BaseOption<any> = any> extends
     public onehundred_percent_base: PercentBase;
     public user_has_voted: boolean;
 
+    public get isStateCreated(): boolean {
+        return this.state === PollState.Created;
+    }
+
+    public get isStateStarted(): boolean {
+        return this.state === PollState.Started;
+    }
+
+    public get isStateFinished(): boolean {
+        return this.state === PollState.Finished;
+    }
+
+    public get isStatePublished(): boolean {
+        return this.state === PollState.Published;
+    }
+
     /**
      * Determine if the state is finished or published
      */

--- a/client/src/app/shared/pipes/parse-poll-number.pipe.spec.ts
+++ b/client/src/app/shared/pipes/parse-poll-number.pipe.spec.ts
@@ -1,0 +1,20 @@
+import { inject, TestBed } from '@angular/core/testing';
+
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+
+import { ParsePollNumberPipe } from './parse-poll-number.pipe';
+
+describe('ParsePollNumberPipe', () => {
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [TranslateModule.forRoot()],
+            declarations: [ParsePollNumberPipe]
+        });
+        TestBed.compileComponents();
+    });
+
+    it('create an instance', inject([TranslateService], (translate: TranslateService) => {
+        const pipe = new ParsePollNumberPipe(translate);
+        expect(pipe).toBeTruthy();
+    }));
+});

--- a/client/src/app/shared/pipes/parse-poll-number.pipe.ts
+++ b/client/src/app/shared/pipes/parse-poll-number.pipe.ts
@@ -1,0 +1,22 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+import { TranslateService } from '@ngx-translate/core';
+
+@Pipe({
+    name: 'parsePollNumber'
+})
+export class ParsePollNumberPipe implements PipeTransform {
+    public constructor(private translate: TranslateService) {}
+
+    public transform(value: number): number | string {
+        const input = Math.trunc(value);
+        switch (input) {
+            case -1:
+                return this.translate.instant('majority');
+            case -2:
+                return this.translate.instant('undocumented');
+            default:
+                return input;
+        }
+    }
+}

--- a/client/src/app/shared/pipes/reverse.pipe.spec.ts
+++ b/client/src/app/shared/pipes/reverse.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { ReversePipe } from './reverse.pipe';
+
+describe('ReversePipe', () => {
+    it('create an instance', () => {
+        const pipe = new ReversePipe();
+        expect(pipe).toBeTruthy();
+    });
+});

--- a/client/src/app/shared/pipes/reverse.pipe.ts
+++ b/client/src/app/shared/pipes/reverse.pipe.ts
@@ -1,0 +1,20 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+/**
+ * Invert the order of arrays in templates
+ *
+ * @example
+ * ```html
+ * <li *ngFor="let user of users | reverse">
+ *     {{ user.name }} has the id: {{ user.id }}
+ * </li>
+ * ```
+ */
+@Pipe({
+    name: 'reverse'
+})
+export class ReversePipe implements PipeTransform {
+    public transform(value: any[]): any[] {
+        return value.slice().reverse();
+    }
+}

--- a/client/src/app/shared/shared.module.ts
+++ b/client/src/app/shared/shared.module.ts
@@ -119,6 +119,8 @@ import { BasePollDialogComponent } from 'app/site/polls/components/base-poll-dia
 import { PollFormComponent } from 'app/site/polls/components/poll-form/poll-form.component';
 import { MotionPollDialogComponent } from 'app/site/motions/modules/motion-poll/motion-poll-dialog/motion-poll-dialog.component';
 import { AssignmentPollDialogComponent } from 'app/site/assignments/components/assignment-poll-dialog/assignment-poll-dialog.component';
+import { ParsePollNumberPipe } from './pipes/parse-poll-number.pipe';
+import { ReversePipe } from './pipes/reverse.pipe';
 
 /**
  * Share Module for all "dumb" components and pipes.
@@ -279,7 +281,9 @@ import { AssignmentPollDialogComponent } from 'app/site/assignments/components/a
         BannerComponent,
         PollFormComponent,
         MotionPollDialogComponent,
-        AssignmentPollDialogComponent
+        AssignmentPollDialogComponent,
+        ParsePollNumberPipe,
+        ReversePipe
     ],
     declarations: [
         PermsDirective,
@@ -333,7 +337,9 @@ import { AssignmentPollDialogComponent } from 'app/site/assignments/components/a
         BannerComponent,
         PollFormComponent,
         MotionPollDialogComponent,
-        AssignmentPollDialogComponent
+        AssignmentPollDialogComponent,
+        ParsePollNumberPipe,
+        ReversePipe
     ],
     providers: [
         {
@@ -349,7 +355,9 @@ import { AssignmentPollDialogComponent } from 'app/site/assignments/components/a
         DecimalPipe,
         ProgressSnackBarComponent,
         TrustPipe,
-        LocalizedDatePipe
+        LocalizedDatePipe,
+        ParsePollNumberPipe,
+        ReversePipe
     ],
     entryComponents: [
         SortBottomSheetComponent,

--- a/client/src/app/site/assignments/components/assignment-detail/assignment-detail.component.html
+++ b/client/src/app/site/assignments/components/assignment-detail/assignment-detail.component.html
@@ -65,20 +65,12 @@
     <div *ngIf="!editAssignment">
         <!-- assignment meta infos-->
         <ng-container [ngTemplateOutlet]="metaInfoTemplate"></ng-container>
-        <!-- votable polls -->
-        <ng-container *ngIf="assignment">
-            <ng-container *ngFor="let poll of assignment.polls; trackBy: trackByIndex">
-                <mat-card class="os-card" *ngIf="poll.canBeVotedFor">
-                    <os-assignment-poll [poll]="poll"> </os-assignment-poll>
-                </mat-card>
-            </ng-container>
-        </ng-container>
         <!-- candidates list -->
         <ng-container [ngTemplateOutlet]="candidatesTemplate"></ng-container>
         <!-- closed polls -->
         <ng-container *ngIf="assignment">
-            <ng-container *ngFor="let poll of assignment.polls; trackBy: trackByIndex">
-                <mat-card class="os-card" *ngIf="!poll.canBeVotedFor">
+            <ng-container *ngFor="let poll of assignment.polls | reverse; trackBy: trackByIndex">
+                <mat-card class="os-card">
                     <os-assignment-poll [poll]="poll"> </os-assignment-poll>
                 </mat-card>
             </ng-container>
@@ -135,13 +127,17 @@
 </ng-template>
 
 <ng-template #candidatesTemplate>
-    <mat-card class="os-card">
-        <ng-container *ngIf="assignment && !assignment.isFinished">
+    <mat-card class="os-card" *ngIf="assignment && !assignment.isFinished">
+        <ng-container>
             <h3 translate>Candidates</h3>
             <div>
                 <div
                     class="candidates-list"
-                    *ngIf="assignment && assignment.assignment_related_users && assignment.assignment_related_users.length > 0"
+                    *ngIf="
+                        assignment &&
+                        assignment.assignment_related_users &&
+                        assignment.assignment_related_users.length > 0
+                    "
                 >
                     <os-sorting-list
                         [input]="assignment.assignment_related_users"

--- a/client/src/app/site/assignments/components/assignment-poll/assignment-poll.component.html
+++ b/client/src/app/site/assignments/components/assignment-poll/assignment-poll.component.html
@@ -1,4 +1,10 @@
 <div class="assignment-poll-wrapper" *ngIf="poll">
+
+    <div class="">
+
+    </div>
+
+
     <div class="poll-menu">
         <!-- Buttons -->
         <button
@@ -9,30 +15,16 @@
         >
             <mat-icon>more_horiz</mat-icon>
         </button>
-        <mat-menu #pollItemMenu="matMenu">
-            <div *osPerms="'assignments.can_manage'">
-                <button mat-menu-item (click)="openDialog()">
-                    <mat-icon>edit</mat-icon>
-                    <span translate>Edit</span>
-                </button>
-            </div>
-            <div *osPerms="'core.can_manage_projector'">
-                <os-projector-button menuItem="true" [object]="poll"></os-projector-button>
-            </div>
-            <div *osPerms="'assignments.can_manage'">
-                <mat-divider></mat-divider>
-                <button mat-menu-item class="red-warning-text" (click)="onDeletePoll()">
-                    <mat-icon>delete</mat-icon>
-                    <span translate>Delete</span>
-                </button>
-            </div>
-        </mat-menu>
     </div>
 
     <div>
         <div>
+            <h3>
+                <a routerLink="/assignments/polls/{{ poll.id }}">
+                    {{ poll.title }}
+                </a>
+            </h3>
             <div class="poll-properties">
-                <!-- <mat-chip *ngIf="pollService.isElectronicVotingEnabled">{{ poll.typeVerbose }}</mat-chip> -->
                 <mat-chip
                     class="poll-state active"
                     [matMenuTriggerFor]="triggerMenu"
@@ -41,22 +33,13 @@
                     {{ poll.stateVerbose }}
                 </mat-chip>
             </div>
-
-            <h3>
-                <a routerLink="/assignments/polls/{{ poll.id }}">
-                    {{ poll.title }}
-                </a>
-            </h3>
         </div>
         <div *ngIf="poll.stateHasVotes">
             <os-charts [type]="chartType" [labels]="candidatesLabels" [data]="chartDataSubject"></os-charts>
         </div>
     </div>
     <os-assignment-poll-vote *ngIf="poll.canBeVotedFor" [poll]="poll"></os-assignment-poll-vote>
-    <!-- <ng-container *ngIf="poll.state === pollStates.STATE_PUBLISHED" [ngTemplateOutlet]="resultsTemplate"></ng-container> -->
 </div>
-
-<ng-template #resultsTemplate> </ng-template>
 
 <mat-menu #triggerMenu="matMenu">
     <ng-container *ngIf="poll">
@@ -64,4 +47,23 @@
             <span translate>{{ state.key }}</span>
         </button>
     </ng-container>
+</mat-menu>
+
+<mat-menu #pollItemMenu="matMenu">
+    <div *osPerms="'assignments.can_manage'">
+        <button mat-menu-item (click)="openDialog()">
+            <mat-icon>edit</mat-icon>
+            <span translate>Edit</span>
+        </button>
+    </div>
+    <div *osPerms="'core.can_manage_projector'">
+        <os-projector-button menuItem="true" [object]="poll"></os-projector-button>
+    </div>
+    <div *osPerms="'assignments.can_manage'">
+        <mat-divider></mat-divider>
+        <button mat-menu-item class="red-warning-text" (click)="onDeletePoll()">
+            <mat-icon>delete</mat-icon>
+            <span translate>Delete</span>
+        </button>
+    </div>
 </mat-menu>

--- a/client/src/app/site/assignments/components/assignment-poll/assignment-poll.component.scss
+++ b/client/src/app/site/assignments/components/assignment-poll/assignment-poll.component.scss
@@ -3,33 +3,10 @@
     position: relative;
     padding: 0 15px;
 
-    .poll-main-content {
-        padding-top: 10px;
-    }
-
-    .poll-grid {
-        display: grid;
-        grid-gap: 5px;
-        padding: 5px;
-        grid-template-columns: 30px auto 250px 150px;
-        .candidate-name {
-            word-wrap: break-word;
-        }
-    }
-
-    .right-align {
-        text-align: right;
-    }
-
-    .vote-input {
-        .mat-form-field-wrapper {
-            // padding-bottom: 0;
-
-            .mat-form-field-infix {
-                width: 60px;
-                border-top: 0;
-            }
-        }
+    .poll-menu {
+        position: absolute;
+        top: 0;
+        right: 0;
     }
 
     .poll-properties {
@@ -61,34 +38,5 @@
                 color: black;
             }
         }
-    }
-
-    .poll-menu {
-        position: absolute;
-        top: 0;
-        right: 0;
-    }
-
-    .poll-quorum {
-        text-align: right;
-        margin-right: 10px;
-        mat-icon {
-            vertical-align: middle;
-            font-size: 100%;
-        }
-    }
-
-    .top-aligned {
-        position: absolute;
-        top: 0;
-        left: 0;
-    }
-
-    .wide {
-        width: 90%;
-    }
-
-    .hint-form {
-        margin-top: 20px;
     }
 }

--- a/client/src/app/site/motions/modules/motion-poll/motion-poll-detail/motion-poll-detail.component.html
+++ b/client/src/app/site/motions/modules/motion-poll/motion-poll-detail/motion-poll-detail.component.html
@@ -1,10 +1,10 @@
 <os-head-bar [goBack]="true" [nav]="false">
     <div class="title-slot">
-        <h2 *ngIf="poll">{{ 'Motion' | translate }} {{ poll.motion.id }}</h2>
+        <h2 *ngIf="poll">{{ 'Motion' | translate }} {{ poll.motion.identifierOrTitle }}</h2>
     </div>
 
     <div class="menu-slot" *osPerms="'motions.can_manage_polls'">
-        <button type="button" mat-icon-button  [matMenuTriggerFor]="pollDetailMenu">
+        <button type="button" mat-icon-button [matMenuTriggerFor]="pollDetailMenu">
             <mat-icon>more_vert</mat-icon>
         </button>
     </div>
@@ -19,12 +19,11 @@
     <ng-container *ngIf="poll">
         <h1>{{ poll.title }}</h1>
         <span *ngIf="poll.type !== 'analog'">{{ poll.typeVerbose | translate }}</span>
-        <os-breadcrumb *osPerms="'motions.can_manage_polls'"[breadcrumbs]="breadcrumbs"></os-breadcrumb>
+
+        <div *ngIf="!poll.hasVotes || !poll.stateHasVotes">{{ 'No results to show' | translate }}</div>
 
         <div *ngIf="poll.stateHasVotes">
             <h2 translate>Result</h2>
-
-            <div *ngIf="!poll.hasVotes">{{ 'No results to show' | translate }}</div>
 
             <div class="result-wrapper" *ngIf="poll.hasVotes">
                 <!-- Chart -->
@@ -52,25 +51,28 @@
                 </mat-table>
 
                 <!-- Named table: only show if votes are present -->
-                <ng-container *ngIf="poll.type === 'named' && votesDataSource.data">
-                    <input matInput [(ngModel)]="votesDataSource.filter" placeholder="Filter"/>
+                <div class="named-result-table" *ngIf="poll.type === 'named' && votesDataSource.data">
+                    <h3>{{ 'Single votes' | translate }}</h3>
+                    <mat-form-field>
+                        <input matInput [(ngModel)]="votesDataSource.filter" placeholder="Filter" />
+                    </mat-form-field>
                     <mat-table [dataSource]="votesDataSource">
                         <ng-container matColumnDef="key" sticky>
-                            <mat-header-cell *matHeaderCellDef>{{ "User" | translate }}</mat-header-cell>
+                            <mat-header-cell *matHeaderCellDef>{{ 'User' | translate }}</mat-header-cell>
                             <mat-cell *matCellDef="let vote">
                                 <div *ngIf="vote.user">{{ vote.user.getFullName() }}</div>
                                 <div *ngIf="!vote.user">{{ 'Unknown user' | translate }}</div>
                             </mat-cell>
                         </ng-container>
                         <ng-container matColumnDef="value" sticky>
-                            <mat-header-cell *matHeaderCellDef>{{ "Vote" | translate }}</mat-header-cell>
+                            <mat-header-cell *matHeaderCellDef>{{ 'Vote' | translate }}</mat-header-cell>
                             <mat-cell *matCellDef="let vote">{{ vote.valueVerbose }}</mat-cell>
                         </ng-container>
 
                         <mat-header-row *matHeaderRowDef="columnDefinition"></mat-header-row>
                         <mat-row *matRowDef="let vote; columns: columnDefinition"></mat-row>
                     </mat-table>
-                </ng-container>
+                </div>
             </div>
         </div>
 
@@ -85,12 +87,6 @@
             <div>{{ 'Required majority' | translate }}: {{ poll.majorityMethodVerbose | translate }}</div>
             <div>{{ '100% base' | translate }}: {{ poll.percentBaseVerbose | translate }}</div>
         </div>
-
-        <!-- TODO -->
-        <div *ngIf="poll.state === 2">
-        <!-- <div *ngIf="poll.state === PollState.started"> -->
-            <os-poll-progress [poll]="poll"></os-poll-progress>
-        </div>
     </ng-container>
 </ng-template>
 
@@ -101,7 +97,11 @@
         <mat-icon>edit</mat-icon>
         <span translate>Edit</span>
     </button>
-    <button mat-menu-item *ngIf="poll && poll.type === 'named'" (click)="pseudoanonymizePoll()">
+    <button
+        mat-menu-item
+        *osPerms="'motions.can_manage_polls'; and: poll && poll.type === 'named'"
+        (click)="pseudoanonymizePoll()"
+    >
         <mat-icon>warning</mat-icon>
         <span translate>Anonymize votes</span>
     </button>

--- a/client/src/app/site/motions/modules/motion-poll/motion-poll-detail/motion-poll-detail.component.scss
+++ b/client/src/app/site/motions/modules/motion-poll/motion-poll-detail/motion-poll-detail.component.scss
@@ -35,4 +35,8 @@
 
 .named-result-table {
     grid-area: names;
+    .mat-form-field {
+        font-size: 14px;
+        width: 100%;
+    }
 }

--- a/client/src/app/site/motions/modules/motion-poll/motion-poll-dialog/motion-poll-dialog.component.html
+++ b/client/src/app/site/motions/modules/motion-poll/motion-poll-dialog/motion-poll-dialog.component.html
@@ -40,7 +40,9 @@
             ></os-check-input>
         </form>
     </div>
-    <div>
+
+    <!-- Publish immediately button. Only show for new polls -->
+    <div *ngIf="!pollData.state">
         <mat-checkbox [(ngModel)]="publishImmediately" (change)="publishStateChanged($event.checked)">
             <span translate>Publish immediately</span>
         </mat-checkbox>

--- a/client/src/app/site/motions/modules/motion-poll/motion-poll-dialog/motion-poll-dialog.component.ts
+++ b/client/src/app/site/motions/modules/motion-poll/motion-poll-dialog/motion-poll-dialog.component.ts
@@ -42,9 +42,6 @@ export class MotionPollDialogComponent extends BasePollDialogComponent {
             votesinvalid: data.votesinvalid,
             votescast: data.votescast
         };
-        // if (data.pollmethod === 'YNA') {
-        //     update.A = data.options[0].abstain;
-        // }
 
         if (this.dialogVoteForm) {
             const result = this.undoReplaceEmptyValues(update);
@@ -64,9 +61,7 @@ export class MotionPollDialogComponent extends BasePollDialogComponent {
             votesinvalid: ['', [Validators.min(-2)]],
             votescast: ['', [Validators.min(-2)]]
         });
-        // if (this.pollData.pollmethod === MotionPollMethods.YNA) {
-        //     this.dialogVoteForm.addControl('A', this.fb.control('', [Validators.min(-2)]));
-        // }
+
         if (this.pollData.poll) {
             this.updateDialogVoteForm(this.pollData);
         }

--- a/client/src/app/site/motions/modules/motion-poll/motion-poll-vote/motion-poll-vote.component.html
+++ b/client/src/app/site/motions/modules/motion-poll/motion-poll-vote/motion-poll-vote.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="poll">
-    <div *osPerms="'motions.can_manage_polls;and:poll.state === PollState.started'">
+    <div *osPerms="'motions.can_manage_polls';and:poll.isStateStarted">
         <os-poll-progress [poll]="poll"></os-poll-progress>
     </div>
     <ng-container *ngIf="vmanager.canVote(poll)">

--- a/client/src/app/site/motions/modules/motion-poll/motion-poll-vote/motion-poll-vote.component.scss
+++ b/client/src/app/site/motions/modules/motion-poll/motion-poll-vote/motion-poll-vote.component.scss
@@ -1,16 +1,15 @@
-/**
- * These colors should be extracted from some global CSS Constants file
- */
+@import '~assets/styles/poll-colors.scss';
+
 .voted-yes {
-    background-color: #9fd773;
+    background-color: $votes-yes-color;
 }
 
 .voted-no {
-    background-color: #cc6c5b;
+    background-color: $votes-no-color;
 }
 
 .voted-abstain {
-    background-color: #a6a6a6;
+    background-color: $votes-abstain-color;
 }
 
 .vote-label {

--- a/client/src/app/site/motions/modules/motion-poll/motion-poll/motion-poll.component.html
+++ b/client/src/app/site/motions/modules/motion-poll/motion-poll/motion-poll.component.html
@@ -1,15 +1,15 @@
-<div class="poll-preview-wrapper">
+<div class="poll-preview-wrapper" *ngIf="poll && showPoll()">
     <!-- Poll Infos -->
-    <div class="poll-title-wrapper" *ngIf="poll">
+    <div class="poll-title-wrapper">
         <!-- Title -->
-        <a class="poll-title" routerLink="/motions/polls/{{ poll.id }}">
+        <a class="poll-title" [routerLink]="pollLink">
             {{ poll.title }}
         </a>
 
-        <!-- Edit button -->
+        <!-- Dot Menu -->
         <span class="poll-title-actions" *osPerms="'motions.can_manage_polls'">
-            <button mat-icon-button (click)="openDialog()">
-                <mat-icon class="small-icon">edit</mat-icon>
+            <button mat-icon-button [matMenuTriggerFor]="pollDetailMenu">
+                <mat-icon class="small-icon">more_horiz</mat-icon>
             </button>
         </span>
 
@@ -37,7 +37,7 @@
 </div>
 
 <ng-template #votingResult>
-    <div (click)="openPoll()">
+    <div [routerLink]="pollLink">
         <ng-container
             [ngTemplateOutlet]="poll.hasVotes && poll.stateHasVotes ? viewTemplate : emptyTemplate"
         ></ng-container>
@@ -46,28 +46,63 @@
 
 <ng-template #viewTemplate>
     <div class="poll-chart-wrapper">
-        <div class="votes-yes">
-            <os-icon-container icon="check" size="large">
-                {{ voteYes }}
-            </os-icon-container>
+        <!-- empty helper div to center the grid wrapper -->
+        <div></div>
+        <div class="doughnut-chart">
+            <os-charts *ngIf="showChart" [type]="'doughnut'" [data]="chartDataSubject" [showLegend]="false"> </os-charts>
         </div>
-        <div *ngIf="showChart" class="doughnut-chart">
-            <os-charts [type]="'doughnut'" [data]="chartDataSubject" [showLegend]="false"> </os-charts>
+        <div class="vote-legend">
+            <div class="votes-yes" *ngIf="isVoteDocumented(voteYes)">
+                <os-icon-container icon="thumb_up" size="large">
+                    {{ voteYes | parsePollNumber }}
+                </os-icon-container>
+            </div>
+            <div class="votes-no" *ngIf="isVoteDocumented(voteNo)">
+                <os-icon-container icon="thumb_down" size="large">
+                    {{ voteNo | parsePollNumber }}
+                </os-icon-container>
+            </div>
+            <div class="votes-abstain" *ngIf="isVoteDocumented(voteAbstain)">
+                <os-icon-container icon="trip_origin" size="large">
+                    {{ voteAbstain | parsePollNumber }}
+                </os-icon-container>
+            </div>
         </div>
-        <div class="votes-no">
-            <os-icon-container icon="close" size="large">
-                {{ voteNo }}
-            </os-icon-container>
-        </div>
+    </div>
+    <div class="poll-detail-button-wrapper" *ngIf="poll.type !== 'analog'">
+        <button mat-button [routerLink]="pollLink">
+            {{ 'Single Votes' | translate }}
+        </button>
     </div>
 </ng-template>
 
 <ng-template #emptyTemplate>
-    <div>
-        An empty poll - you have to enter votes.
+    <div *osPerms="'motions.can_manage_polls'">
+        {{ 'An empty poll - you have to enter votes.' | translate }}
     </div>
 </ng-template>
 
+<!-- More Menu -->
+<mat-menu #pollDetailMenu="matMenu">
+    <os-projector-button [menuItem]="true" [object]="poll" *osPerms="'core.can_manage_projector'"></os-projector-button>
+    <button *osPerms="'motions.can_manage_polls'" mat-menu-item (click)="openDialog()">
+        <mat-icon>edit</mat-icon>
+        <span translate>Edit</span>
+    </button>
+    <button mat-menu-item (click)="downloadPdf()">
+        <mat-icon>picture_as_pdf</mat-icon>
+        <span translate>PDF</span>
+    </button>
+    <div *osPerms="'motions.can_manage_polls'">
+        <mat-divider></mat-divider>
+        <button mat-menu-item (click)="deletePoll()">
+            <mat-icon color="warn">delete</mat-icon>
+            <span translate>Delete</span>
+        </button>
+    </div>
+</mat-menu>
+
+<!-- Select state menu -->
 <mat-menu #triggerMenu="matMenu">
     <ng-container *ngIf="poll">
         <button mat-menu-item (click)="changeState(state.value)" *ngFor="let state of poll.nextStates | keyvalue">

--- a/client/src/app/site/motions/modules/motion-poll/motion-poll/motion-poll.component.scss
+++ b/client/src/app/site/motions/modules/motion-poll/motion-poll/motion-poll.component.scss
@@ -1,3 +1,5 @@
+@import '~assets/styles/poll-colors.scss';
+
 .poll-preview-wrapper {
     padding: 8px;
     background: white;
@@ -49,17 +51,38 @@
         display: grid;
         grid-template-columns: auto minmax(50px, 20%) auto;
 
-        .votes-no {
-            color: #cc6c5b;
-            margin: auto 0;
-            width: fit-content;
+        .doughnut-chart {
+            margin-top: auto;
+            margin-bottom: auto;
         }
 
-        .votes-yes {
-            color: #9fc773;
-            margin: auto 0 auto auto;
-            width: fit-content;
+        .vote-legend {
+            margin: auto 10px;
+
+            div + div {
+                margin-top: 10px;
+            }
+
+            .votes-yes {
+                color: $votes-yes-color;
+            }
+
+            .votes-no {
+                color: $votes-no-color;
+            }
+
+            .votes-abstain {
+                color: $votes-abstain-color;
+            }
         }
+    }
+}
+
+.poll-detail-button-wrapper {
+    display: flex;
+    margin: auto 0;
+    > button {
+        margin-left: auto;
     }
 }
 

--- a/client/src/app/site/motions/modules/motion-poll/motion-poll/motion-poll.component.ts
+++ b/client/src/app/site/motions/modules/motion-poll/motion-poll/motion-poll.component.ts
@@ -1,7 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { MatDialog, MatSnackBar } from '@angular/material';
 import { Title } from '@angular/platform-browser';
-import { Router } from '@angular/router';
 
 import { TranslateService } from '@ngx-translate/core';
 import { BehaviorSubject } from 'rxjs';
@@ -12,6 +11,7 @@ import { PromptService } from 'app/core/ui-services/prompt.service';
 import { ChartData } from 'app/shared/components/charts/charts.component';
 import { ViewMotionPoll } from 'app/site/motions/models/view-motion-poll';
 import { MotionPollDialogService } from 'app/site/motions/services/motion-poll-dialog.service';
+import { MotionPollPdfService } from 'app/site/motions/services/motion-poll-pdf.service';
 import { BasePollComponent } from 'app/site/polls/components/base-poll.component';
 import { PollService } from 'app/site/polls/services/poll.service';
 
@@ -40,12 +40,19 @@ export class MotionPollComponent extends BasePollComponent<ViewMotionPoll> {
             if (data.label === 'NO') {
                 this.voteNo = data.data[0];
             }
+            if (data.label === 'ABSTAIN') {
+                this.voteAbstain = data.data[0];
+            }
         }
         this.chartDataSubject.next(chartData);
     }
 
     public get poll(): ViewMotionPoll {
         return this._poll;
+    }
+
+    public get pollLink(): string {
+        return `/motions/polls/${this.poll.id}`;
     }
 
     /**
@@ -56,32 +63,45 @@ export class MotionPollComponent extends BasePollComponent<ViewMotionPoll> {
     /**
      * Number of votes for `Yes`.
      */
-    public set voteYes(n: number | string) {
+    public set voteYes(n: number) {
         this._voteYes = n;
     }
 
-    public get voteYes(): number | string {
-        return this.verboseForNumber(this._voteYes as number);
+    public get voteYes(): number {
+        return this._voteYes;
     }
 
     /**
      * Number of votes for `No`.
      */
-    public set voteNo(n: number | string) {
+    public set voteNo(n: number) {
         this._voteNo = n;
     }
 
-    public get voteNo(): number | string {
-        return this.verboseForNumber(this._voteNo as number);
+    public get voteNo(): number {
+        return this._voteNo;
+    }
+
+    /**
+     * Number of votes for `Abstain`.
+     */
+    public set voteAbstain(n: number) {
+        this._voteAbstain = n;
+    }
+
+    public get voteAbstain(): number {
+        return this._voteAbstain;
     }
 
     public get showChart(): boolean {
         return this._voteYes >= 0 && this._voteNo >= 0;
     }
 
-    private _voteNo: number | string = 0;
+    private _voteNo: number;
 
-    private _voteYes: number | string = 0;
+    private _voteYes: number;
+
+    private _voteAbstain: number;
 
     /**
      * Constructor.
@@ -101,27 +121,35 @@ export class MotionPollComponent extends BasePollComponent<ViewMotionPoll> {
         public pollRepo: MotionPollRepositoryService,
         pollDialog: MotionPollDialogService,
         public pollService: PollService,
-        private router: Router,
-        private operator: OperatorService
+        private operator: OperatorService,
+        private pdfService: MotionPollPdfService
     ) {
         super(titleService, matSnackBar, translate, dialog, promptService, pollRepo, pollDialog);
     }
 
-    public openPoll(): void {
-        if (this.operator.hasPerms('motions.can_manage_polls')) {
-            this.router.navigate(['motions', 'polls', this.poll.id]);
+    public showPoll(): boolean {
+        return (
+            this.operator.hasPerms('motions.can_manage_polls') ||
+            this.poll.isStatePublished ||
+            (this.poll.type !== 'analog' && this.poll.isStateStarted)
+        );
+    }
+
+    public downloadPdf(): void {
+        console.log('picture_as_pdf');
+        this.pdfService.printBallots(this.poll);
+    }
+
+    public async deletePoll(): Promise<void> {
+        const title = 'Delete poll';
+        const text = 'Do you really want to delete the selected poll?';
+
+        if (await this.promptService.open(title, text)) {
+            this.repo.delete(this.poll).catch(this.raiseError);
         }
     }
 
-    private verboseForNumber(input: number): number | string {
-        input = Math.trunc(input);
-        switch (input) {
-            case -1:
-                return this.translate.instant('majority');
-            case -2:
-                return this.translate.instant('undocumented');
-            default:
-                return input;
-        }
+    public isVoteDocumented(vote: number): boolean {
+        return vote !== null && vote !== undefined && vote !== -2;
     }
 }

--- a/client/src/app/site/motions/services/motion-poll-pdf.service.ts
+++ b/client/src/app/site/motions/services/motion-poll-pdf.service.ts
@@ -17,7 +17,7 @@ type BallotCountChoices = 'NUMBER_OF_DELEGATES' | 'NUMBER_OF_ALL_PARTICIPANTS' |
  *
  * @example
  * ```ts
- * this.MotionPollPdfService.printBallos(this.poll);
+ * this.MotionPollPdfService.printBallots(this.poll);
  * ```
  */
 @Injectable({

--- a/client/src/app/site/polls/components/base-poll-detail.component.ts
+++ b/client/src/app/site/polls/components/base-poll-detail.component.ts
@@ -75,7 +75,7 @@ export abstract class BasePollDetailComponent<V extends ViewBasePoll> extends Ba
      * @param fb
      * @param groupRepo
      * @param location
-     * @param promptDialog
+     * @param promptService
      * @param dialog
      */
     public constructor(
@@ -85,7 +85,7 @@ export abstract class BasePollDetailComponent<V extends ViewBasePoll> extends Ba
         protected repo: BasePollRepositoryService,
         protected route: ActivatedRoute,
         protected groupRepo: GroupRepositoryService,
-        protected promptDialog: PromptService,
+        protected promptService: PromptService,
         protected pollDialog: BasePollDialogService<V>
     ) {
         super(title, translate, matSnackbar);
@@ -108,7 +108,7 @@ export abstract class BasePollDetailComponent<V extends ViewBasePoll> extends Ba
         const title = 'Delete poll';
         const text = 'Do you really want to delete the selected poll?';
 
-        if (await this.promptDialog.open(title, text)) {
+        if (await this.promptService.open(title, text)) {
             this.repo.delete(this.poll).then(() => this.onDeleted(), this.raiseError);
         }
     }
@@ -117,7 +117,7 @@ export abstract class BasePollDetailComponent<V extends ViewBasePoll> extends Ba
         const title = 'Anonymize single votes';
         const text = 'Do you really want to anonymize all votes? This cannot be undone.';
 
-        if (await this.promptDialog.open(title, text)) {
+        if (await this.promptService.open(title, text)) {
             this.repo.pseudoanonymize(this.poll).then(() => this.onPollLoaded(), this.raiseError); // votes have changed, but not the poll, so the components have to be informed about the update
         }
     }

--- a/client/src/app/site/polls/components/poll-progress/poll-progress.component.html
+++ b/client/src/app/site/polls/components/poll-progress/poll-progress.component.html
@@ -1,3 +1,3 @@
 <span>{{ poll.voted_id.length }} von {{ max }} haben abgestimmt.</span>
 
-<mat-progress-bar class="voting-progress-bar" [value]="valueInPercent" ></mat-progress-bar>
+<mat-progress-bar class="voting-progress-bar" [value]="valueInPercent"></mat-progress-bar>

--- a/client/src/assets/styles/poll-colors.scss
+++ b/client/src/assets/styles/poll-colors.scss
@@ -1,0 +1,6 @@
+/**
+ * Define the colors used for yes, no and abstain
+ */
+$votes-yes-color: #9fd773;
+$votes-no-color: #cc6c5b;
+$votes-abstain-color: #a6a6a6;

--- a/openslides/assignments/config_variables.py
+++ b/openslides/assignments/config_variables.py
@@ -35,6 +35,7 @@ def get_config_variables():
         label="Required majority",
         help_text="Default method to check whether a candidate has reached the required majority.",
         weight=405,
+        hidden=True,
         group="Voting",
         subgroup="Elections",
     )

--- a/openslides/motions/config_variables.py
+++ b/openslides/motions/config_variables.py
@@ -414,6 +414,7 @@ def get_config_variables():
         label="Required majority",
         help_text="Default method to check whether a motion has reached the required majority.",
         weight=425,
+        hidden=True,
         group="Voting",
         subgroup="Motions",
     )


### PR DESCRIPTION
More voting UI improvements
    
    For Motion poll:
    - Overworked how motion poll chart displays the legend
    - Added the vote counter to the motion detail
    - Added a progress bar to the vote counter
    - Fixed some perm errors with the chart
    - Show a "Singe Votes" link as button for published named polls
    - Replace the edit-button with a dot-menu
      - Having project, Edit, PDF and Delete
    
    For Motion Poll detail:
    - enhance search panel
    - Remove the breadcrumbs
    - Remove the vote counter
    - Enhanced the single-vote grid, table and filter bar
    - Enhance how the poll state enum was checkend
    
    For the Motion Poll Create/Update Form:
    - Remove the selection of poll-methode (whenever possible)
    - only show "publish imediately" during creation