### PR TITLE
Projector indicator list view tables

### DIFF
--- a/client/src/app/shared/components/list-view-table/list-view-table.component.html
+++ b/client/src/app/shared/components/list-view-table/list-view-table.component.html
@@ -22,6 +22,8 @@
         [columns]="columnSet"
         [hideColumns]="hiddenColumns"
         (rowClick)="onSelectRow($event)"
+        [rowClassUpdate]="isElementProjected"
+        rowClassUpdateFreq="ngDoCheck"
     >
         <!-- "row" has the view model -->
         <!-- "value" has the property, that was defined in the columnDefinition -->
@@ -30,10 +32,21 @@
         <!-- Projector column -->
         <div *pblNgridCellDef="'projector'; row as viewModel" class="fill ngrid-lg">
             <os-projector-button
+                *osPerms="'core.can_manage_projector'"
                 class="projector-button"
                 [object]="getProjectable(viewModel)"
                 (changeEvent)="viewUpdateEvent()"
             ></os-projector-button>
+            <!-- Projector indicator -->
+            <div class="projector-button" *osPerms="'core.can_manage_projector'; complement: true">
+                <mat-icon
+                    color="accent"
+                    *ngIf="projectorService.isProjected(getProjectable(viewModel))"
+                    matTooltip="{{ 'Currently projected' | translate }}"
+                >
+                    videocam
+                </mat-icon>
+            </div>
         </div>
 
         <!-- No Results -->

--- a/client/src/app/shared/components/list-view-table/list-view-table.component.scss
+++ b/client/src/app/shared/components/list-view-table/list-view-table.component.scss
@@ -4,6 +4,7 @@ $pbl-height: var(--pbl-height);
 
 .projector-button {
     margin: auto;
+    display: flex;
 }
 
 .pbl-ngrid-row {

--- a/client/src/app/shared/components/list-view-table/list-view-table.component.scss-theme.scss
+++ b/client/src/app/shared/components/list-view-table/list-view-table.component.scss-theme.scss
@@ -1,0 +1,13 @@
+@import '~@angular/material/theming';
+
+@mixin os-list-view-table-theme($theme) {
+    $primary: map-get($theme, primary);
+    $accent: map-get($theme, accent);
+    $warn: map-get($theme, accent);
+    $foreground: map-get($theme, foreground);
+    $background: map-get($theme, background);
+
+    .projected {
+        background-color: mat-color($background, hover) !important;
+    }
+}

--- a/client/src/app/shared/components/list-view-table/list-view-table.component.spec.ts
+++ b/client/src/app/shared/components/list-view-table/list-view-table.component.spec.ts
@@ -5,8 +5,8 @@ import { E2EImportsModule } from 'e2e-imports.module';
 import { ListViewTableComponent } from './list-view-table.component';
 
 describe('ListViewTableComponent', () => {
-    let component: ListViewTableComponent<any, any>;
-    let fixture: ComponentFixture<ListViewTableComponent<any, any>>;
+    let component: ListViewTableComponent<any>;
+    let fixture: ComponentFixture<ListViewTableComponent<any>>;
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({

--- a/client/src/app/site/agenda/components/agenda-list/agenda-list.component.html
+++ b/client/src/app/site/agenda/components/agenda-list/agenda-list.component.html
@@ -33,19 +33,31 @@
     <div *pblNgridCellDef="'title'; row as item; rowContext as rowContext" class="cell-slot fill">
         <a class="detail-link" [routerLink]="getDetailUrl(item)" *ngIf="!isMultiSelect"></a>
         <div [ngStyle]="{ 'margin-left': item.level * 25 + 'px' }" class="innerTable">
-            <os-icon-container [noWrap]="true" [icon]="item.closed ? 'check' : null" size="large">
-                <div class="ellipsis-overflow">
+
+            <!-- Title line -->
+            <div class="title-line ellipsis-overflow">
+                <!-- Is Closed -->
+                <span class="icon-prefix" *ngIf="item.closed">
+                    <mat-icon>check</mat-icon>
+                </span>
+
+                <!-- Title -->
+                <span>
                     {{ item.getListTitle() }}
-                </div>
-                <div *ngIf="showSubtitle" class="subtitle ellipsis-overflow">
-                    {{ item.getSubtitle() }}
-                </div>
-                <div *ngIf="item.comment" class="subtitle ellipsis-overflow">
-                    <os-icon-container size="small" icon="comment" [noWrap]="true">
-                        {{ item.comment }}
-                    </os-icon-container>
-                </div>
-            </os-icon-container>
+                </span>
+            </div>
+
+            <!-- Subtitle line -->
+            <div class="subtitle ellipsis-overflow">
+                {{ item.getSubtitle() }}
+            </div>
+
+            <!-- Comment line -->
+            <div class="subtitle ellipsis-overflow" *ngIf="item.comment">
+                <os-icon-container size="small" icon="comment" [noWrap]="true">
+                    {{ item.comment }}
+                </os-icon-container>
+            </div>
         </div>
     </div>
 
@@ -121,7 +133,12 @@
             <span>{{ 'Import' | translate }}</span>
         </button>
         <mat-divider></mat-divider>
-        <button mat-menu-item *osPerms="'agenda.can_manage'" class="red-warning-text" (click)="deleteAllSpeakersOfAllListsOfSpeakers()">
+        <button
+            mat-menu-item
+            *osPerms="'agenda.can_manage'"
+            class="red-warning-text"
+            (click)="deleteAllSpeakersOfAllListsOfSpeakers()"
+        >
             <mat-icon>delete</mat-icon>
             <span>{{ 'Clear all list of speakers' | translate }}</span>
         </button>
@@ -229,7 +246,12 @@
                 <span>{{ 'Remove from agenda' | translate }}</span>
             </button>
 
-            <button mat-menu-item class="red-warning-text" (click)="deleteTopic(item)" *ngIf="isTopic(item.contentObject)">
+            <button
+                mat-menu-item
+                class="red-warning-text"
+                (click)="deleteTopic(item)"
+                *ngIf="isTopic(item.contentObject)"
+            >
                 <mat-icon>delete</mat-icon>
                 <span>{{ 'Delete' | translate }}</span>
             </button>

--- a/client/src/app/site/agenda/components/agenda-list/agenda-list.component.scss
+++ b/client/src/app/site/agenda/components/agenda-list/agenda-list.component.scss
@@ -16,10 +16,3 @@
 .align-right {
     margin-left: auto;
 }
-
-/*
-* Where is this used?
-*/
-.done-check {
-    margin-right: 10px;
-}

--- a/client/src/app/site/motions/modules/motion-block/components/motion-block-detail/motion-block-detail.component.html
+++ b/client/src/app/site/motions/modules/motion-block/components/motion-block-detail/motion-block-detail.component.html
@@ -68,7 +68,7 @@
                 </span>
 
                 <!-- Has File -->
-                <span class="attached-files" *ngIf="motion.hasAttachments()">
+                <span class="icon-prefix" *ngIf="motion.hasAttachments()">
                     <mat-icon>attach_file</mat-icon>
                 </span>
 

--- a/client/src/app/site/motions/modules/motion-list/components/motion-list/motion-list.component.html
+++ b/client/src/app/site/motions/modules/motion-list/components/motion-list/motion-list.component.html
@@ -74,7 +74,7 @@
                     </span>
 
                     <!-- Has File -->
-                    <span class="attached-files" *ngIf="motion.hasAttachments()">
+                    <span class="icon-prefix" *ngIf="motion.hasAttachments()">
                         <mat-icon>attach_file</mat-icon>
                     </span>
 

--- a/client/src/assets/styles/tables.scss
+++ b/client/src/assets/styles/tables.scss
@@ -4,7 +4,7 @@
     font-weight: 500;
     font-size: 16px;
 
-    .attached-files {
+    .icon-prefix {
         .mat-icon {
             display: inline-flex;
             vertical-align: middle;

--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -33,6 +33,7 @@
 @import './app/site/assignments/components/assignment-poll-detail/assignment-poll-detail-component.scss-theme.scss';
 @import './app/shared/components/progress-snack-bar/progress-snack-bar.component.scss-theme.scss';
 @import './app/shared/components/jitsi/jitsi.component.scss-theme.scss';
+@import './app/shared/components/list-view-table/list-view-table.component.scss-theme.scss';
 
 /** fonts */
 @import './assets/styles/fonts.scss';
@@ -66,6 +67,7 @@ $narrow-spacing: (
     @include os-assignment-poll-detail-style($theme);
     @include os-progress-snack-bar-style($theme);
     @include os-jitsi-theme($theme);
+    @include os-list-view-table-theme($theme);
 }
 
 /** Load projector specific SCSS values */


### PR DESCRIPTION
Shows a projector indicator in the list view tables.
Width is 24px, just as small as mat-icon needs.
Works in every list view that allows projector buttons (which should
cover all where an indicator could be demanded)

(the branch name is misleading)

@emanuelschuetze tell me if you like it