### PR TITLE
Change recommendations for amendments

### DIFF
--- a/client/src/app/core/ui-services/diff.service.spec.ts
+++ b/client/src/app/core/ui-services/diff.service.spec.ts
@@ -1172,6 +1172,28 @@ describe('DiffService', () => {
                 );
             }
         ));
+
+        it('detects a word replacement at the end of line correctly', inject([DiffService], (service: DiffService) => {
+            const before =
+                '<p>' +
+                noMarkup(1) +
+                'wuid Brotzeit? Pfenningguat Stubn bitt da, hog di hi fei nia need nia need Goaßmaß ' +
+                brMarkup(2) +
+                'gscheid kloan mim';
+            const after =
+                '<P>wuid Brotzeit? Pfenningguat Stubn bitt da, ' +
+                'hog di hi fei nia need nia need Radler gscheid kloan mim';
+
+            const diff = service.diff(before, after);
+            expect(diff).toBe(
+                '<p>' +
+                    noMarkup(1) +
+                    'wuid Brotzeit? Pfenningguat Stubn bitt da, ' +
+                    'hog di hi fei nia need nia need <del>Goaßmaß </del><ins>Radler </ins>' +
+                    brMarkup(2) +
+                    'gscheid kloan mim</p>'
+            );
+        }));
     });
 
     describe('addCSSClassToFirstTag function', () => {

--- a/client/src/app/core/ui-services/linenumbering.service.ts
+++ b/client/src/app/core/ui-services/linenumbering.service.ts
@@ -4,6 +4,11 @@ const ELEMENT_NODE = 1;
 const TEXT_NODE = 3;
 
 /**
+ * A helper to indicate that certain functions expect the provided HTML strings to contain line numbers
+ */
+export type LineNumberedString = string;
+
+/**
  * Specifies a point within a HTML Text Node where a line break might be possible, if the following word
  * exceeds the maximum line length.
  */
@@ -894,7 +899,7 @@ export class LinenumberingService {
         highlight?: number,
         callback?: () => void,
         firstLine?: number
-    ): string {
+    ): LineNumberedString {
         let newHtml, newRoot;
 
         if (highlight > 0) {

--- a/client/src/app/site/motions/models/view-motion.ts
+++ b/client/src/app/site/motions/models/view-motion.ts
@@ -199,7 +199,6 @@ export class ViewMotion extends BaseViewModelWithAgendaItemAndListOfSpeakers<Mot
      * Extract the lines of the amendments
      * If an amendments has multiple changes, they will be printed like an array of strings
      *
-     * @param amendment the motion to create the amendment to
      * @return The lines of the amendment
      */
     public getChangeLines(): string {

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.html
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.html
@@ -530,7 +530,6 @@
                     [matMenuTriggerFor]="changeRecoMenu"
                     *ngIf="
                         motion &&
-                        !motion.isParagraphBasedAmendment() &&
                         ((allChangingObjects && allChangingObjects.length) || motion.modified_final_version)
                     "
                 >
@@ -874,33 +873,40 @@
             <div class="alert alert-info" *ngIf="motion.diffLines.length === 0">
                 <span>{{ 'No changes at the text.' | translate }}</span>
             </div>
-            <div
-                *ngFor="let paragraph of getAmendmentParagraphs(showAmendmentContext)"
-                class="motion-text motion-text-diff amendment-view"
-                [class.line-numbers-none]="isLineNumberingNone()"
-                [class.line-numbers-inline]="isLineNumberingInline()"
-                [class.line-numbers-outside]="isLineNumberingOutside()"
-                [class.amendment-context]="showAmendmentContext"
-            >
-                <!-- TODO: everything here is required for PDF as well. Should be in a service -->
-                <h3
-                    *ngIf="paragraph.diffLineTo === paragraph.diffLineFrom + 1 && !showAmendmentContext"
-                    class="amendment-line-header"
+            <ng-container *ngIf="!isRecoMode(ChangeRecoMode.Diff) && !isFinalEdit">
+                <div
+                    *ngFor="let paragraph of getAmendmentParagraphs()"
+                    class="motion-text motion-text-diff amendment-view"
+                    [class.line-numbers-none]="isLineNumberingNone()"
+                    [class.line-numbers-inline]="isLineNumberingInline()"
+                    [class.line-numbers-outside]="isLineNumberingOutside()"
+                    [class.amendment-context]="showAmendmentContext"
                 >
-                    {{ 'Line' | translate }} {{ paragraph.diffLineFrom }}:
-                </h3>
-                <h3
-                    *ngIf="paragraph.diffLineTo !== paragraph.diffLineFrom + 1 && !showAmendmentContext"
-                    class="amendment-line-header"
-                >
-                    {{ 'Line' | translate }} {{ paragraph.diffLineFrom }} - {{ paragraph.diffLineTo - 1 }}:
-                </h3>
+                    <h3 class="amendment-line-header" *ngIf="!showAmendmentContext">{{ getAmendmentParagraphLinesTitle(paragraph) }}</h3>
 
-                <!-- TODO: Seems to be directly duplicated in the slide -->
-                <div class="paragraphcontext" [innerHtml]="paragraph.textPre | trust: 'html'"></div>
-                <div [innerHtml]="paragraph.text | trust: 'html'"></div>
-                <div class="paragraphcontext" [innerHtml]="paragraph.textPost | trust: 'html'"></div>
-            </div>
+                    <os-motion-detail-original-change-recommendations
+                        *ngIf="isLineNumberingOutside() && (isRecoMode(ChangeRecoMode.Original) || isRecoMode(ChangeRecoMode.Changed))"
+                        [html]="getAmendmentDiffTextWithContext(paragraph)"
+                        [changeRecommendations]="changeRecommendations"
+                        (createChangeRecommendation)="createChangeRecommendation($event)"
+                        (gotoChangeRecommendation)="gotoChangeRecommendation($event)"
+                    ></os-motion-detail-original-change-recommendations>
+                    <div
+                        *ngIf="!isLineNumberingOutside() || !(isRecoMode(ChangeRecoMode.Original) || isRecoMode(ChangeRecoMode.Changed))"
+                        [outerHTML]="getAmendmentDiffTextWithContext(paragraph) | trust: 'html'"
+                    ></div><!-- the <div> element is only a placeholder -> outerHTML to replace it -->
+                </div>
+            </ng-container>
+
+            <os-motion-detail-diff
+                *ngIf="isRecoMode(ChangeRecoMode.Diff)"
+                [motion]="motion"
+                [changes]="getChangesForDiffMode()"
+                [scrollToChange]="scrollToChange"
+                [highlightedLine]="highlightedLine"
+                [lineNumberingMode]="lnMode"
+                (createChangeRecommendation)="createChangeRecommendation($event)"
+            ></os-motion-detail-diff>
         </div>
         <div *ngIf="!motion.diffLines">
             <span class="red-warning-text">{{
@@ -910,7 +916,7 @@
     </section>
 
     <!-- Show entire motion text -->
-    <div>
+    <div *ngIf="isRecoMode(ChangeRecoMode.Original) || isRecoMode(ChangeRecoMode.Changed)">
         <mat-checkbox
             (change)="showAmendmentContext = !showAmendmentContext"
             *ngIf="motion && motion.isParagraphBasedAmendment()"
@@ -953,7 +959,10 @@
     </div>
 </mat-menu>
 
-<!-- Diff View Menu -->
+<!-- Diff View Menu
+     For motions, all items are available if there are changing objects. The final print template only after is has been created.
+     For paragraph-based amendments, only the original and the diff version is available.
+-->
 <mat-menu #changeRecoMenu="matMenu">
     <button
         mat-menu-item
@@ -982,13 +991,13 @@
         mat-menu-item
         (click)="setChangeRecoMode(ChangeRecoMode.Final)"
         [ngClass]="{ selected: crMode === ChangeRecoMode.Final }"
-        *ngIf="allChangingObjects && allChangingObjects.length"
+        *ngIf="motion && !motion.isParagraphBasedAmendment() && allChangingObjects && allChangingObjects.length"
     >
         {{ 'Final version' | translate }}
     </button>
     <button
         mat-menu-item
-        *ngIf="motion && motion.modified_final_version"
+        *ngIf="motion && motion.modified_final_version && !motion.isParagraphBasedAmendment()"
         (click)="setChangeRecoMode(ChangeRecoMode.ModifiedFinal)"
         [ngClass]="{ selected: crMode === ChangeRecoMode.ModifiedFinal }"
     >

--- a/client/src/app/site/motions/services/motion-csv-export.service.ts
+++ b/client/src/app/site/motions/services/motion-csv-export.service.ts
@@ -64,7 +64,14 @@ export class MotionCsvExportService {
         const amendments = this.motionRepo.getAmendmentsInstantly(motion.id);
         if (amendments) {
             for (const amendment of amendments) {
-                const changedParagraphs = this.motionRepo.getAmendmentAmendedParagraphs(amendment, lineLength);
+                const changeRecos = this.changeRecoRepo
+                    .getChangeRecoOfMotion(amendment.id)
+                    .filter(reco => reco.showInFinalView());
+                const changedParagraphs = this.motionRepo.getAmendmentAmendedParagraphs(
+                    amendment,
+                    lineLength,
+                    changeRecos
+                );
                 for (const change of changedParagraphs) {
                     changes.push(change as ViewUnifiedChange);
                 }


### PR DESCRIPTION
Not ready to be merged.

What works:
- Creating, editing and deleting change recommendations for paragraph-based amendments
- Original, Changed and Diff view of an amendment, where the three terms refer to the amendment in relation to the change recommendations
- Setting the status of change recommendations
- The overhauled amendment is shown in the Diff / Final view of the motion