### PR TITLE
Remove counting of IndexedDB and LocalStore

### DIFF
--- a/client/src/app/core/ui-services/count-users.service.ts
+++ b/client/src/app/core/ui-services/count-users.service.ts
@@ -11,7 +11,6 @@ interface CountUserRequest {
 
 export interface CountUserData {
     userId: number;
-    usesIndexedDB: boolean;
 }
 
 interface CountUserResponse extends CountUserRequest {
@@ -49,8 +48,7 @@ export class CountUsersService {
                     {
                         token: request.content.token,
                         data: {
-                            userId: this.currentUserId,
-                            usesIndexedDB: true
+                            userId: this.currentUserId
                         }
                     },
                     request.senderChannelName

--- a/client/src/app/site/common/components/count-users/count-users.component.html
+++ b/client/src/app/site/common/components/count-users/count-users.component.html
@@ -7,17 +7,16 @@
     </button>
     <div *ngIf="stats">
         <p>
-            {{ userIds().length }} <span translate>active users</span>
-            ({{ stats.usesIndexedDB }} <span translate>with indexedDB</span>,
-            {{ stats.activeUserHandles-stats.usesIndexedDB }} <span translate>with local storage</span>)
-            ({{ stats.activeUserHandles }} <span translate>connections</span>)
+            {{ userIds().length }} <span translate>active users</span> ({{ stats.activeUserHandles }}
+            <span translate>connections</span>)
         </p>
         <h3 translate>Groups</h3>
         <ul>
             <li *ngFor="let groupId of groupIds()">
-                <strong>{{ stats.groups[groupId].name }}</strong>:
-                {{ userInGroupIds(groupId).length }} <span translate>active users</span>
-                ({{ stats.groups[groupId].userHandleCount }} <span translate>connections</span>)
+                <strong>{{ stats.groups[groupId].name }}</strong>
+                <span> : {{ userInGroupIds(groupId).length }} </span>
+                <span translate>active users</span>
+                (<span>{{ stats.groups[groupId].userHandleCount }}</span> <span translate>connections</span>)
             </li>
         </ul>
     </div>

--- a/client/src/app/site/common/services/count-user-statistics.service.ts
+++ b/client/src/app/site/common/services/count-user-statistics.service.ts
@@ -10,7 +10,6 @@ import { CountUserData, CountUsersService } from 'app/core/ui-services/count-use
  */
 export interface CountUserStatistics {
     activeUserHandles: number;
-    usesIndexedDB: number;
     activeUsers: {
         [id: number]: number;
     };
@@ -52,7 +51,6 @@ export class CountUsersStatisticsService {
         [token, userDataObservable] = this.countUserService.countUsers();
         this.runningCounts[token] = new BehaviorSubject<CountUserStatistics>({
             activeUserHandles: 0,
-            usesIndexedDB: 0,
             activeUsers: {},
             groups: {}
         });
@@ -66,9 +64,6 @@ export class CountUsersStatisticsService {
 
             // Add to user stats
             stats.activeUserHandles++;
-            if (data.usesIndexedDB) {
-                stats.usesIndexedDB++;
-            }
             if (!stats.activeUsers[userId]) {
                 stats.activeUsers[userId] = 0;
             }


### PR DESCRIPTION
Mainly simplify the user counting component.

It seems that counting IndexedDB has no value anymore,
since even Firefox ESR uses IndexedDB just fine and the LS fallback
proves to be reliable enough