### PR TITLE
Adds more permissive html validation for topics and welcome page

### DIFF
--- a/openslides/assignments/serializers.py
+++ b/openslides/assignments/serializers.py
@@ -17,7 +17,7 @@ from openslides.utils.rest_api import (
 
 from ..utils.auth import has_perm
 from ..utils.autoupdate import inform_changed_data
-from ..utils.validate import validate_html
+from ..utils.validate import validate_html_strict
 from .models import (
     Assignment,
     AssignmentOption,
@@ -177,7 +177,7 @@ class AssignmentSerializer(ModelSerializer):
 
     def validate(self, data):
         if "description" in data:
-            data["description"] = validate_html(data["description"])
+            data["description"] = validate_html_strict(data["description"])
         return data
 
     def create(self, validated_data):

--- a/openslides/core/config.py
+++ b/openslides/core/config.py
@@ -7,7 +7,7 @@ from django.core.exceptions import ValidationError as DjangoValidationError
 from mypy_extensions import TypedDict
 
 from ..utils.cache import element_cache
-from ..utils.validate import validate_html
+from ..utils.validate import validate_html_permissive, validate_html_strict
 from .exceptions import ConfigError, ConfigNotFound
 from .models import ConfigStore
 
@@ -183,7 +183,10 @@ class ConfigHandler:
                         raise ConfigError(f"{required_entry} has to be a string.")
 
         if config_variable.input_type == "markupText":
-            value = validate_html(value)
+            if config_variable.name == "general_event_welcome_text":
+                value = validate_html_permissive(value)
+            else:
+                value = validate_html_strict(value)
 
         # Save the new value to the database.
         db_value = ConfigStore.objects.get(key=key)

--- a/openslides/core/serializers.py
+++ b/openslides/core/serializers.py
@@ -10,7 +10,7 @@ from ..utils.rest_api import (
     SerializerMethodField,
     ValidationError,
 )
-from ..utils.validate import validate_html
+from ..utils.validate import validate_html_strict
 from .models import (
     ConfigStore,
     Countdown,
@@ -161,7 +161,7 @@ class ProjectorMessageSerializer(ModelSerializer):
 
     def validate(self, data):
         if "message" in data:
-            data["message"] = validate_html(data["message"])
+            data["message"] = validate_html_strict(data["message"])
         return data
 
 

--- a/openslides/motions/serializers.py
+++ b/openslides/motions/serializers.py
@@ -24,7 +24,7 @@ from ..utils.rest_api import (
     SerializerMethodField,
     ValidationError,
 )
-from ..utils.validate import validate_html
+from ..utils.validate import validate_html_strict
 from .models import (
     Category,
     Motion,
@@ -292,7 +292,7 @@ class MotionChangeRecommendationSerializer(ModelSerializer):
     def validate(self, data):
         # Change recommendations for titles are stored as plain-text, thus they don't need to be html-escaped
         if "text" in data and not self.is_title_cr(data):
-            data["text"] = validate_html(data["text"])
+            data["text"] = validate_html_strict(data["text"])
         return data
 
 
@@ -419,21 +419,21 @@ class MotionSerializer(ModelSerializer):
 
     def validate(self, data):
         if "text" in data:
-            data["text"] = validate_html(data["text"])
+            data["text"] = validate_html_strict(data["text"])
 
         if "modified_final_version" in data:
-            data["modified_final_version"] = validate_html(
+            data["modified_final_version"] = validate_html_strict(
                 data["modified_final_version"]
             )
 
         if "reason" in data:
-            data["reason"] = validate_html(data["reason"])
+            data["reason"] = validate_html_strict(data["reason"])
 
         # The motion text is only needed, if it is not a paragraph based amendment.
         if data.get("amendment_paragraphs") is not None:
             data["amendment_paragraphs"] = list(
                 map(
-                    lambda entry: validate_html(entry)
+                    lambda entry: validate_html_strict(entry)
                     if isinstance(entry, str)
                     else None,
                     data["amendment_paragraphs"],

--- a/openslides/topics/serializers.py
+++ b/openslides/topics/serializers.py
@@ -1,6 +1,6 @@
 from openslides.utils.autoupdate import inform_changed_data
 from openslides.utils.rest_api import CharField, IntegerField, ModelSerializer
-from openslides.utils.validate import validate_html
+from openslides.utils.validate import validate_html_permissive
 
 from .models import Topic
 
@@ -36,7 +36,7 @@ class TopicSerializer(ModelSerializer):
 
     def validate(self, data):
         if "text" in data:
-            data["text"] = validate_html(data["text"])
+            data["text"] = validate_html_permissive(data["text"])
         return data
 
     def create(self, validated_data):

--- a/openslides/users/serializers.py
+++ b/openslides/users/serializers.py
@@ -9,7 +9,7 @@ from ..utils.rest_api import (
     RelatedField,
     ValidationError,
 )
-from ..utils.validate import validate_html
+from ..utils.validate import validate_html_strict
 from .models import Group, PersonalNote, User
 
 
@@ -95,7 +95,7 @@ class UserSerializer(ModelSerializer):
 
         # check the about_me html
         if "about_me" in data:
-            data["about_me"] = validate_html(data["about_me"])
+            data["about_me"] = validate_html_strict(data["about_me"])
 
         return data
 

--- a/tests/unit/utils/test_validate.py
+++ b/tests/unit/utils/test_validate.py
@@ -1,12 +1,12 @@
 from unittest import TestCase
 
-from openslides.utils.validate import validate_html
+from openslides.utils.validate import validate_html_strict
 
 
 class ValidatorTest(TestCase):
     def test_XSS_protection(self):
         data = "tuveegi2Ho<a><p>tuveegi2Ho<script>kekj9(djwk</script></p>Boovai7esu</a>ee4Yaiw0ei"
         self.assertEqual(
-            validate_html(data),
+            validate_html_strict(data),
             "tuveegi2Ho<a><p>tuveegi2Ho&lt;script&gt;kekj9(djwk&lt;/script&gt;</p>Boovai7esu</a>ee4Yaiw0ei",
         )


### PR DESCRIPTION
Currently allows usage of `<video>` tags
an exception for the welcome page greeting has been implemented, this could also be extended to all markup config variables if needed