### PR TITLE
Toggle to show all amendments in diff view

### DIFF
--- a/client/src/app/site/motions/models/view-motion-amended-paragraph.ts
+++ b/client/src/app/site/motions/models/view-motion-amended-paragraph.ts
@@ -15,7 +15,7 @@ export class ViewMotionAmendedParagraph implements ViewUnifiedChange {
     }
 
     public constructor(
-        private amendment: ViewMotion,
+        public amendment: ViewMotion,
         private paragraphNo: number,
         private newText: string,
         private lineRange: LineRange

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-detail-diff/motion-detail-diff.component.html
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-detail-diff/motion-detail-diff.component.html
@@ -26,10 +26,10 @@
                     -->
                 </span>
                 <span class="status">
-                    <ng-container *ngIf="change.isRejected()">
+                    <ng-container *ngIf="change.isRejected() && !isAmendment(change)">
                         – <span>{{ 'Rejected' | translate }}</span></ng-container
                     >
-                    <ng-container *ngIf="change.isAccepted() && isAmendment(change)">
+                    <ng-container *ngIf="(change.isAccepted() || isAmendment(change)) && change.stateName">
                         – {{ change.stateName | translate }}</ng-container
                     >
                 </span>
@@ -104,6 +104,15 @@
                 >
                     <mat-icon>more_horiz</mat-icon>
                 </button>
+                <button
+                    mat-icon-button
+                    *ngIf="isAmendment(change)"
+                    type="button"
+                    [matMenuTriggerFor]="amendmentMenu"
+                    [matMenuTriggerData]="{ change: change }"
+                >
+                    <mat-icon>more_horiz</mat-icon>
+                </button>
 
                 <!--
                     <a ng-if="change.type == 'amendment'" ui-sref="motions.motion.detail({id: change.original.id})"
@@ -114,8 +123,16 @@
                     </a>
                 -->
             </div>
-            <div class="status-row" *ngIf="change.isRejected()">
+            <div class="status-row" *ngIf="isChangeRecommendation(change) && change.isRejected()">
                 <i class="grey">{{ 'Rejected' | translate }}</i>
+            </div>
+            
+            <!-- If it's an amendment, only accepted ones will be passed to this component
+                 by default (== !showAllAmendments). In this case, don't show the prefix.
+                 However, if showAllAmendments === true, the prefix should be shown alwayes,
+                 even if it's accepted -->
+            <div class="status-row" *ngIf="isAmendment(change) && showAllAmendments">
+                <i class="grey">{{ change.amendment.identifier }} - {{ change.amendment.state.name | translate }}</i>
             </div>
 
             <div
@@ -143,12 +160,46 @@
     </div>
 </div>
 
+<mat-menu #amendmentMenu="matMenu">
+    <ng-template matMenuContent let-change="change">
+        <button
+            type="button"
+            mat-menu-item
+            [routerLink]="change.amendment.getDetailStateURL()" [state]="{ back: 'true' }"
+        >
+            <mat-icon>visibility_on</mat-icon>
+            <span>{{ 'Show amendment' | translate }}</span>
+        </button>
+
+        <mat-divider *ngIf="change.amendment.state.next_states.length > 0"></mat-divider>
+
+        <button *ngFor="let state of change.amendment.state.next_states" mat-menu-item (click)="setAmendmentState(change, state.id)">
+            {{ state.name | translate }} <span *ngIf="state.show_state_extension_field">&nbsp;...</span>
+        </button>
+        <mat-divider *ngIf="change.amendment.state.next_states.length > 0"></mat-divider>
+        <button
+            *ngFor="let state of change.amendment.state.previous_states"
+            mat-menu-item
+            (click)="setAmendmentState(change, state.id)"
+        >
+            <mat-icon>arrow_back</mat-icon>
+            {{ state.name | translate }}
+            <span *ngIf="state.show_state_extension_field">&nbsp;...</span>
+        </button>
+        <button mat-menu-item (click)="setAmendmentState(change, null)">
+            <mat-icon>replay</mat-icon>
+            {{ 'Reset state' | translate }}
+        </button>
+
+        <!-- perms.isAllowed('change_state', motion) -->
+    </ng-template>
+</mat-menu>
+
 <mat-menu #changeRecommendationMenu="matMenu">
     <ng-template matMenuContent let-change="change">
         <button
             type="button"
             mat-menu-item
-            [disabled]="hasCollissions(change, changes)"
             (click)="setAcceptanceValue(change, 'accepted')"
         >
             <mat-icon>thumb_up</mat-icon>
@@ -158,7 +209,6 @@
         <button
             type="button"
             mat-menu-item
-            [disabled]="hasCollissions(change, changes)"
             (click)="setAcceptanceValue(change, 'rejected')"
         >
             <mat-icon>thumb_down</mat-icon>

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-detail-diff/motion-detail-diff.component.ts
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-detail-diff/motion-detail-diff.component.ts
@@ -26,6 +26,7 @@ import {
     MotionTitleChangeRecommendationDialogComponent,
     MotionTitleChangeRecommendationDialogComponentData
 } from '../motion-title-change-recommendation-dialog/motion-title-change-recommendation-dialog.component';
+import { ViewMotionAmendedParagraph } from '../../../../models/view-motion-amended-paragraph';
 
 /**
  * This component displays the original motion text with the change blocks inside.
@@ -45,6 +46,7 @@ import {
  *       [scrollToChange]="change"
  *       [highlightedLine]="highlightedLine"
  *       [lineNumberingMode]="lnMode"
+ *       [showAllAmendments]="showAllAmendments"
  *       (createChangeRecommendation)="createChangeRecommendation($event)"
  * ></os-motion-detail-diff>
  * ```
@@ -70,6 +72,8 @@ export class MotionDetailDiffComponent extends BaseViewComponent implements Afte
     public highlightedLine: number;
     @Input()
     public lineNumberingMode: LineNumberingMode;
+    @Input()
+    public showAllAmendments: boolean;
 
     @Output()
     public createChangeRecommendation: EventEmitter<LineRange> = new EventEmitter<LineRange>();
@@ -362,6 +366,10 @@ export class MotionDetailDiffComponent extends BaseViewComponent implements Afte
             ...mediumDialogSettings,
             data: data
         });
+    }
+
+    public setAmendmentState(change: ViewUnifiedChange, state: number): void {
+        this.motionRepo.setState((change as ViewMotionAmendedParagraph).amendment, state).catch(this.raiseError);
     }
 
     /**

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.html
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.html
@@ -463,6 +463,11 @@
                 <span *ngIf="amendments.length === 1">{{ 'Amendment' | translate }}</span>
                 <span *ngIf="amendments.length > 1">{{ 'Amendments' | translate }}</span>
             </a>
+
+            <br>
+            <mat-checkbox [(ngModel)]="showAllAmendments" *ngIf="isRecoMode(ChangeRecoMode.Diff)">
+                {{ 'Temporarily show all in text' | translate }}
+            </mat-checkbox>
         </div>
 
         <!-- motion polls -->
@@ -681,6 +686,7 @@
                 [changes]="getChangesForDiffMode()"
                 [scrollToChange]="scrollToChange"
                 [highlightedLine]="highlightedLine"
+                [showAllAmendments]="showAllAmendments"
                 [lineNumberingMode]="lnMode"
                 (createChangeRecommendation)="createChangeRecommendation($event)"
             ></os-motion-detail-diff>
@@ -904,6 +910,7 @@
                 [changes]="getChangesForDiffMode()"
                 [scrollToChange]="scrollToChange"
                 [highlightedLine]="highlightedLine"
+                [showAllAmendments]="showAllAmendments"
                 [lineNumberingMode]="lnMode"
                 (createChangeRecommendation)="createChangeRecommendation($event)"
             ></os-motion-detail-diff>

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.ts
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.ts
@@ -328,6 +328,11 @@ export class MotionDetailComponent extends BaseViewComponent implements OnInit, 
     private amendmentTextMode: string;
 
     /**
+     * Show all amendments in the text, not only the ones with the apropriate state
+     */
+    public showAllAmendments = false;
+
+    /**
      * For using the enum constants from the template
      */
     public ChangeRecoMode = ChangeRecoMode;
@@ -1005,7 +1010,11 @@ export class MotionDetailComponent extends BaseViewComponent implements OnInit, 
 
     public getChangesForDiffMode(): ViewUnifiedChange[] {
         return this.allChangingObjects.filter(change => {
-            return change.showInDiffView();
+            if (this.showAllAmendments) {
+                return true;
+            } else {
+                return change.showInDiffView();
+            }
         });
     }
 


### PR DESCRIPTION
This adds a "temporarily show all in text" button to the amendment list when being in Diff Mode. If activated, then also amendments that have not yet been accepted are shown in diff mode.
Additionally, there is a context menu for amendments in Diff Mode to change the state and go to the amendment detail page.