### PR TITLE
Add option to export motions with pagebreaks

### DIFF
--- a/client/src/app/core/pdf-services/pdf-document.service.ts
+++ b/client/src/app/core/pdf-services/pdf-document.service.ts
@@ -712,6 +712,13 @@ export class PdfDocumentService {
         };
     }
 
+    public getSpacer(): Object {
+        return {
+            text: '',
+            margin: [0, 10]
+        };
+    }
+
     /**
      * Generates the table definition for the TOC
      *

--- a/client/src/app/site/motions/modules/shared-motion/motion-export-dialog/motion-export-dialog.component.html
+++ b/client/src/app/site/motions/modules/shared-motion/motion-export-dialog/motion-export-dialog.component.html
@@ -62,6 +62,7 @@
                 <mat-button-toggle value="toc"> <span translate>Table of contents</span> </mat-button-toggle>
                 <mat-button-toggle value="page"> <span translate>Page numbers</span> </mat-button-toggle>
                 <mat-button-toggle value="date"> <span translate>Current date</span> </mat-button-toggle>
+                <mat-button-toggle value="addBreaks"> <span translate>Enforce page breaks</span> </mat-button-toggle>
             </mat-button-toggle-group>
         </div>
 

--- a/client/src/app/site/motions/modules/shared-motion/motion-export-dialog/motion-export-dialog.component.ts
+++ b/client/src/app/site/motions/modules/shared-motion/motion-export-dialog/motion-export-dialog.component.ts
@@ -65,7 +65,7 @@ export class MotionExportDialogComponent implements OnInit {
     private defaults: MotionExportInfo = {
         format: ExportFileFormat.PDF,
         content: ['text', 'reason'],
-        pdfOptions: ['toc', 'page'],
+        pdfOptions: ['toc', 'page', 'addBreaks'],
         metaInfo: ['submitters', 'state', 'recommendation', 'category', 'origin', 'tags', 'motion_block', 'polls']
     };
 

--- a/client/src/app/site/motions/services/motion-pdf-catalog.service.ts
+++ b/client/src/app/site/motions/services/motion-pdf-catalog.service.ts
@@ -59,6 +59,8 @@ export class MotionPdfCatalogService {
     public motionListToDocDef(motions: ViewMotion[], exportInfo: MotionExportInfo): object {
         let doc = [];
         const motionDocList = [];
+        const printToc = exportInfo.pdfOptions.includes('toc');
+        const enforcePageBreaks = exportInfo.pdfOptions.includes('addBreaks');
 
         for (let motionIndex = 0; motionIndex < motions.length; ++motionIndex) {
             try {
@@ -69,8 +71,10 @@ export class MotionPdfCatalogService {
 
                 motionDocList.push(motionDocDef);
 
-                if (motionIndex < motions.length - 1) {
+                if (motionIndex < motions.length - 1 && enforcePageBreaks) {
                     motionDocList.push(this.pdfService.getPageBreak());
+                } else if (motionIndex < motions.length - 1 && !enforcePageBreaks) {
+                    motionDocList.push(this.pdfService.getSpacer());
                 }
             } catch (err) {
                 const errorText = `${this.translate.instant('Error during PDF creation of motion:')} ${
@@ -82,7 +86,7 @@ export class MotionPdfCatalogService {
         }
 
         // print extra data (title, preamble, categories, toc) only if there are more than 1 motion
-        if (motions.length > 1 && (!exportInfo.pdfOptions || exportInfo.pdfOptions.includes('toc'))) {
+        if (motions.length > 1 && (!exportInfo.pdfOptions || printToc)) {
             doc.push(
                 this.pdfService.createTitle('motions_export_title'),
                 this.pdfService.createPreamble('motions_export_preamble'),


### PR DESCRIPTION
Adds an option to the PDF motion list exporter
that allows users to explicitly enforce or prevent
page breaks before a new motion was printed.

The option is enabled by default