### PR TITLE
Show assignment poll result table instad of chart

### DIFF
--- a/client/src/app/site/assignments/components/assignment-poll/assignment-poll.component.html
+++ b/client/src/app/site/assignments/components/assignment-poll/assignment-poll.component.html
@@ -56,15 +56,13 @@
             </div>
         </div>
 
-        <!-- Chart -->
-        <div *ngIf="poll.stateHasVotes">
+        <!-- Chart / Table -->
+        <div *ngIf="poll.stateHasVotes" class="poll-result-wrapper">
             <div *osPerms="'assignments.can_manage'; or: poll.isPublished">
-                <os-charts
-                    class="pointer"
+                <os-assignment-poll-detail-content
                     routerLink="/assignments/polls/{{ poll.id }}"
-                    [labels]="candidatesLabels"
-                    [data]="chartDataSubject | async"
-                ></os-charts>
+                    [poll]="poll"
+                ></os-assignment-poll-detail-content>
             </div>
 
             <!-- Cannot see unpublished -->

--- a/client/src/app/site/assignments/components/assignment-poll/assignment-poll.component.scss
+++ b/client/src/app/site/assignments/components/assignment-poll/assignment-poll.component.scss
@@ -11,6 +11,10 @@
         right: 0;
     }
 
+    .poll-result-wrapper {
+        cursor: pointer;
+    }
+
     .poll-detail-button-wrapper {
         display: flex;
         margin: auto 0;


### PR DESCRIPTION
Replaces the assignment result chart with the result table from the
detail view and projector