### PR TITLE
Set tinymce urls to absolute

### DIFF
--- a/client/src/app/base.component.ts
+++ b/client/src/app/base.component.ts
@@ -58,7 +58,9 @@ export abstract class BaseComponent {
         mobile: {
             theme: 'mobile',
             plugins: ['autosave', 'lists', 'autolink']
-        }
+        },
+        relative_urls: false,
+        remove_script_host: true
     };
 
     public constructor(protected titleService: Title, protected translate: TranslateService) {


### PR DESCRIPTION
Potentially fixes a deeper TinyMCE issue that causes TinyMCE to remove
important parts of pasted URLs