### PR TITLE
Fix Shift-Enter to save poll

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -82,6 +82,7 @@
         "@angular/compiler-cli": "^8.2.14",
         "@angular/language-service": "^8.2.14",
         "@biesbjerg/ngx-translate-extract": "^3.0.5",
+        "@babel/compat-data": "~7.8.0",
         "@compodoc/compodoc": "^1.1.11",
         "@types/jasmine": "^3.5.0",
         "@types/jasminewd2": "^2.0.8",

--- a/client/src/app/site/assignments/components/assignment-poll-dialog/assignment-poll-dialog.component.spec.ts
+++ b/client/src/app/site/assignments/components/assignment-poll-dialog/assignment-poll-dialog.component.spec.ts
@@ -13,10 +13,10 @@ describe('AssignmentPollDialogComponent', () => {
         TestBed.configureTestingModule({
             imports: [E2EImportsModule],
             providers: [
-                { provide: MatDialogRef, useValue: {} },
+                { provide: MatDialogRef, useValue: null },
                 {
                     provide: MAT_DIALOG_DATA,
-                    useValue: {}
+                    useValue: null
                 }
             ]
         }).compileComponents();

--- a/client/src/app/site/motions/modules/motion-poll/motion-poll-dialog/motion-poll-dialog.component.spec.ts
+++ b/client/src/app/site/motions/modules/motion-poll/motion-poll-dialog/motion-poll-dialog.component.spec.ts
@@ -13,10 +13,10 @@ describe('MotionPollDialogComponent', () => {
         TestBed.configureTestingModule({
             imports: [E2EImportsModule],
             providers: [
-                { provide: MatDialogRef, useValue: {} },
+                { provide: MatDialogRef, useValue: null },
                 {
                     provide: MAT_DIALOG_DATA,
-                    useValue: {}
+                    useValue: null
                 }
             ]
         }).compileComponents();

--- a/client/src/app/site/motions/modules/motion-poll/motion-poll-dialog/motion-poll-dialog.component.ts
+++ b/client/src/app/site/motions/modules/motion-poll/motion-poll-dialog/motion-poll-dialog.component.ts
@@ -57,7 +57,7 @@ export class MotionPollDialogComponent extends BasePollDialogComponent<ViewMotio
     }
 
     /**
-     * Pre-executed method to initialize the dialog-form depending on the poll-method.
+     * Initialize the dialog-form depending on the poll-method.
      */
     private createDialog(): void {
         this.dialogVoteForm = this.formBuilder.group({
@@ -69,7 +69,7 @@ export class MotionPollDialogComponent extends BasePollDialogComponent<ViewMotio
             votescast: ['', [Validators.min(LOWEST_VOTE_VALUE)]]
         });
 
-        if (this.pollData.poll) {
+        if (this.pollData && this.pollData.poll) {
             this.updateDialogVoteForm(this.pollData);
         }
     }

--- a/client/src/app/site/polls/components/base-poll-dialog.component.ts
+++ b/client/src/app/site/polls/components/base-poll-dialog.component.ts
@@ -1,4 +1,3 @@
-import { OnInit } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { MatSnackBar } from '@angular/material';
 import { MatDialogRef } from '@angular/material/dialog';
@@ -16,8 +15,7 @@ import { ViewBasePoll } from '../models/view-base-poll';
 /**
  * A dialog for updating the values of a poll.
  */
-export abstract class BasePollDialogComponent<T extends ViewBasePoll, S extends PollService> extends BaseViewComponent
-    implements OnInit {
+export abstract class BasePollDialogComponent<T extends ViewBasePoll, S extends PollService> extends BaseViewComponent {
     public publishImmediately: boolean;
 
     protected pollForm: PollFormComponent<T, S>;
@@ -31,11 +29,11 @@ export abstract class BasePollDialogComponent<T extends ViewBasePoll, S extends 
         public dialogRef: MatDialogRef<BasePollDialogComponent<T, S>>
     ) {
         super(title, translate, matSnackbar);
+        this.addKeyListener();
     }
 
-    public ngOnInit(): void {
+    private addKeyListener(): void {
         if (this.dialogRef) {
-            // Jasmin/Karma fails here. TODO:
             this.dialogRef.keydownEvents().subscribe((event: KeyboardEvent) => {
                 if (event.key === 'Enter' && event.shiftKey) {
                     this.submitPoll();


### PR DESCRIPTION
Fixes a bug which caused the event listener not to register
in BasePollDialog

**also**, hotfix for a bug with Babel. See:
https://github.com/angular/angular-cli/issues/17262

This currently prevents building the client in master -> priority set to high