### PR TITLE
Hide print-template button

### DIFF
--- a/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.html
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.html
@@ -532,7 +532,7 @@
                     type="button"
                     mat-icon-button
                     matTooltip="{{ 'Create final print template' | translate }}"
-                    *ngIf="motion.state.isFinalState"
+                    *ngIf="motion.state.isFinalState && !motion.modified_final_version"
                     (click)="createModifiedFinalVersion()"
                 >
                     <mat-icon>file_copy</mat-icon>

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.ts
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.ts
@@ -1116,19 +1116,7 @@ export class MotionDetailComponent extends BaseViewComponent implements OnInit, 
         // Update the motion
         try {
             // Just confirm this, if there is one modified final version the user would override.
-            if (this.motion.modified_final_version) {
-                const title = this.translate.instant(
-                    'Are you sure you want to copy the final version to the print template?'
-                );
-                if (await this.promptService.open(title)) {
-                    this.updateMotion({ modified_final_version: finalVersion }, this.motion).then(
-                        () => this.setChangeRecoMode(ChangeRecoMode.ModifiedFinal),
-                        this.raiseError
-                    );
-                }
-            } else {
-                await this.updateMotion({ modified_final_version: finalVersion }, this.motion);
-            }
+            await this.updateMotion({ modified_final_version: finalVersion }, this.motion);
         } catch (e) {
             this.raiseError(e);
         }


### PR DESCRIPTION
Hides the "create final print template" button if
a print template exists.
Should be more user friendly and less dangerous to use.