### PR TITLE
Allow empty input values in recommendation

### DIFF
--- a/client/src/app/site/motions/modules/motion-workflow/components/workflow-detail/workflow-detail.component.html
+++ b/client/src/app/site/motions/modules/motion-workflow/components/workflow-detail/workflow-detail.component.html
@@ -34,7 +34,10 @@
                 </td>
             </ng-container>
 
-            <ng-container [matColumnDef]="getColumnDef(state)" *ngFor="let state of workflow.states; trackBy: trackByIndex">
+            <ng-container
+                [matColumnDef]="getColumnDef(state)"
+                *ngFor="let state of workflow.states; trackBy: trackByIndex"
+            >
                 <th mat-header-cell *matHeaderCellDef (click)="onClickStateName(state)">
                     <div class="clickable-cell stretch-to-fill-parent">
                         <div class="inner-table">
@@ -49,16 +52,14 @@
                             (change)="onToggleStatePerm(state, perm.selector, $event)"
                         ></mat-checkbox>
                     </div>
-                    <div
-                        *ngIf="perm.type === 'input'"
-                    >
+                    <div *ngIf="perm.type === 'input'">
                         <div class="inner-table">
                             {{ (state[perm.selector] | translate) || '–' }}
                         </div>
                         <div
                             class="clickable-cell stretch-to-fill-parent"
                             (click)="onClickInputPerm(perm, state)"
-                            ></div>
+                        ></div>
                     </div>
                     <div class="inner-table" *ngIf="perm.type === 'color'">
                         <mat-basic-chip
@@ -104,8 +105,8 @@
                             </div>
                             <div *ngIf="state.restriction.length">
                                 <div *ngFor="let restriction of state.restriction; let last = last">
-                                    {{ getRestrictionLabel(restriction) | translate
-                                    }}<span *ngIf="!last">,&nbsp;</span>
+                                    {{ getRestrictionLabel(restriction) | translate }}
+                                    <span *ngIf="!last">,&nbsp;</span>
                                 </div>
                             </div>
                         </div>
@@ -138,7 +139,7 @@
     <div mat-dialog-actions>
         <button
             type="submit"
-            [disabled]="dialogData.value === ''"
+            [disabled]="dialogData.value === '' && !dialogData.allowEmpty"
             mat-button
             color="primary"
             [mat-dialog-close]="{ action: 'update', value: dialogData.value }"

--- a/client/src/app/site/motions/modules/motion-workflow/components/workflow-detail/workflow-detail.component.ts
+++ b/client/src/app/site/motions/modules/motion-workflow/components/workflow-detail/workflow-detail.component.ts
@@ -27,6 +27,7 @@ interface DialogData {
     description: string;
     value: string;
     deletable?: boolean;
+    allowEmpty?: boolean;
 }
 
 /**
@@ -256,7 +257,10 @@ export class WorkflowDetailComponent extends BaseViewComponent implements OnInit
      * @param state The selected workflow state
      */
     public onClickInputPerm(perm: StatePerm, state: ViewState): void {
-        this.openEditDialog(state[perm.selector], 'Edit', perm.name).subscribe(result => {
+        this.openEditDialog(state[perm.selector], 'Edit', perm.name, false, true).subscribe(result => {
+            if (result.value === '') {
+                result.value = null;
+            }
             if (result && result.action === 'update') {
                 this.stateRepo.update({ [perm.selector]: result.value }, state).then(() => {}, this.raiseError);
             }
@@ -347,18 +351,21 @@ export class WorkflowDetailComponent extends BaseViewComponent implements OnInit
      * @param title The title of the dialog
      * @param description The description of the dialog
      * @param deletable determine if a delete button should be offered
+     * @param allowEmpty to allow empty values
      */
     private openEditDialog(
         value: string,
         title?: string,
         description?: string,
-        deletable?: boolean
+        deletable?: boolean,
+        allowEmpty?: boolean
     ): Observable<DialogResult> {
         this.dialogData = {
             title: title || '',
             description: description || '',
             value: value,
-            deletable: deletable
+            deletable: deletable,
+            allowEmpty: allowEmpty
         };
 
         const dialogRef = this.dialog.open(this.workflowDialog, infoDialogSettings);


### PR DESCRIPTION
Allows the client to send empty values as workflow
recommendation label in the workflow detail view.
This is required to remove a recommendation from a
workflow