### PR TITLE
Defined ActionResult as custom type. Added Error-interface.

### DIFF
--- a/docs/interfaces/actions-service.txt
+++ b/docs/interfaces/actions-service.txt
@@ -19,7 +19,9 @@ interface Action {
     data: object[];  # An array of action specific data. See JSON schema defintions.
 }
 
-interface ActionResult {
-    success: boolean;
-    message: string;
+type actionResult = object | ActionError
+
+Interface ActionError {
+    type: number;
+    msg: string;
 }

--- a/docs/interfaces/presenter-service.txt
+++ b/docs/interfaces/presenter-service.txt
@@ -32,7 +32,7 @@ handle_request(payload: Presenter[], user_id: Id): PresenterResult[]
  */
 Interface Presenter {
     presenter: string;
-    data: any;
+    data: object;
 }
 
 /**
@@ -43,7 +43,7 @@ Interface Presenter {
  * TODO: Maybe we do not want to response an error but always throw an exception
  * instead.
  */
-type PresenterResult = any | PresenterError;
+type PresenterResult = object | PresenterError;
 
 /**
  * A common format for errors.


### PR DESCRIPTION
In order to reflect the result of a bulk operation I decided to define `ActionResult` as a custom type.
`ActionResult` itself is either an actual result in form of an `object` or it is an `Error` such that you could have the following as a result

```
[{
	msg: "user 2 created"
        ...
}, {
	type: 1,
	msg: "failed to create user4 "
}, {
	msg: "user 4 created"
        ...
}]
```