### PR TITLE
Remove pseudo-disabled values in poll form

### DIFF
--- a/client/src/app/shared/components/check-input/check-input.component.ts
+++ b/client/src/app/shared/components/check-input/check-input.component.ts
@@ -66,7 +66,13 @@ export class CheckInputComponent extends BaseViewComponent implements OnInit, Co
      * Subscribes to value-changes of the form-control.
      */
     public ngOnInit(): void {
-        this.subscriptions.push(this.contentForm.valueChanges.subscribe(value => this.sendValue(value)));
+        this.subscriptions.push(
+            this.contentForm.valueChanges.subscribe(value => {
+                if (value) {
+                    this.sendValue(value);
+                }
+            })
+        );
     }
 
     /**

--- a/client/src/app/site/polls/components/poll-form/poll-form.component.html
+++ b/client/src/app/site/polls/components/poll-form/poll-form.component.html
@@ -8,17 +8,6 @@
         </mat-form-field>
     </form>
 
-    <!-- TODO: rather disable forms than duplicate them -->
-    <div *ngIf="data && data.state" class="poll-preview-meta-info">
-        <span class="short-description" *ngFor="let value of pollValues">
-            <span class="short-description-label subtitle">
-                {{ value[0] }}
-            </span>
-            <span class="short-description-value">
-                {{ value[1] }}
-            </span>
-        </span>
-    </div>
     <form [formGroup]="contentForm" class="poll-preview-meta-info-form">
         <ng-container *ngIf="!data || !data.state || data.isCreated">
             <!-- Poll Type -->

--- a/client/src/app/site/polls/components/poll-form/poll-form.component.ts
+++ b/client/src/app/site/polls/components/poll-form/poll-form.component.ts
@@ -125,6 +125,10 @@ export class PollFormComponent<T extends ViewBasePoll, S extends PollService> ex
         this.groupObservable = this.groupRepo.getViewModelListObservableWithoutDefaultGroup();
 
         if (this.data) {
+            if (this.data.state) {
+                this.disablePollType();
+            }
+
             if (this.data instanceof ViewAssignmentPoll) {
                 if (this.data.assignment && !this.data.votes_amount) {
                     this.data.votes_amount = this.data.assignment.open_posts;
@@ -162,6 +166,10 @@ export class PollFormComponent<T extends ViewBasePoll, S extends PollService> ex
                 this.setVotesAmountCtrl();
             })
         );
+    }
+
+    private disablePollType(): void {
+        this.contentForm.get('type').disable();
     }
 
     /**


### PR DESCRIPTION
Removed the previously disabled-looking poll options from the poll form
component.
I figguered that it would be more intuitive and closer to my
expectations if I could change the poll values even if the poll was
already created.

I suppose this needs some discussion. Tell me if you do not like how this behaves