### PR TITLE
Show final state in Motion PDF toc

### DIFF
--- a/client/src/app/core/translate/marked-translations.ts
+++ b/client/src/app/core/translate/marked-translations.ts
@@ -176,7 +176,7 @@ _('Custom number of ballot papers');
 _('PDF export');
 _('Title for PDF documents of motions');
 _('Preamble text for PDF documents of motions');
-_('Show submitters and recommendation in table of contents');
+_('Show submitters and recommendation/state in table of contents');
 _('Show checkbox to record decision');
 // misc motion strings
 _('Amendment');

--- a/client/src/app/site/motions/services/motion-pdf-catalog.service.ts
+++ b/client/src/app/site/motions/services/motion-pdf-catalog.service.ts
@@ -243,8 +243,13 @@ export class MotionPdfCatalogService {
      * @returns {Array<Object>} An array containing the `DocDefinitions` for `pdf-make`.
      */
     private appendSubmittersAndRecommendation(motion: ViewMotion, style: StyleType = StyleType.DEFAULT): Object[] {
-        const recommendation = this.motionRepo.getExtendedRecommendationLabel(motion);
         let submitterList = '';
+        let state = '';
+        if (motion.state.isFinalState) {
+            state = this.motionRepo.getExtendedStateLabel(motion);
+        } else {
+            state = this.motionRepo.getExtendedRecommendationLabel(motion);
+        }
         for (let i = 0; i < motion.submitters.length; ++i) {
             submitterList +=
                 i !== motion.submitters.length - 1
@@ -257,7 +262,7 @@ export class MotionPdfCatalogService {
             `${motion.id}`,
             style,
             this.pdfService.createTocLineInline(submitterList),
-            this.pdfService.createTocLineInline(recommendation, true)
+            this.pdfService.createTocLineInline(state, true)
         );
     }
 }

--- a/openslides/motions/config_variables.py
+++ b/openslides/motions/config_variables.py
@@ -416,7 +416,7 @@ def get_config_variables():
     yield ConfigVariable(
         name="motions_export_submitter_recommendation",
         default_value=False,
-        label="Show submitters and recommendation in table of contents",
+        label="Show submitters and recommendation/state in table of contents",
         input_type="boolean",
         weight=384,
         group="Motions",


### PR DESCRIPTION
Renamed the option
"Show submitters and recommendation in table of contents"
to
"Show submitters and recommendation/state in table of contents"
If the option is selected, the PDF-TOC for motions will print
the name of the current state (if final) rather than the
current recomendation