### PR TITLE
(WIP) Synchronize autoupdate code in the client

### DIFF
--- a/client/src/app/core/core-services/autoupdate.service.ts
+++ b/client/src/app/core/core-services/autoupdate.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@angular/core';
 import { BaseModel } from '../../shared/models/base/base-model';
 import { CollectionStringMapperService } from './collection-string-mapper.service';
 import { DataStoreService, DataStoreUpdateManagerService } from './data-store.service';
+import { Mutex } from '../promises/mutex';
 import { WebsocketService, WEBSOCKET_ERROR_CODES } from './websocket.service';
 
 interface AutoupdateFormat {
@@ -45,6 +46,7 @@ interface AutoupdateFormat {
     providedIn: 'root'
 })
 export class AutoupdateService {
+    private mutex = new Mutex();
     /**
      * Constructor to create the AutoupdateService. Calls the constructor of the parent class.
      * @param websocketService
@@ -79,11 +81,13 @@ export class AutoupdateService {
      * Handles the change ids of all autoupdates.
      */
     private async storeResponse(autoupdate: AutoupdateFormat): Promise<void> {
+        const unlock = await this.mutex.lock();
         if (autoupdate.all_data) {
             await this.storeAllData(autoupdate);
         } else {
             await this.storePartialAutoupdate(autoupdate);
         }
+        unlock();
     }
 
     /**

--- a/client/src/app/core/core-services/data-store.service.ts
+++ b/client/src/app/core/core-services/data-store.service.ts
@@ -258,6 +258,7 @@ export class DataStoreUpdateManagerService {
 
     private serveNextSlot(): void {
         if (this.updateSlotRequests.length > 0) {
+            console.warn('Concurrent update slots');
             const request = this.updateSlotRequests.pop();
             request.resolve();
         }

--- a/client/src/app/core/promises/mutex.ts
+++ b/client/src/app/core/promises/mutex.ts
@@ -1,0 +1,30 @@
+/**
+ * A mutex as described in every textbook
+ *
+ * Usage:
+ * ```
+ * mutex = new Mutex(); // create e.g. as class member
+ *
+ * // Somewhere in the code to lock (must be async code!)
+ * const unlock = await this.mutex.lock()
+ * // ...the code to synchronize
+ * unlock()
+ * ```
+ */
+export class Mutex {
+    private mutex = Promise.resolve();
+
+    public lock(): PromiseLike<() => void> {
+        // this will capture the code-to-synchronize
+        let begin: (unlock: () => void) => void = () => {};
+
+        // All "requests" to execute code are chained in a promise-chain
+        this.mutex = this.mutex.then(() => {
+            return new Promise(begin);
+        });
+
+        return new Promise(res => {
+            begin = res;
+        });
+    }
+}

--- a/client/src/app/site/common/components/start/start.component.html
+++ b/client/src/app/site/common/components/start/start.component.html
@@ -12,6 +12,11 @@
     </div>
 </os-head-bar>
 
+<button mat-button (click)="echo()">Echo</button>
+<button mat-button (click)="echoLogin()">Echo Login</button>
+<button mat-button (click)="currentAutoupdate()">Current Autoupdate</button>
+<button mat-button (click)="currentAutoupdateLogin()">Current Autoupdate Login</button>
+
 <mat-card [ngClass]="isEditing ? 'os-form-card' : 'os-card'">
     <ng-container *ngIf="!isEditing">
         <div class="app-content">

--- a/client/src/app/site/common/components/start/start.component.html
+++ b/client/src/app/site/common/components/start/start.component.html
@@ -11,9 +11,14 @@
         <h2>{{ 'Home' | translate }}</h2>
     </div>
 </os-head-bar>
-
+<button mat-button (click)="setpresence()">set presence</button>
+<button mat-button (click)="setpresence_no_autoupdate()">set presence no autoupdate</button>
+<button mat-button (click)="setpresence_only_autoupdate()">set presence only autoupdate</button>
+<button mat-button (click)="simple_autoupdate()">simple autoupdate</button>
 <button mat-button (click)="echo()">Echo</button>
 <button mat-button (click)="echoLogin()">Echo Login</button>
+<button mat-button (click)="getConfig()">get config</button>
+<button mat-button (click)="getConfigLogin()">get config Login</button>
 <button mat-button (click)="currentAutoupdate()">Current Autoupdate</button>
 <button mat-button (click)="currentAutoupdateLogin()">Current Autoupdate Login</button>
 

--- a/client/src/app/site/common/components/start/start.component.html
+++ b/client/src/app/site/common/components/start/start.component.html
@@ -15,6 +15,7 @@
 <button mat-button (click)="setpresence_no_autoupdate()">set presence no autoupdate</button>
 <button mat-button (click)="setpresence_only_autoupdate()">set presence only autoupdate</button>
 <button mat-button (click)="simple_autoupdate()">simple autoupdate</button>
+<button mat-button (click)="simple_autoupdate_no_history()">simple autoupdate no history</button>
 <button mat-button (click)="echo()">Echo</button>
 <button mat-button (click)="echoLogin()">Echo Login</button>
 <button mat-button (click)="getConfig()">get config</button>

--- a/client/src/app/site/common/components/start/start.component.ts
+++ b/client/src/app/site/common/components/start/start.component.ts
@@ -90,6 +90,26 @@ export class StartComponent extends BaseViewComponent implements OnInit {
         });
     }
 
+    public async setpresence(): Promise<void> {
+        const response = await this.http.post(environment.urlPrefix + "/users/setpresence/", true);
+        console.log(response);
+    }
+
+    public async setpresence_no_autoupdate(): Promise<void> {
+        const response = await this.http.post(environment.urlPrefix + "/users/setpresence-no-autoupdate/", true);
+        console.log(response);
+    }
+
+    public async setpresence_only_autoupdate(): Promise<void> {
+        const response = await this.http.post(environment.urlPrefix + "/users/setpresence-only-autoupdate/", true);
+        console.log(response);
+    }
+
+    public async simple_autoupdate(): Promise<void> {
+        const response = await this.http.post(environment.urlPrefix + "/users/simple-autoupdate/", true);
+        console.log(response);
+    }
+
     public async echo(): Promise<void> {
         const data = {data: Math.random().toString(36).substring(7)};
         const response = await this.http.post(environment.urlPrefix + "/users/echo/", data);
@@ -99,6 +119,16 @@ export class StartComponent extends BaseViewComponent implements OnInit {
     public async echoLogin(): Promise<void> {
         const data = {data: Math.random().toString(36).substring(7)};
         const response = await this.http.post(environment.urlPrefix + "/users/echo-login/", data);
+        console.log(response);
+    }
+
+    public async getConfig(): Promise<void> {
+        const response = await this.http.post(environment.urlPrefix + "/users/get-config/");
+        console.log(response);
+    }
+
+    public async getConfigLogin(): Promise<void> {
+        const response = await this.http.post(environment.urlPrefix + "/users/get-config-login/");
         console.log(response);
     }
 

--- a/client/src/app/site/common/components/start/start.component.ts
+++ b/client/src/app/site/common/components/start/start.component.ts
@@ -9,6 +9,8 @@ import { OperatorService } from 'app/core/core-services/operator.service';
 import { ConfigRepositoryService } from 'app/core/repositories/config/config-repository.service';
 import { ConfigService } from 'app/core/ui-services/config.service';
 import { BaseViewComponent } from 'app/site/base/base-view';
+import { environment } from 'environments/environment';
+import { HttpService } from 'app/core/core-services/http.service';
 
 /**
  * Interface describes the keys for the fields at start-component.
@@ -59,7 +61,8 @@ export class StartComponent extends BaseViewComponent implements OnInit {
         private configService: ConfigService,
         private configRepo: ConfigRepositoryService,
         private fb: FormBuilder,
-        private operator: OperatorService
+        private operator: OperatorService,
+        private http: HttpService,
     ) {
         super(titleService, translate, matSnackbar);
         this.startForm = this.fb.group({
@@ -85,6 +88,28 @@ export class StartComponent extends BaseViewComponent implements OnInit {
         this.configService.get<string>('general_event_welcome_text').subscribe(welcomeText => {
             this.startContent.general_event_welcome_text = this.translate.instant(welcomeText);
         });
+    }
+
+    public async echo(): Promise<void> {
+        const data = {data: Math.random().toString(36).substring(7)};
+        const response = await this.http.post(environment.urlPrefix + "/users/echo/", data);
+        console.log(response);
+    }
+
+    public async echoLogin(): Promise<void> {
+        const data = {data: Math.random().toString(36).substring(7)};
+        const response = await this.http.post(environment.urlPrefix + "/users/echo-login/", data);
+        console.log(response);
+    }
+
+    public async currentAutoupdate(): Promise<void> {
+        const response = await this.http.post(environment.urlPrefix + "/users/current-autoupdate/");
+        console.log(response);
+    }
+
+    public async currentAutoupdateLogin(): Promise<void> {
+        const response = await this.http.post(environment.urlPrefix + "/users/current-autoupdate-login/");
+        console.log(response);
     }
 
     /**

--- a/client/src/app/site/common/components/start/start.component.ts
+++ b/client/src/app/site/common/components/start/start.component.ts
@@ -110,6 +110,11 @@ export class StartComponent extends BaseViewComponent implements OnInit {
         console.log(response);
     }
 
+    public async simple_autoupdate_no_history(): Promise<void> {
+        const response = await this.http.post(environment.urlPrefix + "/users/simple-autoupdate-no-history/", true);
+        console.log(response);
+    }
+
     public async echo(): Promise<void> {
         const data = {data: Math.random().toString(36).substring(7)};
         const response = await this.http.post(environment.urlPrefix + "/users/echo/", data);

--- a/openslides/users/urls.py
+++ b/openslides/users/urls.py
@@ -11,8 +11,13 @@ urlpatterns = [
     url(r"^whoami/$", views.WhoAmIView.as_view(), name="user_whoami"),
     url(r"^setpassword/$", views.SetPasswordView.as_view(), name="user_setpassword"),
     url(r"^setpresence/$", views.SetPresenceView.as_view(), name="user_setpresence"),
+    url(r"^setpresence-no-autoupdate/$", views.SetPresenceNoAutoupdateView.as_view(), name="user_setpresence_no_autoupdate"),
+    url(r"^setpresence-only-autoupdate/$", views.SetPresenceOnlyAutoupdateView.as_view(), name="user_setpresence_only_autoupdate"),
+    url(r"^simple-autoupdate/$", views.SimpleAutoupdate.as_view(), name="user_simple_autoupdate"),
     url(r"^echo/$", csrf_exempt(views.Echo.as_view()), name="user_echo"),
     url(r"^echo-login/$", views.EchoLogin.as_view(), name="user_echo_login"),
+    url(r"^get-config/$", views.GetConfig.as_view(), name="user_get_config"),
+    url(r"^get-config-login/$", views.GetConfigLogin.as_view(), name="user_get_config_login"),
     url(r"^current-autoupdate/$", csrf_exempt(views.CurrentAutoupdate.as_view()), name="user_current_autoupdate"),
     url(r"^current-autoupdate-login/$", views.CurrentAutoupdateLogin.as_view(), name="user_current_autoupdate_login"),
     url(

--- a/openslides/users/urls.py
+++ b/openslides/users/urls.py
@@ -1,4 +1,5 @@
 from django.conf.urls import url
+from django.views.decorators.csrf import csrf_exempt
 
 from . import views
 
@@ -10,6 +11,10 @@ urlpatterns = [
     url(r"^whoami/$", views.WhoAmIView.as_view(), name="user_whoami"),
     url(r"^setpassword/$", views.SetPasswordView.as_view(), name="user_setpassword"),
     url(r"^setpresence/$", views.SetPresenceView.as_view(), name="user_setpresence"),
+    url(r"^echo/$", csrf_exempt(views.Echo.as_view()), name="user_echo"),
+    url(r"^echo-login/$", views.EchoLogin.as_view(), name="user_echo_login"),
+    url(r"^current-autoupdate/$", csrf_exempt(views.CurrentAutoupdate.as_view()), name="user_current_autoupdate"),
+    url(r"^current-autoupdate-login/$", views.CurrentAutoupdateLogin.as_view(), name="user_current_autoupdate_login"),
     url(
         r"^reset-password/$",
         views.PasswordResetView.as_view(),

--- a/openslides/users/urls.py
+++ b/openslides/users/urls.py
@@ -14,6 +14,7 @@ urlpatterns = [
     url(r"^setpresence-no-autoupdate/$", views.SetPresenceNoAutoupdateView.as_view(), name="user_setpresence_no_autoupdate"),
     url(r"^setpresence-only-autoupdate/$", views.SetPresenceOnlyAutoupdateView.as_view(), name="user_setpresence_only_autoupdate"),
     url(r"^simple-autoupdate/$", views.SimpleAutoupdate.as_view(), name="user_simple_autoupdate"),
+    url(r"^simple-autoupdate-no-history/$", views.SimpleAutoupdateNoHistory.as_view(), name="user_simple_autoupdate_no_history"),
     url(r"^echo/$", csrf_exempt(views.Echo.as_view()), name="user_echo"),
     url(r"^echo-login/$", views.EchoLogin.as_view(), name="user_echo_login"),
     url(r"^get-config/$", views.GetConfig.as_view(), name="user_get_config"),

--- a/openslides/users/views.py
+++ b/openslides/users/views.py
@@ -784,6 +784,21 @@ class SimpleAutoupdate(APIView):
         inform_elements(elements)
         return Response()
 
+class SimpleAutoupdateNoHistory(APIView):
+    http_method_names = ["post"]
+
+    def post(self, request, *args, **kwargs):
+        elements = [AutoupdateElement(
+            id=1,
+            collection_string="users/user",
+            disable_history=True,
+            information=[],
+            user_id=1,
+            no_delete_on_restriction=False,
+        )]
+        inform_elements(elements)
+        return Response()
+
 class Echo(APIView):
     http_method_names = ["post"]
 

--- a/openslides/utils/autoupdate.py
+++ b/openslides/utils/autoupdate.py
@@ -10,7 +10,8 @@ from mypy_extensions import TypedDict
 
 from .cache import element_cache, get_element_id
 from .projector import get_projector_data
-from .utils import get_model_from_collection_string, is_iterable, timeprint
+from .utils import get_model_from_collection_string, is_iterable
+from .timing import timeprint
 
 
 class AutoupdateElementBase(TypedDict):
@@ -75,7 +76,7 @@ class AutoupdateBundle:
         if not self.autoupdate_elements:
             return
 
-        a0 = time.time()
+        a = [time.time()]
 
         for collection, elements in self.autoupdate_elements.items():
             # Get all ids, that do not have a full_data key
@@ -94,18 +95,18 @@ class AutoupdateBundle:
                 for full_data in model_class.get_elements(ids):
                     elements[full_data["id"]]["full_data"] = full_data
 
-        a1 = time.time()
+        a.append(time.time())
 
         # Save histroy here using sync code.
         save_history(self.elements)
 
-        a2 = time.time()
+        a.append(time.time())
 
         # Update cache and send autoupdate using async code.
         async_to_sync(self.async_handle_collection_elements)()
 
-        a3 = time.time()
-        print("done(): 1:", a1-a0, "2:", a2-a1, "3:", a3-a2, "sum:", a3-a0)
+        a.append(time.time())
+        timeprint("done()", a)
 
     @property
     def elements(self) -> Iterable[AutoupdateElement]:

--- a/openslides/utils/autoupdate.py
+++ b/openslides/utils/autoupdate.py
@@ -1,4 +1,5 @@
 import threading
+import asyncio
 import time
 from collections import defaultdict
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
@@ -153,7 +154,9 @@ class AutoupdateBundle:
 
         a.append(time.time())
 
-        projector_data = await get_projector_data()
+        #projector_data = await get_projector_data()
+        projector_data = {}
+        await asyncio.sleep(0.01)
 
         a.append(time.time())
 

--- a/openslides/utils/cache.py
+++ b/openslides/utils/cache.py
@@ -18,7 +18,8 @@ from .cache_providers import (
 from .locking import locking
 from .redis import use_redis
 from .schema_version import SchemaVersion, schema_version_handler
-from .utils import get_element_id, split_element_id, timeprint
+from .utils import get_element_id, split_element_id
+from .timing import timeprint
 
 
 logger = logging.getLogger(__name__)

--- a/openslides/utils/cache_providers.py
+++ b/openslides/utils/cache_providers.py
@@ -8,7 +8,11 @@ from django.core.exceptions import ImproperlyConfigured
 from typing_extensions import Protocol
 
 from . import logging
-from .redis import read_only_redis_amount_replicas, use_redis
+from .redis import (
+    read_only_redis_amount_replicas,
+    read_only_redis_wait_timeout,
+    use_redis,
+)
 from .schema_version import SchemaVersion
 from .utils import split_element_id, str_dict_to_bytes
 
@@ -452,11 +456,11 @@ class RedisCacheProvider:
                     raise e
             if not read_only and read_only_redis_amount_replicas is not None:
                 reported_amount = await redis.wait(
-                    read_only_redis_amount_replicas, 1000
+                    read_only_redis_amount_replicas, read_only_redis_wait_timeout
                 )
                 if reported_amount != read_only_redis_amount_replicas:
                     logger.warn(
-                        f"WAIT reported {reported_amount} replicas of {read_only_redis_amount_replicas} requested!"
+                        f"WAIT reported {reported_amount} replicas of {read_only_redis_amount_replicas} requested after {read_only_redis_wait_timeout} ms!"
                     )
             return result
 

--- a/openslides/utils/consumers.py
+++ b/openslides/utils/consumers.py
@@ -203,7 +203,11 @@ class SiteConsumer(ProtocollAsyncJsonWebsocketConsumer):
         Send changed or deleted elements to the user.
         """
         change_id = event["change_id"]
+        a = time.time()
+        logger.debug(f"request for autoupdate ({self._id}) {change_id}")
         await self.send_autoupdate(change_id, max_change_id=change_id)
+        b = time.time()
+        logger.debug(f"request for autoupdate ({self._id}) done in {b-a:.5f}")
 
     async def projector_changed(self, event: Dict[str, Any]) -> None:
         """

--- a/openslides/utils/projector.py
+++ b/openslides/utils/projector.py
@@ -4,10 +4,12 @@ General projector code.
 Functions  that handel the registration of projector elements and the rendering
 of the data to present it on the projector.
 """
+import time
 
 from typing import Any, Awaitable, Callable, Dict, List
 
 from .cache import element_cache
+from .utils import timeprint
 
 
 AllData = Dict[str, Dict[int, Dict[str, Any]]]
@@ -64,11 +66,15 @@ async def get_projector_data(
         ],
     }
     """
+    a = [time.time()]
+
     if projector_ids is None:
         projector_ids = []
 
     all_data = await element_cache.get_all_data_dict()
     projector_data: Dict[int, List[Dict[str, Any]]] = {}
+
+    a.append(time.time())
 
     for projector_id, projector in all_data.get("core/projector", {}).items():
         if projector_ids and projector_id not in projector_ids:
@@ -88,6 +94,8 @@ async def get_projector_data(
                 data = {"error": str(err)}
             projector_data[projector_id].append({"data": data, "element": element})
 
+    a.append(time.time())
+    timeprint("projector", a)
     return projector_data
 
 

--- a/openslides/utils/projector.py
+++ b/openslides/utils/projector.py
@@ -9,7 +9,7 @@ import time
 from typing import Any, Awaitable, Callable, Dict, List
 
 from .cache import element_cache
-from .utils import timeprint
+from .timing import timeprint
 
 
 AllData = Dict[str, Dict[int, Dict[str, Any]]]

--- a/openslides/utils/redis.py
+++ b/openslides/utils/redis.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 use_redis = False
 use_read_only_redis = False
 read_only_redis_amount_replicas = None
+read_only_redis_wait_timeout = None
 
 try:
     import aioredis
@@ -35,6 +36,8 @@ else:
 
             read_only_redis_amount_replicas = getattr(settings, "AMOUNT_REPLICAS", 1)
             logger.info(f"AMOUNT_REPLICAS={read_only_redis_amount_replicas}")
+            read_only_redis_wait_timeout = getattr(settings, "WAIT_TIMEOUT", 1000)
+            logger.info(f"WAIT_TIMEOUT={read_only_redis_wait_timeout}")
     else:
         logger.info("Redis is not configured.")
 

--- a/openslides/utils/timing.py
+++ b/openslides/utils/timing.py
@@ -1,0 +1,10 @@
+from . import logging
+
+timelogger = logging.getLogger(__name__)
+
+def timeprint(name, times):
+    s = f"{name}: "
+    for i in range(1, len(times)):
+        s += f"{i}: {times[i]-times[i-1]:.5f} "
+    s += f"sum: {times[-1]-times[0]:.5f}"
+    timelogger.info(s)

--- a/openslides/utils/utils.py
+++ b/openslides/utils/utils.py
@@ -12,6 +12,14 @@ CAMEL_CASE_TO_PSEUDO_SNAKE_CASE_CONVERSION_REGEX_1 = re.compile("(.)([A-Z][a-z]+
 CAMEL_CASE_TO_PSEUDO_SNAKE_CASE_CONVERSION_REGEX_2 = re.compile("([a-z0-9])([A-Z])")
 
 
+def timeprint(name, times):
+    s = f"{name}: "
+    for i in range(1, len(times)):
+        s += f"{i}: {times[i]-times[i-1]:.5f} "
+    s += f"sum: {times[-1]-times[0]:.5f}"
+    print(s)
+
+
 def convert_camel_case_to_pseudo_snake_case(text: str) -> str:
     """
     Converts camel case to pseudo snake case using hyphen instead of

--- a/openslides/utils/utils.py
+++ b/openslides/utils/utils.py
@@ -7,17 +7,8 @@ import roman
 from django.apps import apps
 from django.db.models import Model
 
-
 CAMEL_CASE_TO_PSEUDO_SNAKE_CASE_CONVERSION_REGEX_1 = re.compile("(.)([A-Z][a-z]+)")
 CAMEL_CASE_TO_PSEUDO_SNAKE_CASE_CONVERSION_REGEX_2 = re.compile("([a-z0-9])([A-Z])")
-
-
-def timeprint(name, times):
-    s = f"{name}: "
-    for i in range(1, len(times)):
-        s += f"{i}: {times[i]-times[i-1]:.5f} "
-    s += f"sum: {times[-1]-times[0]:.5f}"
-    print(s)
 
 
 def convert_camel_case_to_pseudo_snake_case(text: str) -> str:


### PR DESCRIPTION
If autoupdates are too fast, the first one may not be fully executed. Especially when the maxChangeId is not yet updated, the second Autoupdate will trigger a refresh, because for the client it "lay in the future". This can be prevented by synchronizing the autoupdate-handling code with a mutex.
