### PR TITLE
Removed vote weight from votes_cast

### DIFF
--- a/client/src/app/core/repositories/users/user-repository.service.ts
+++ b/client/src/app/core/repositories/users/user-repository.service.ts
@@ -17,6 +17,11 @@ import { DataSendService } from '../../core-services/data-send.service';
 import { DataStoreService } from '../../core-services/data-store.service';
 import { environment } from '../../../../environments/environment';
 
+export interface MassImportResult {
+    importedTrackIds: number[];
+    errors: { [id: number]: string };
+}
+
 /**
  * type for determining the user name from a string during import.
  * See {@link parseUserString} for implementations
@@ -222,15 +227,11 @@ export class UserRepositoryService extends BaseRepository<ViewUser, User, UserTi
      *
      * @param newEntries
      */
-    public async bulkCreate(newEntries: NewEntry<User>[]): Promise<number[]> {
+    public async bulkCreate(newEntries: NewEntry<User>[]): Promise<MassImportResult> {
         const data = newEntries.map(entry => {
             return { ...entry.newEntry, importTrackId: entry.importTrackId };
         });
-        const response = (await this.httpService.post(`/rest/users/user/mass_import/`, { users: data })) as {
-            detail: string;
-            importedTrackIds: number[];
-        };
-        return response.importedTrackIds;
+        return await this.httpService.post<MassImportResult>(`/rest/users/user/mass_import/`, { users: data });
     }
 
     /**

--- a/client/src/app/site/base/base-import-list.ts
+++ b/client/src/app/site/base/base-import-list.ts
@@ -141,7 +141,6 @@ export abstract class BaseImportListComponentDirective<M extends BaseModel> exte
             .getNewEntries()
             .pipe(auditTime(100))
             .subscribe(newEntries => {
-                this.dataSource.data = [];
                 this.dataSource.data = newEntries;
                 this.hasFile = newEntries.length > 0;
             });

--- a/openslides/poll/models.py
+++ b/openslides/poll/models.py
@@ -211,7 +211,7 @@ class BasePoll(models.Model):
         if self.type == self.TYPE_ANALOG:
             return self.db_votescast
         else:
-            return Decimal(self.amount_users_voted_with_individual_weight())
+            return Decimal(self.amount_users_voted())
 
     def set_votescast(self, value):
         if self.type != self.TYPE_ANALOG:
@@ -220,11 +220,14 @@ class BasePoll(models.Model):
 
     votescast = property(get_votescast, set_votescast)
 
+    def amount_users_voted(self):
+        return len(self.voted.all())
+
     def amount_users_voted_with_individual_weight(self):
         if config["users_activate_vote_weight"]:
             return sum(user.vote_weight for user in self.voted.all())
         else:
-            return len(self.voted.all())
+            return self.amount_users_voted()
 
     def create_options(self):
         """ Should be called after creation of this model. """

--- a/tests/integration/assignments/test_polls.py
+++ b/tests/integration/assignments/test_polls.py
@@ -1013,7 +1013,7 @@ class VoteAssignmentPollNamedYNA(VoteAssignmentPollBaseTestClass):
         poll = AssignmentPoll.objects.get()
         self.assertEqual(poll.votesvalid, weight)
         self.assertEqual(poll.votesinvalid, Decimal("0"))
-        self.assertEqual(poll.votescast, weight)
+        self.assertEqual(poll.votescast, Decimal("1"))
         self.assertEqual(poll.state, AssignmentPoll.STATE_STARTED)
         self.assertEqual(poll.amount_users_voted_with_individual_weight(), weight)
         option1 = poll.options.get(pk=1)

--- a/tests/integration/motions/test_polls.py
+++ b/tests/integration/motions/test_polls.py
@@ -779,7 +779,7 @@ class VoteMotionPollNamed(TestCase):
         poll = MotionPoll.objects.get()
         self.assertEqual(poll.votesvalid, weight)
         self.assertEqual(poll.votesinvalid, Decimal("0"))
-        self.assertEqual(poll.votescast, weight)
+        self.assertEqual(poll.votescast, Decimal("1"))
         self.assertEqual(poll.get_votes().count(), 1)
         self.assertEqual(poll.amount_users_voted_with_individual_weight(), weight)
         option = poll.options.get()


### PR DESCRIPTION
@emanuelschuetze I added a server side error for a wrong vote weight in the user import. The code is not flexible enough to just pass server errors, so there is a default string to display. Another thing: I do get a red entry on an error, but I cannot see the error message in the UI. Maybe @tsiegleauq have a look, where the message should be shown.

I'm not sure if the change, that votes_cast have the amount of users voted, must reflect in the client in some way.

The csv import works with 6 decimal places. With more, an error is now returned per user.