### PR TITLE
Improve: replacements at end of line

### DIFF
--- a/client/src/app/core/ui-services/diff.service.spec.ts
+++ b/client/src/app/core/ui-services/diff.service.spec.ts
@@ -1169,6 +1169,26 @@ describe('DiffService', () => {
                 );
             }
         ));
+
+        it('detects a word replacement at the end of line correctly', inject([DiffService], (service: DiffService) => {
+            let before =
+                '<p>' +
+                noMarkup(1) +
+                'wuid Brotzeit? Pfenningguat Stubn bitt da, hog di hi fei nia need nia need Goaßmaß ' +
+                brMarkup(2) +
+                'gscheid kloan mim';
+            const after =
+                '<P>wuid Brotzeit? Pfenningguat Stubn bitt da, hog di hi fei nia need nia need Radler gscheid kloan mim';
+
+            const diff = service.diff(before, after);
+            expect(diff).toBe(
+                '<p>' +
+                    noMarkup(1) +
+                    'wuid Brotzeit? Pfenningguat Stubn bitt da, hog di hi fei nia need nia need <del>Goaßmaß </del><ins>Radler </ins>' +
+                    brMarkup(2) +
+                    'gscheid kloan mim</p>'
+            );
+        }));
     });
 
     describe('addCSSClassToFirstTag function', () => {


### PR DESCRIPTION
This partly fixes a problem when in a change recommendation the last word of the last line is getting replaced: the insertion was shown at the beginning of the next line of the motion/amendment. Once the final text is getting created, this does not matter, but when displaying it, this might be confusing.

However, a similar problem is still open and a lot harder to fix when it is not a replacement, but only an insertion, as this is not easily detectable at this point.