### PR TITLE
Set version of pytest-django and pytest-asyncio

### DIFF
--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -4,6 +4,6 @@ flake8
 isort
 mypy
 pytest
-pytest-django
-pytest-asyncio
+pytest-django<3.9.0
+pytest-asyncio<0.11.0
 pytest-cov


### PR DESCRIPTION
Apparently, updates in these two libraries are not compatible
with out current testing setup