### PR TITLE
Autoupdate performance

### DIFF
--- a/SETTINGS.rst
+++ b/SETTINGS.rst
@@ -143,3 +143,7 @@ not affect the client.
 operator is in one of these groups, the client disconnected and reconnects again.
 All requests urls (including websockets) are now prefixed with `/prioritize`, so
 these requests from "prioritized clients" can be routed to different servers.
+
+`AUTOUPDATE_DELAY`: The delay to send autoupdates. This feature can be
+deactivated by setting it to `None`. It is deactivated per default. The Delay is
+given in seconds

--- a/client/src/app/core/core-services/autoupdate.service.ts
+++ b/client/src/app/core/core-services/autoupdate.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@angular/core';
 import { BaseModel } from '../../shared/models/base/base-model';
 import { CollectionStringMapperService } from './collection-string-mapper.service';
 import { DataStoreService, DataStoreUpdateManagerService } from './data-store.service';
+import { Mutex } from '../promises/mutex';
 import { WebsocketService, WEBSOCKET_ERROR_CODES } from './websocket.service';
 
 interface AutoupdateFormat {
@@ -45,6 +46,7 @@ interface AutoupdateFormat {
     providedIn: 'root'
 })
 export class AutoupdateService {
+    private mutex = new Mutex();
     /**
      * Constructor to create the AutoupdateService. Calls the constructor of the parent class.
      * @param websocketService
@@ -79,11 +81,13 @@ export class AutoupdateService {
      * Handles the change ids of all autoupdates.
      */
     private async storeResponse(autoupdate: AutoupdateFormat): Promise<void> {
+        const unlock = await this.mutex.lock();
         if (autoupdate.all_data) {
             await this.storeAllData(autoupdate);
         } else {
             await this.storePartialAutoupdate(autoupdate);
         }
+        unlock();
     }
 
     /**

--- a/client/src/app/core/core-services/autoupdate.service.ts
+++ b/client/src/app/core/core-services/autoupdate.service.ts
@@ -60,6 +60,7 @@ export function isAutoupdateFormat(obj: any): obj is AutoupdateFormat {
 })
 export class AutoupdateService {
     private mutex = new Mutex();
+
     /**
      * Constructor to create the AutoupdateService. Calls the constructor of the parent class.
      * @param websocketService
@@ -104,7 +105,7 @@ export class AutoupdateService {
     }
 
     /**
-     * Stores all data from the autoupdate. This means, that the DS is resettet and filled with just the
+     * Stores all data from the autoupdate. This means, that the DS is resetted and filled with just the
      * given data from the autoupdate.
      * @param autoupdate The autoupdate
      */
@@ -133,9 +134,10 @@ export class AutoupdateService {
 
         // Normal autoupdate
         if (autoupdate.from_change_id <= maxChangeId + 1 && autoupdate.to_change_id > maxChangeId) {
-            this.injectAutupdateIntoDS(autoupdate, true);
+            await this.injectAutupdateIntoDS(autoupdate, true);
         } else {
             // autoupdate fully in the future. we are missing something!
+            console.log('Autoupdate in the future', maxChangeId, autoupdate.from_change_id, autoupdate.to_change_id);
             this.requestChanges();
         }
     }
@@ -143,7 +145,7 @@ export class AutoupdateService {
     public async injectAutoupdateIgnoreChangeId(autoupdate: AutoupdateFormat): Promise<void> {
         const unlock = await this.mutex.lock();
         console.debug('inject autoupdate', autoupdate);
-        this.injectAutupdateIntoDS(autoupdate, false);
+        await this.injectAutupdateIntoDS(autoupdate, false);
         unlock();
     }
 

--- a/client/src/app/core/core-services/data-store.service.ts
+++ b/client/src/app/core/core-services/data-store.service.ts
@@ -258,6 +258,7 @@ export class DataStoreUpdateManagerService {
 
     private serveNextSlot(): void {
         if (this.updateSlotRequests.length > 0) {
+            console.log('Concurrent update slots');
             const request = this.updateSlotRequests.pop();
             request.resolve();
         }
@@ -664,5 +665,12 @@ export class DataStoreService {
         this._maxChangeId = changeId;
         await this.storageService.set(DataStoreService.cachePrefix + 'DS', this.jsonStore);
         await this.storageService.set(DataStoreService.cachePrefix + 'maxChangeId', changeId);
+    }
+
+    public print(): void {
+        console.log('Max change id', this.maxChangeId);
+        console.log('json storage');
+        console.log(JSON.stringify(this.jsonStore));
+        console.log(this.modelStore);
     }
 }

--- a/client/src/app/core/core-services/data-store.service.ts
+++ b/client/src/app/core/core-services/data-store.service.ts
@@ -258,7 +258,6 @@ export class DataStoreUpdateManagerService {
 
     private serveNextSlot(): void {
         if (this.updateSlotRequests.length > 0) {
-            console.warn('Concurrent update slots');
             const request = this.updateSlotRequests.pop();
             request.resolve();
         }

--- a/client/src/app/core/core-services/data-store.service.ts
+++ b/client/src/app/core/core-services/data-store.service.ts
@@ -258,6 +258,7 @@ export class DataStoreUpdateManagerService {
 
     private serveNextSlot(): void {
         if (this.updateSlotRequests.length > 0) {
+            console.warn('Concurrent update slots');
             const request = this.updateSlotRequests.pop();
             request.resolve();
         }

--- a/client/src/app/core/core-services/openslides.service.ts
+++ b/client/src/app/core/core-services/openslides.service.ts
@@ -130,10 +130,7 @@ export class OpenSlidesService {
      * Init DS from cache and after this start the websocket service.
      */
     private async setupDataStoreAndWebSocket(): Promise<void> {
-        let changeId = await this.DS.initFromStorage();
-        if (changeId > 0) {
-            changeId += 1;
-        }
+        const changeId = await this.DS.initFromStorage();
         // disconnect the WS connection, if there was one. This is needed
         // to update the connection parameters, namely the cookies. If the user
         // is changed, the WS needs to reconnect, so the new connection holds the new
@@ -141,7 +138,7 @@ export class OpenSlidesService {
         if (this.websocketService.isConnected) {
             await this.websocketService.close(); // Wait for the disconnect.
         }
-        await this.websocketService.connect({ changeId: changeId }); // Request changes after changeId.
+        await this.websocketService.connect(changeId); // Request changes after changeId.
     }
 
     /**

--- a/client/src/app/core/core-services/operator.service.ts
+++ b/client/src/app/core/core-services/operator.service.ts
@@ -456,7 +456,8 @@ export class OperatorService implements OnAfterAppsLoaded {
      * Set the operators presence to isPresent
      */
     public async setPresence(isPresent: boolean): Promise<void> {
-        await this.http.post(environment.urlPrefix + '/users/setpresence/', isPresent);
+        const r = await this.http.post(environment.urlPrefix + '/users/setpresence/', isPresent);
+        console.log('operator', r);
     }
 
     /**

--- a/client/src/app/core/core-services/operator.service.ts
+++ b/client/src/app/core/core-services/operator.service.ts
@@ -456,8 +456,7 @@ export class OperatorService implements OnAfterAppsLoaded {
      * Set the operators presence to isPresent
      */
     public async setPresence(isPresent: boolean): Promise<void> {
-        const r = await this.http.post(environment.urlPrefix + '/users/setpresence/', isPresent);
-        console.log('operator', r);
+        await this.http.post(environment.urlPrefix + '/users/setpresence/', isPresent);
     }
 
     /**

--- a/client/src/app/core/core-services/prioritize.service.ts
+++ b/client/src/app/core/core-services/prioritize.service.ts
@@ -40,7 +40,7 @@ export class PrioritizeService {
         if (this.openSlidesStatusService.isPrioritizedClient !== opPrioritized) {
             console.log('Alter prioritization:', opPrioritized);
             this.openSlidesStatusService.isPrioritizedClient = opPrioritized;
-            this.websocketService.reconnect({ changeId: this.DS.maxChangeId });
+            this.websocketService.reconnect(this.DS.maxChangeId);
         }
     }
 }

--- a/client/src/app/core/core-services/websocket.service.ts
+++ b/client/src/app/core/core-services/websocket.service.ts
@@ -55,14 +55,6 @@ export const WEBSOCKET_ERROR_CODES = {
     WRONG_FORMAT: 102
 };
 
-/*
- * Options for (re-)connecting.
- */
-interface ConnectOptions {
-    changeId?: number;
-    enableAutoupdates?: boolean;
-}
-
 /**
  * Service that handles WebSocket connections. Other services can register themselfs
  * with {@method getOberservable} for a specific type of messages. The content will be published.
@@ -207,7 +199,7 @@ export class WebsocketService {
      *
      * Uses NgZone to let all callbacks run in the angular context.
      */
-    public async connect(options: ConnectOptions = {}, retry: boolean = false): Promise<void> {
+    public async connect(changeId: number | null = null, retry: boolean = false): Promise<void> {
         const websocketId = Math.random().toString(36).substring(7);
         this.websocketId = websocketId;
 
@@ -220,17 +212,10 @@ export class WebsocketService {
             this.shouldBeClosed = false;
         }
 
-        // set defaults
-        options = Object.assign(options, {
-            enableAutoupdates: true
-        });
+        const queryParams: QueryParams = {};
 
-        const queryParams: QueryParams = {
-            autoupdate: options.enableAutoupdates
-        };
-
-        if (options.changeId !== undefined) {
-            queryParams.change_id = options.changeId;
+        if (changeId !== null) {
+            queryParams.change_id = changeId;
         }
 
         // Create the websocket
@@ -398,7 +383,7 @@ export class WebsocketService {
             const timeout = Math.floor(Math.random() * 3000 + 2000);
             this.retryTimeout = setTimeout(() => {
                 this.retryTimeout = null;
-                this.connect({ enableAutoupdates: true }, true);
+                this.connect(null, true);
             }, timeout);
         }
     }
@@ -438,9 +423,9 @@ export class WebsocketService {
      *
      * @param options The options for the new connection
      */
-    public async reconnect(options: ConnectOptions = {}): Promise<void> {
+    public async reconnect(changeId: number | null = null): Promise<void> {
         await this.close();
-        await this.connect(options);
+        await this.connect(changeId);
     }
 
     /**

--- a/client/src/app/core/promises/mutex.ts
+++ b/client/src/app/core/promises/mutex.ts
@@ -1,0 +1,30 @@
+/**
+ * A mutex as described in every textbook
+ *
+ * Usage:
+ * ```
+ * mutex = new Mutex(); // create e.g. as class member
+ *
+ * // Somewhere in the code to lock (must be async code!)
+ * const unlock = await this.mutex.lock()
+ * // ...the code to synchronize
+ * unlock()
+ * ```
+ */
+export class Mutex {
+    private mutex = Promise.resolve();
+
+    public lock(): PromiseLike<() => void> {
+        // this will capture the code-to-synchronize
+        let begin: (unlock: () => void) => void = () => {};
+
+        // All "requests" to execute code are chained in a promise-chain
+        this.mutex = this.mutex.then(() => {
+            return new Promise(begin);
+        });
+
+        return new Promise(res => {
+            begin = res;
+        });
+    }
+}

--- a/client/src/app/site/common/components/legal-notice/legal-notice.component.html
+++ b/client/src/app/site/common/components/legal-notice/legal-notice.component.html
@@ -32,6 +32,26 @@
             <span>{{ 'Check for updates' | translate }}</span>
         </button>
     </div>
+
+    <div>
+        <button type="button" mat-button (click)="showDevTools=!showDevTools">
+            <span>{{ 'Show devtools' | translate }}</span>
+        </button>
+    </div>
+
+    <mat-card class="os-card" *ngIf="showDevTools">
+        <div>
+            <button type="button" mat-button (click)="printDS()">
+                <span>Print DS</span>
+            </button>
+        </div>
+
+        <div>
+            <button type="button" mat-button (click)="getThisComponent()">
+                <span>Get this component</span>
+            </button>
+        </div>
+    </mat-card>
 </mat-card>
 
 <mat-card class="os-card" *osPerms="'users.can_manage'">

--- a/client/src/app/site/common/components/legal-notice/legal-notice.component.ts
+++ b/client/src/app/site/common/components/legal-notice/legal-notice.component.ts
@@ -4,6 +4,7 @@ import { Title } from '@angular/platform-browser';
 
 import { TranslateService } from '@ngx-translate/core';
 
+import { DataStoreService } from 'app/core/core-services/data-store.service';
 import { OpenSlidesService } from 'app/core/core-services/openslides.service';
 import { OperatorService, Permission } from 'app/core/core-services/operator.service';
 import { ConfigRepositoryService } from 'app/core/repositories/config/config-repository.service';
@@ -25,6 +26,8 @@ export class LegalNoticeComponent extends BaseViewComponent implements OnInit {
      */
     public legalNotice = '';
 
+    public showDevTools = false;
+
     /**
      * Constructor.
      */
@@ -35,7 +38,8 @@ export class LegalNoticeComponent extends BaseViewComponent implements OnInit {
         private openSlidesService: OpenSlidesService,
         private update: UpdateService,
         private configRepo: ConfigRepositoryService,
-        private operator: OperatorService
+        private operator: OperatorService,
+        private DS: DataStoreService
     ) {
         super(title, translate, matSnackbar);
     }
@@ -66,5 +70,13 @@ export class LegalNoticeComponent extends BaseViewComponent implements OnInit {
      */
     public canManage(): boolean {
         return this.operator.hasPerms(Permission.coreCanManageConfig);
+    }
+
+    public printDS(): void {
+        this.DS.print();
+    }
+
+    public getThisComponent(): void {
+        console.log(this);
     }
 }

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.ts
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.ts
@@ -554,7 +554,7 @@ export class MotionDetailComponent extends BaseViewComponent implements OnInit, 
             this.motionFilterService.initFilters(this.motionObserver);
             this.motionSortService.initSorting(this.motionFilterService.outputObservable);
             this.sortedMotionsObservable = this.motionSortService.outputObservable;
-        } else if (this.motion.parent_id) {
+        } else if (this.motion && this.motion.parent_id) {
             // only use the amendments for this motion
             this.amendmentFilterService.initFilters(this.repo.amendmentsTo(this.motion.parent_id));
             this.amendmentSortService.initSorting(this.amendmentFilterService.outputObservable);

--- a/client/src/app/site/polls/components/poll-progress/poll-progress.component.html
+++ b/client/src/app/site/polls/components/poll-progress/poll-progress.component.html
@@ -1,6 +1,6 @@
 <div *ngIf="poll" class="poll-progress-wrapper">
     <div class="vote-number">
-        <span>{{ poll.votescast }} / {{ max }}</span>
+        <span>{{ votescast }} / {{ max }}</span>
     </div>
 
     <span>{{ 'Received votes' | translate }}</span>

--- a/client/src/app/site/polls/components/poll-progress/poll-progress.component.ts
+++ b/client/src/app/site/polls/components/poll-progress/poll-progress.component.ts
@@ -1,58 +1,98 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Title } from '@angular/platform-browser';
 
 import { TranslateService } from '@ngx-translate/core';
-import { map } from 'rxjs/operators';
+import { Subscription } from 'rxjs';
 
+import { MotionPollRepositoryService } from 'app/core/repositories/motions/motion-poll-repository.service';
 import { UserRepositoryService } from 'app/core/repositories/users/user-repository.service';
 import { BaseViewComponent } from 'app/site/base/base-view';
 import { ViewBasePoll } from 'app/site/polls/models/view-base-poll';
+import { ViewUser } from 'app/site/users/models/view-user';
 
 @Component({
     selector: 'os-poll-progress',
     templateUrl: './poll-progress.component.html',
     styleUrls: ['./poll-progress.component.scss']
 })
-export class PollProgressComponent extends BaseViewComponent implements OnInit {
-    @Input()
-    public poll: ViewBasePoll;
+export class PollProgressComponent extends BaseViewComponent {
+    private pollId: number = null;
+    private pollSubscription: Subscription = null;
 
+    @Input()
+    public set poll(value: ViewBasePoll) {
+        if (value.id !== this.pollId) {
+            this.pollId = value.id;
+
+            if (this.pollSubscription !== null) {
+                this.pollSubscription.unsubscribe();
+                this.pollSubscription = null;
+            }
+
+            this.pollSubscription = this.pollRepo.getViewModelObservable(this.pollId).subscribe(poll => {
+                if (poll) {
+                    this._poll = poll;
+
+                    // We may cannot use this.poll.votescast during the voting, since it can
+                    // be reported with false values from the server
+                    // -> calculate the votes on our own.
+                    const ids = new Set();
+                    for (const option of this.poll.options) {
+                        for (const vote of option.votes) {
+                            if (vote.user_id) {
+                                ids.add(vote.user_id);
+                            }
+                        }
+                    }
+                    this.votescast = ids.size;
+
+                    // But sometimes there are not enough votes (poll.votescast is higher).
+                    // If this happens, take the value from the poll
+                    if (this.poll.votescast > this.votescast) {
+                        this.votescast = this.poll.votescast;
+                    }
+
+                    this.calculateMaxUsers();
+                }
+            });
+        }
+    }
+    public get poll(): ViewBasePoll {
+        return this._poll;
+    }
+    private _poll: ViewBasePoll;
+
+    public votescast: number;
     public max: number;
+    public valueInPercent: number;
 
     public constructor(
         title: Title,
         protected translate: TranslateService,
         snackbar: MatSnackBar,
-        private userRepo: UserRepositoryService
+        private userRepo: UserRepositoryService,
+        private pollRepo: MotionPollRepositoryService
     ) {
         super(title, translate, snackbar);
+        this.userRepo.getViewModelListObservable().subscribe(users => {
+            if (users) {
+                this.calculateMaxUsers(users);
+            }
+        });
     }
 
-    public get valueInPercent(): number {
-        if (this.poll) {
-            return (this.poll.votesvalid / this.max) * 100;
-        } else {
-            return 0;
+    private calculateMaxUsers(allUsers?: ViewUser[]): void {
+        if (!this.poll) {
+            return;
         }
-    }
+        if (!allUsers) {
+            allUsers = this.userRepo.getViewModelList();
+        }
 
-    /**
-     * OnInit.
-     * Sets the observable for groups.
-     */
-    public ngOnInit(): void {
-        if (this.poll) {
-            this.userRepo
-                .getViewModelListObservable()
-                .pipe(
-                    map(users =>
-                        users.filter(user => user.is_present && this.poll.groups_id.intersect(user.groups_id).length)
-                    )
-                )
-                .subscribe(users => {
-                    this.max = users.length;
-                });
-        }
+        allUsers = allUsers.filter(user => user.is_present && this.poll.groups_id.intersect(user.groups_id).length);
+
+        this.max = allUsers.length;
+        this.valueInPercent = this.poll ? (this.votescast / this.max) * 100 : 0;
     }
 }

--- a/openslides/core/apps.py
+++ b/openslides/core/apps.py
@@ -34,16 +34,10 @@ class CoreAppConfig(AppConfig):
             ProjectionDefaultViewSet,
             TagViewSet,
         )
-        from .websocket import (
-            NotifyWebsocketClientMessage,
-            ConstantsWebsocketClientMessage,
-            GetElementsWebsocketClientMessage,
-            AutoupdateWebsocketClientMessage,
-            ListenToProjectors,
-            PingPong,
-        )
         from ..utils.rest_api import router
-        from ..utils.websocket import register_client_message
+
+        # Let all client websocket message register
+        from ..utils import websocket_client_messages  # noqa
 
         # Collect all config variables before getting the constants.
         config.collect_config_variables_from_apps()
@@ -91,14 +85,6 @@ class CoreAppConfig(AppConfig):
         router.register(
             self.get_model("Countdown").get_collection_string(), CountdownViewSet
         )
-
-        # Register client messages
-        register_client_message(NotifyWebsocketClientMessage())
-        register_client_message(ConstantsWebsocketClientMessage())
-        register_client_message(GetElementsWebsocketClientMessage())
-        register_client_message(AutoupdateWebsocketClientMessage())
-        register_client_message(ListenToProjectors())
-        register_client_message(PingPong())
 
         if "runserver" in sys.argv or "changeconfig" in sys.argv:
             from openslides.utils.startup import run_startup_hooks

--- a/openslides/core/projector.py
+++ b/openslides/core/projector.py
@@ -1,20 +1,17 @@
 from typing import Any, Dict
 
 from ..utils.projector import (
-    AllData,
-    ProjectorElementException,
+    ProjectorAllDataProvider,
     get_config,
+    get_model,
     register_projector_slide,
 )
 
 
-# Important: All functions have to be prune. This means, that thay can only
-#            access the data, that they get as argument and do not have any
-#            side effects.
-
-
 async def countdown_slide(
-    all_data: AllData, element: Dict[str, Any], projector_id: int
+    all_data_provider: ProjectorAllDataProvider,
+    element: Dict[str, Any],
+    projector_id: int,
 ) -> Dict[str, Any]:
     """
     Countdown slide.
@@ -26,23 +23,21 @@ async def countdown_slide(
         id: 5,  # Countdown ID
     }
     """
-    countdown_id = element.get("id") or 1
-
-    try:
-        countdown = all_data["core/countdown"][countdown_id]
-    except KeyError:
-        raise ProjectorElementException(f"Countdown {countdown_id} does not exist")
-
+    countdown = await get_model(all_data_provider, "core/countdown", element.get("id"))
     return {
         "description": countdown["description"],
         "running": countdown["running"],
         "countdown_time": countdown["countdown_time"],
-        "warning_time": await get_config(all_data, "agenda_countdown_warning_time"),
+        "warning_time": await get_config(
+            all_data_provider, "agenda_countdown_warning_time"
+        ),
     }
 
 
 async def message_slide(
-    all_data: AllData, element: Dict[str, Any], projector_id: int
+    all_data_provider: ProjectorAllDataProvider,
+    element: Dict[str, Any],
+    projector_id: int,
 ) -> Dict[str, Any]:
     """
     Message slide.
@@ -54,16 +49,15 @@ async def message_slide(
         id: 5,  # ProjectorMessage ID
     }
     """
-    message_id = element.get("id") or 1
-
-    try:
-        return all_data["core/projector-message"][message_id]
-    except KeyError:
-        raise ProjectorElementException(f"Message {message_id} does not exist")
+    return await get_model(
+        all_data_provider, "core/projector-message", element.get("id")
+    )
 
 
 async def clock_slide(
-    all_data: AllData, element: Dict[str, Any], projector_id: int
+    all_data_provider: ProjectorAllDataProvider,
+    element: Dict[str, Any],
+    projector_id: int,
 ) -> Dict[str, Any]:
     return {}
 

--- a/openslides/mediafiles/projector.py
+++ b/openslides/mediafiles/projector.py
@@ -1,35 +1,23 @@
 from typing import Any, Dict
 
 from ..utils.projector import (
-    AllData,
-    ProjectorElementException,
+    ProjectorAllDataProvider,
+    get_model,
     register_projector_slide,
 )
 
 
-# Important: All functions have to be prune. This means, that thay can only
-#            access the data, that they get as argument and do not have any
-#            side effects.
-
-
 async def mediafile_slide(
-    all_data: AllData, element: Dict[str, Any], projector_id: int
+    all_data_provider: ProjectorAllDataProvider,
+    element: Dict[str, Any],
+    projector_id: int,
 ) -> Dict[str, Any]:
     """
     Slide for Mediafile.
     """
-    mediafile_id = element.get("id")
-
-    if mediafile_id is None:
-        raise ProjectorElementException("id is required for mediafile slide")
-
-    try:
-        mediafile = all_data["mediafiles/mediafile"][mediafile_id]
-    except KeyError:
-        raise ProjectorElementException(
-            f"mediafile with id {mediafile_id} does not exist"
-        )
-
+    mediafile = await get_model(
+        all_data_provider, "mediafiles/mediafile", element.get("id")
+    )
     return {
         "path": mediafile["path"],
         "mimetype": mediafile["mimetype"],

--- a/openslides/poll/views.py
+++ b/openslides/poll/views.py
@@ -156,9 +156,11 @@ class BasePollViewSet(ModelViewSet):
 
         poll.state = BasePoll.STATE_PUBLISHED
         poll.save()
-        inform_changed_data(vote.user for vote in poll.get_votes().all() if vote.user)
-        inform_changed_data(poll.get_votes())
-        inform_changed_data(poll.get_options())
+        inform_changed_data(
+            (vote.user for vote in poll.get_votes().all() if vote.user), final_data=True
+        )
+        inform_changed_data(poll.get_votes(), final_data=True)
+        inform_changed_data(poll.get_options(), final_data=True)
         return Response()
 
     @detail_route(methods=["POST"])

--- a/openslides/topics/projector.py
+++ b/openslides/topics/projector.py
@@ -1,19 +1,16 @@
 from typing import Any, Dict
 
 from ..utils.projector import (
-    AllData,
-    ProjectorElementException,
+    ProjectorAllDataProvider,
+    get_model,
     register_projector_slide,
 )
 
 
-# Important: All functions have to be prune. This means, that thay can only
-#            access the data, that they get as argument and do not have any
-#            side effects.
-
-
 async def topic_slide(
-    all_data: AllData, element: Dict[str, Any], projector_id: int
+    all_data_provider: ProjectorAllDataProvider,
+    element: Dict[str, Any],
+    projector_id: int,
 ) -> Dict[str, Any]:
     """
     Topic slide.
@@ -22,22 +19,8 @@ async def topic_slide(
     * title
     * text
     """
-    topic_id = element.get("id")
-
-    if topic_id is None:
-        raise ProjectorElementException("id is required for topic slide")
-
-    try:
-        topic = all_data["topics/topic"][topic_id]
-    except KeyError:
-        raise ProjectorElementException(f"topic with id {topic_id} does not exist")
-
-    item_id = topic["agenda_item_id"]
-    try:
-        item = all_data["agenda/item"][item_id]
-    except KeyError:
-        raise ProjectorElementException(f"item with id {item_id} does not exist")
-
+    topic = await get_model(all_data_provider, "topics/topic", element.get("id"))
+    item = await get_model(all_data_provider, "agenda/item", topic["agenda_item_id"])
     return {
         "title": topic["title"],
         "text": topic["text"],

--- a/openslides/users/projector.py
+++ b/openslides/users/projector.py
@@ -1,19 +1,16 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from ..utils.projector import (
-    AllData,
-    ProjectorElementException,
+    ProjectorAllDataProvider,
+    get_model,
     register_projector_slide,
 )
 
 
-# Important: All functions have to be prune. This means, that thay can only
-#            access the data, that they get as argument and do not have any
-#            side effects.
-
-
 async def user_slide(
-    all_data: AllData, element: Dict[str, Any], projector_id: int
+    all_data_provider: ProjectorAllDataProvider,
+    element: Dict[str, Any],
+    projector_id: int,
 ) -> Dict[str, Any]:
     """
     User slide.
@@ -21,22 +18,16 @@ async def user_slide(
     The returned dict can contain the following fields:
     * user
     """
-    user_id = element.get("id")
-
-    if user_id is None:
-        raise ProjectorElementException("id is required for user slide")
-
-    return {"user": await get_user_name(all_data, user_id)}
+    return {"user": await get_user_name(all_data_provider, element.get("id"))}
 
 
-async def get_user_name(all_data: AllData, user_id: int) -> str:
+async def get_user_name(
+    all_data_provider: ProjectorAllDataProvider, user_id: Optional[int]
+) -> str:
     """
     Returns the short name for an user_id.
     """
-    try:
-        user = all_data["users/user"][user_id]
-    except KeyError:
-        raise ProjectorElementException(f"user with id {user_id} does not exist")
+    user = await get_model(all_data_provider, "users/user", user_id)
 
     name_parts: List[str] = []
     for name_part in ("title", "first_name", "last_name"):

--- a/openslides/utils/autoupdate.py
+++ b/openslides/utils/autoupdate.py
@@ -92,13 +92,13 @@ class AutoupdateBundle:
                     elements[full_data["id"]]["full_data"] = full_data
 
         # Save histroy here using sync code.
-        save_history(self.elements)
+        save_history(self.element_iterator)
 
         # Update cache and send autoupdate using async code.
         async_to_sync(self.async_handle_collection_elements)()
 
     @property
-    def elements(self) -> Iterable[AutoupdateElement]:
+    def element_iterator(self) -> Iterable[AutoupdateElement]:
         """ Iterator for all elements in this bundle """
         for elements in self.autoupdate_elements.values():
             yield from elements.values()
@@ -110,7 +110,7 @@ class AutoupdateBundle:
         Returns the change_id
         """
         cache_elements: Dict[str, Optional[Dict[str, Any]]] = {}
-        for element in self.elements:
+        for element in self.element_iterator:
             element_id = get_element_id(element["collection_string"], element["id"])
             full_data = element.get("full_data")
             if full_data:
@@ -253,7 +253,7 @@ class AutoupdateBundleMiddleware:
         return response
 
 
-def save_history(elements: Iterable[AutoupdateElement]) -> Iterable:
+def save_history(element_iterator: Iterable[AutoupdateElement]) -> Iterable:
     """
     Thin wrapper around the call of history saving manager method.
 
@@ -261,4 +261,4 @@ def save_history(elements: Iterable[AutoupdateElement]) -> Iterable:
     """
     from ..core.models import History
 
-    return History.objects.add_elements(elements)
+    return History.objects.add_elements(element_iterator)

--- a/openslides/utils/cache.py
+++ b/openslides/utils/cache.py
@@ -254,25 +254,6 @@ class ElementCache:
                 all_data[collection] = await restricter(user_id, all_data[collection])
         return dict(all_data)
 
-    async def get_all_data_dict(self) -> Dict[str, Dict[int, Dict[str, Any]]]:
-        """
-        Returns all data with a dict (id <-> element) per collection:
-        {
-            <collection>: {
-                <id>: <element>
-            }
-        }
-        """
-        all_data: Dict[str, Dict[int, Dict[str, Any]]] = defaultdict(dict)
-        for element_id, data in (await self.cache_provider.get_all_data()).items():
-            collection, id = split_element_id(element_id)
-            element = json.loads(data.decode())
-            element.pop(
-                "_no_delete_on_restriction", False
-            )  # remove special field for get_data_since
-            all_data[collection][id] = element
-        return dict(all_data)
-
     async def get_collection_data(self, collection: str) -> Dict[int, Dict[str, Any]]:
         """
         Returns the data for one collection as dict: {id: <element>}

--- a/openslides/utils/cache_providers.py
+++ b/openslides/utils/cache_providers.py
@@ -8,7 +8,11 @@ from django.core.exceptions import ImproperlyConfigured
 from typing_extensions import Protocol
 
 from . import logging
-from .redis import read_only_redis_amount_replicas, use_redis
+from .redis import (
+    read_only_redis_amount_replicas,
+    read_only_redis_wait_timeout,
+    use_redis,
+)
 from .schema_version import SchemaVersion
 from .utils import split_element_id, str_dict_to_bytes
 
@@ -452,11 +456,11 @@ class RedisCacheProvider:
                     raise e
             if not read_only and read_only_redis_amount_replicas is not None:
                 reported_amount = await redis.wait(
-                    read_only_redis_amount_replicas, 1000
+                    read_only_redis_amount_replicas, read_only_redis_wait_timeout
                 )
                 if reported_amount != read_only_redis_amount_replicas:
                     logger.warn(
-                        f"WAIT reported {reported_amount} replicas of {read_only_redis_amount_replicas} requested!"
+                        f"WAIT reported {reported_amount} replicas of {read_only_redis_amount_replicas} requested after {read_only_redis_wait_timeout} ms!"
                     )
             return result
 

--- a/openslides/utils/cache_providers.py
+++ b/openslides/utils/cache_providers.py
@@ -460,7 +460,8 @@ class RedisCacheProvider:
                 )
                 if reported_amount != read_only_redis_amount_replicas:
                     logger.warn(
-                        f"WAIT reported {reported_amount} replicas of {read_only_redis_amount_replicas} requested after {read_only_redis_wait_timeout} ms!"
+                        f"WAIT reported {reported_amount} replicas of {read_only_redis_amount_replicas} "
+                        + f"requested after {read_only_redis_wait_timeout} ms!"
                     )
             return result
 

--- a/openslides/utils/cache_providers.py
+++ b/openslides/utils/cache_providers.py
@@ -261,7 +261,7 @@ class RedisCacheProvider:
 
     async def add_to_full_data(self, data: Dict[str, str]) -> None:
         async with get_connection() as redis:
-            redis.hmset_dict(self.full_data_cache_key, data)
+            await redis.hmset_dict(self.full_data_cache_key, data)
 
     async def data_exists(self) -> bool:
         """

--- a/openslides/utils/consumer_autoupdate_strategy.py
+++ b/openslides/utils/consumer_autoupdate_strategy.py
@@ -1,0 +1,99 @@
+import asyncio
+from asyncio import Task
+from typing import Optional, cast
+
+from django.conf import settings
+
+from .autoupdate import get_autoupdate_data
+from .cache import element_cache
+from .websocket import ChangeIdTooHighException, ProtocollAsyncJsonWebsocketConsumer
+
+
+AUTOUPDATE_DELAY = getattr(settings, "AUTOUPDATE_DELAY", None)
+
+
+class ConsumerAutoupdateStrategy:
+    def __init__(self, consumer: ProtocollAsyncJsonWebsocketConsumer) -> None:
+        self.consumer = consumer
+        # client_change_id = None: unknown -> set on first autoupdate or request_change_id
+        # client_change_id is int: the one
+        self.client_change_id: Optional[int] = None
+        self.max_seen_change_id = 0
+        self.next_send_time = None
+        self.timer_task_handle: Optional[Task[None]] = None
+        self.lock = asyncio.Lock()
+
+    async def request_change_id(
+        self, change_id: int, in_response: Optional[str] = None
+    ) -> None:
+        # This resets the server side tracking of the client's change id.
+        async with self.lock:
+            await self.stop_timer()
+
+            self.max_seen_change_id = await element_cache.get_current_change_id()
+            self.client_change_id = change_id
+
+            if self.client_change_id == self.max_seen_change_id:
+                # The client is up-to-date, so nothing will be done
+                return None
+
+            if self.client_change_id > self.max_seen_change_id:
+                message = (
+                    f"Requested change_id {self.client_change_id} is higher than the "
+                    + f"highest change_id {self.max_seen_change_id}."
+                )
+                raise ChangeIdTooHighException(message, in_response=in_response)
+
+            await self.send_autoupdate(in_response=in_response)
+
+    async def new_change_id(self, change_id: int) -> None:
+        async with self.lock:
+            if self.client_change_id is None:
+                self.client_change_id = change_id
+            if change_id > self.max_seen_change_id:
+                self.max_seen_change_id = change_id
+
+            if AUTOUPDATE_DELAY is None:  # feature deactivated, send directly
+                await self.send_autoupdate()
+            elif self.timer_task_handle is None:
+                await self.start_timer()
+
+    async def get_running_loop(self) -> asyncio.AbstractEventLoop:
+        if hasattr(asyncio, "get_running_loop"):
+            return asyncio.get_running_loop()  # type: ignore
+        else:
+            return asyncio.get_event_loop()
+
+    async def start_timer(self) -> None:
+        loop = await self.get_running_loop()
+        self.timer_task_handle = loop.create_task(self.timer_task())
+
+    async def stop_timer(self) -> None:
+        if self.timer_task_handle is not None:
+            self.timer_task_handle.cancel()
+        self.timer_task_handle = None
+
+    async def timer_task(self) -> None:
+        try:
+            await asyncio.sleep(AUTOUPDATE_DELAY)
+        except asyncio.CancelledError:
+            return
+
+        async with self.lock:
+            await self.send_autoupdate()
+            self.timer_task_handle = None
+
+    async def send_autoupdate(self, in_response: Optional[str] = None) -> None:
+        max_change_id = (
+            self.max_seen_change_id
+        )  # important to save this variable, because
+        # it can change during runtime.
+        autoupdate = await get_autoupdate_data(
+            cast(int, self.client_change_id), max_change_id, self.consumer.user_id
+        )
+        if autoupdate is not None:
+            # It will be send, so we can set the client_change_id
+            self.client_change_id = max_change_id
+            await self.consumer.send_json(
+                type="autoupdate", content=autoupdate, in_response=in_response,
+            )

--- a/openslides/utils/consumer_autoupdate_strategy.py
+++ b/openslides/utils/consumer_autoupdate_strategy.py
@@ -16,7 +16,8 @@ class ConsumerAutoupdateStrategy:
     def __init__(self, consumer: ProtocollAsyncJsonWebsocketConsumer) -> None:
         self.consumer = consumer
         # client_change_id = None: unknown -> set on first autoupdate or request_change_id
-        # client_change_id is int: the one
+        # client_change_id is int: the change_id, the client knows about, so the next
+        # update must be from client_change_id+1 .. <next clange_id>
         self.client_change_id: Optional[int] = None
         self.max_seen_change_id = 0
         self.next_send_time = None
@@ -26,11 +27,16 @@ class ConsumerAutoupdateStrategy:
     async def request_change_id(
         self, change_id: int, in_response: Optional[str] = None
     ) -> None:
+        """
+        The change id is not inclusive, so the client is on change_id and wants
+        data from change_id+1 .. now
+        """
         # This resets the server side tracking of the client's change id.
         async with self.lock:
             await self.stop_timer()
 
             self.max_seen_change_id = await element_cache.get_current_change_id()
+            print(self.max_seen_change_id)
             self.client_change_id = change_id
 
             if self.client_change_id == self.max_seen_change_id:
@@ -49,7 +55,9 @@ class ConsumerAutoupdateStrategy:
     async def new_change_id(self, change_id: int) -> None:
         async with self.lock:
             if self.client_change_id is None:
-                self.client_change_id = change_id
+                # The -1 is to send this autoupdate as the first one to he client.
+                # Remember: the client_change_id is the change_id the client knows about
+                self.client_change_id = change_id - 1
             if change_id > self.max_seen_change_id:
                 self.max_seen_change_id = change_id
 
@@ -84,12 +92,13 @@ class ConsumerAutoupdateStrategy:
             self.timer_task_handle = None
 
     async def send_autoupdate(self, in_response: Optional[str] = None) -> None:
-        max_change_id = (
-            self.max_seen_change_id
-        )  # important to save this variable, because
-        # it can change during runtime.
+        # it is important to save this variable, because it can change during runtime.
+        max_change_id = self.max_seen_change_id
+        # here, 1 is added to the change_id, because the client_change_id is the id the client
+        # *knows* about -> the client needs client_change_id+1 since get_autoupdate_data is
+        # inclusive [change_id .. max_change_id].
         autoupdate = await get_autoupdate_data(
-            cast(int, self.client_change_id), max_change_id, self.consumer.user_id
+            cast(int, self.client_change_id) + 1, max_change_id, self.consumer.user_id
         )
         if autoupdate is not None:
             # It will be send, so we can set the client_change_id

--- a/openslides/utils/consumers.py
+++ b/openslides/utils/consumers.py
@@ -1,31 +1,18 @@
 import time
-from collections import defaultdict
 from typing import Any, Dict, List, Optional, cast
 from urllib.parse import parse_qs
 
 from channels.generic.websocket import AsyncWebsocketConsumer
-from mypy_extensions import TypedDict
 
-from ..utils.websocket import WEBSOCKET_CHANGE_ID_TOO_HIGH
 from . import logging
 from .auth import UserDoesNotExist, async_anonymous_is_enabled
-from .cache import ChangeIdTooLowError, element_cache, split_element_id
+from .cache import element_cache
+from .consumer_autoupdate_strategy import ConsumerAutoupdateStrategy
 from .utils import get_worker_id
-from .websocket import ProtocollAsyncJsonWebsocketConsumer
+from .websocket import BaseWebsocketException, ProtocollAsyncJsonWebsocketConsumer
 
 
 logger = logging.getLogger("openslides.websocket")
-
-AutoupdateFormat = TypedDict(
-    "AutoupdateFormat",
-    {
-        "changed": Dict[str, List[Dict[str, Any]]],
-        "deleted": Dict[str, List[int]],
-        "from_change_id": int,
-        "to_change_id": int,
-        "all_data": bool,
-    },
-)
 
 
 class SiteConsumer(ProtocollAsyncJsonWebsocketConsumer):
@@ -40,12 +27,11 @@ class SiteConsumer(ProtocollAsyncJsonWebsocketConsumer):
     ID counter for assigning each instance of this class an unique id.
     """
 
-    skipped_autoupdate_from_change_id: Optional[int] = None
-
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.projector_hash: Dict[int, int] = {}
         SiteConsumer.ID_COUNTER += 1
         self._id = get_worker_id() + "-" + str(SiteConsumer.ID_COUNTER)
+        self.autoupdate_strategy = ConsumerAutoupdateStrategy(self)
         super().__init__(*args, **kwargs)
 
     async def connect(self) -> None:
@@ -56,11 +42,13 @@ class SiteConsumer(ProtocollAsyncJsonWebsocketConsumer):
 
         Sends the startup data to the user.
         """
+        self.user_id = self.scope["user"]["id"]
+
         self.connect_time = time.time()
         # self.scope['user'] is the full_data dict of the user. For an
         # anonymous user is it the dict {'id': 0}
         change_id = None
-        if not await async_anonymous_is_enabled() and not self.scope["user"]["id"]:
+        if not await async_anonymous_is_enabled() and not self.user_id:
             await self.accept()  # workaround for #4009
             await self.close()
             logger.debug(f"connect: denied ({self._id})")
@@ -74,23 +62,22 @@ class SiteConsumer(ProtocollAsyncJsonWebsocketConsumer):
                 change_id = int(query_string[b"change_id"][0])
             except ValueError:
                 await self.accept()  # workaround for #4009
-                await self.close()  # TODO: Find a way to send an error code
+                await self.close()
                 logger.debug(f"connect: wrong change id ({self._id})")
                 return
-
-        if b"autoupdate" in query_string and query_string[b"autoupdate"][
-            0
-        ].lower() not in [b"0", b"off", b"false"]:
-            # a positive value in autoupdate. Start autoupdate
-            await self.channel_layer.group_add("autoupdate", self.channel_name)
 
         await self.accept()
 
         if change_id is not None:
             logger.debug(f"connect: change id {change_id} ({self._id})")
-            await self.send_autoupdate(change_id)
+            try:
+                await self.request_autoupdate(change_id)
+            except BaseWebsocketException as e:
+                await self.send_exception(e)
         else:
             logger.debug(f"connect: no change id ({self._id})")
+
+        await self.channel_layer.group_add("autoupdate", self.channel_name)
 
     async def disconnect(self, close_code: int) -> None:
         """
@@ -102,110 +89,19 @@ class SiteConsumer(ProtocollAsyncJsonWebsocketConsumer):
             f"disconnect code={close_code} active_secs={active_seconds} ({self._id})"
         )
 
-    async def send_notify(self, event: Dict[str, Any]) -> None:
-        """
-        Send a notify message to the user.
-        """
-        user_id = self.scope["user"]["id"]
-        item = event["incomming"]
-
-        users = item.get("users")
-        reply_channels = item.get("replyChannels")
-        if (
-            (isinstance(users, bool) and users)
-            or (isinstance(users, list) and user_id in users)
-            or (
-                isinstance(reply_channels, list) and self.channel_name in reply_channels
-            )
-            or (users is None and reply_channels is None)
-        ):
-            item["senderChannelName"] = event["senderChannelName"]
-            item["senderUserId"] = event["senderUserId"]
-            await self.send_json(type="notify", content=item)
-
-    async def send_autoupdate(
-        self,
-        change_id: int,
-        max_change_id: Optional[int] = None,
-        in_response: Optional[str] = None,
-    ) -> None:
-        """
-        Sends an autoupdate to the client from change_id to max_change_id.
-        If max_change_id is None, the current change id will be used.
-        """
-        user_id = self.scope["user"]["id"]
-
-        if max_change_id is None:
-            max_change_id = await element_cache.get_current_change_id()
-
-        if change_id == max_change_id + 1:
-            # The client is up-to-date, so nothing will be done
-            return
-
-        if change_id > max_change_id:
-            message = f"Requested change_id {change_id} is higher this highest change_id {max_change_id}."
-            await self.send_error(
-                code=WEBSOCKET_CHANGE_ID_TOO_HIGH,
-                message=message,
-                in_response=in_response,
-            )
-            return
-
-        try:
-            changed_elements, deleted_element_ids = await element_cache.get_data_since(
-                user_id, change_id, max_change_id
-            )
-        except ChangeIdTooLowError:
-            # The change_id is lower the the lowerst change_id in redis. Return all data
-            changed_elements = await element_cache.get_all_data_list(user_id)
-            all_data = True
-            deleted_elements: Dict[str, List[int]] = {}
-        except UserDoesNotExist:
-            # Maybe the user was deleted, but a websocket connection is still open to the user.
-            # So we can close this connection and return.
-            await self.close()
-            return
-        else:
-            all_data = False
-            deleted_elements = defaultdict(list)
-            for element_id in deleted_element_ids:
-                collection_string, id = split_element_id(element_id)
-                deleted_elements[collection_string].append(id)
-
-        # Check, if the autoupdate has any data.
-        if not changed_elements and not deleted_element_ids:
-            # Set the current from_change_id, if it is the first skipped autoupdate
-            if not self.skipped_autoupdate_from_change_id:
-                self.skipped_autoupdate_from_change_id = change_id
-        else:
-            # Normal autoupdate with data
-            from_change_id = change_id
-
-            # If there is at least one skipped autoupdate, take the saved from_change_id
-            if self.skipped_autoupdate_from_change_id:
-                from_change_id = self.skipped_autoupdate_from_change_id
-                self.skipped_autoupdate_from_change_id = None
-
-            await self.send_json(
-                type="autoupdate",
-                content=AutoupdateFormat(
-                    changed=changed_elements,
-                    deleted=deleted_elements,
-                    from_change_id=from_change_id,
-                    to_change_id=max_change_id,
-                    all_data=all_data,
-                ),
-                in_response=in_response,
-            )
-
-    async def send_data(self, event: Dict[str, Any]) -> None:
+    async def msg_new_change_id(self, event: Dict[str, Any]) -> None:
         """
         Send changed or deleted elements to the user.
         """
         change_id = event["change_id"]
-        await self.send_autoupdate(change_id, max_change_id=change_id)
+        try:
+            await self.autoupdate_strategy.new_change_id(change_id)
+        except UserDoesNotExist:
+            # Maybe the user was deleted, but a websocket connection is still open to the user.
+            # So we can close this connection and return.
+            await self.close()
 
-    async def projector_changed(self, event: Dict[str, Any]) -> None:
+    async def msg_projector_data(self, event: Dict[str, Any]) -> None:
         """
         The projector has changed.
         """
@@ -222,6 +118,33 @@ class SiteConsumer(ProtocollAsyncJsonWebsocketConsumer):
 
         if projector_data:
             await self.send_projector_data(projector_data, change_id=change_id)
+
+    async def msg_notify(self, event: Dict[str, Any]) -> None:
+        """
+        Send a notify message to the user.
+        """
+        item = event["incomming"]
+
+        users = item.get("users")
+        reply_channels = item.get("replyChannels")
+        if (
+            (isinstance(users, bool) and users)
+            or (isinstance(users, list) and self.user_id in users)
+            or (
+                isinstance(reply_channels, list) and self.channel_name in reply_channels
+            )
+            or (users is None and reply_channels is None)
+        ):
+            item["senderChannelName"] = event["senderChannelName"]
+            item["senderUserId"] = event["senderUserId"]
+            await self.send_json(type="notify", content=item)
+
+    async def request_autoupdate(
+        self, change_id: int, in_response: Optional[str] = None
+    ) -> None:
+        await self.autoupdate_strategy.request_change_id(
+            change_id, in_response=in_response
+        )
 
     async def send_projector_data(
         self,

--- a/openslides/utils/models.py
+++ b/openslides/utils/models.py
@@ -175,7 +175,7 @@ class RESTModelMixin:
                 current_time = time.time()
                 if current_time > last_time + 5:
                     last_time = current_time
-                    logger.info(f"\t{i+1}/{instances_length}...")
+                    logger.info(f"    {i+1}/{instances_length}...")
         return full_data
 
     @classmethod

--- a/openslides/utils/projector.py
+++ b/openslides/utils/projector.py
@@ -5,22 +5,58 @@ Functions  that handel the registration of projector elements and the rendering
 of the data to present it on the projector.
 """
 
-from typing import Any, Awaitable, Callable, Dict, List
+from collections import defaultdict
+from typing import Any, Awaitable, Callable, Dict, List, Optional
 
+from . import logging
 from .cache import element_cache
 
 
-AllData = Dict[str, Dict[int, Dict[str, Any]]]
-ProjectorSlide = Callable[[AllData, Dict[str, Any], int], Awaitable[Dict[str, Any]]]
-
-
-projector_slides: Dict[str, ProjectorSlide] = {}
+logger = logging.getLogger(__name__)
 
 
 class ProjectorElementException(Exception):
     """
     Exception for errors in one element on the projector.
     """
+
+
+class ProjectorAllDataProvider:
+    NON_EXISTENT_MARKER = object()
+
+    def __init__(self) -> None:
+        self.cache: Any = defaultdict(dict)  # fuu you mypy
+        self.fetched_collection: Dict[str, bool] = {}
+
+    async def get(self, collection: str, id: int) -> Optional[Dict[str, Any]]:
+        cache_data = self.cache[collection].get(id)
+        if cache_data is None:
+            data: Any = await element_cache.get_element_data(collection, id)
+            if data is None:
+                data = ProjectorAllDataProvider.NON_EXISTENT_MARKER
+            self.cache[collection][id] = data
+        elif cache_data == ProjectorAllDataProvider.NON_EXISTENT_MARKER:
+            return None
+        return self.cache[collection][id]
+
+    async def get_collection(self, collection: str) -> Dict[int, Dict[str, Any]]:
+        if not self.fetched_collection.get(collection, False):
+            collection_data = await element_cache.get_collection_data(collection)
+            self.cache[collection] = collection_data
+            self.fetched_collection[collection] = True
+        return self.cache[collection]
+
+    async def exists(self, collection: str, id: int) -> bool:
+        model = await self.get(collection, id)
+        return model is not None
+
+
+ProjectorSlide = Callable[
+    [ProjectorAllDataProvider, Dict[str, Any], int], Awaitable[Dict[str, Any]]
+]
+
+
+projector_slides: Dict[str, ProjectorSlide] = {}
 
 
 def register_projector_slide(name: str, slide: ProjectorSlide) -> None:
@@ -67,10 +103,11 @@ async def get_projector_data(
     if projector_ids is None:
         projector_ids = []
 
-    all_data = await element_cache.get_all_data_dict()
     projector_data: Dict[int, List[Dict[str, Any]]] = {}
+    all_data_provider = ProjectorAllDataProvider()
+    projectors = await all_data_provider.get_collection("core/projector")
 
-    for projector_id, projector in all_data.get("core/projector", {}).items():
+    for projector_id, projector in projectors.items():
         if projector_ids and projector_id not in projector_ids:
             # only render the projector in question.
             continue
@@ -83,7 +120,7 @@ async def get_projector_data(
         for element in projector["elements"]:
             projector_slide = projector_slides[element["name"]]
             try:
-                data = await projector_slide(all_data, element, projector_id)
+                data = await projector_slide(all_data_provider, element, projector_id)
             except ProjectorElementException as err:
                 data = {"error": str(err)}
             projector_data[projector_id].append({"data": data, "element": element})
@@ -91,18 +128,23 @@ async def get_projector_data(
     return projector_data
 
 
-async def get_config(all_data: AllData, key: str) -> Any:
+async def get_config(all_data_provider: ProjectorAllDataProvider, key: str) -> Any:
     """
-    Returns a config value from all_data.
+    Returns a config value from all_data_provider.
+    Triggers the cache early: It access `get_colelction` instead of `get`. It
+    allows for all successive queries for configs to be cached.
     """
     from ..core.config import config
 
     config_id = (await config.async_get_key_to_id())[key]
 
-    return all_data[config.get_collection_string()][config_id]["value"]
+    configs = await all_data_provider.get_collection(config.get_collection_string())
+    return configs[config_id]["value"]
 
 
-def get_model(all_data: AllData, collection: str, id: Any) -> Dict[str, Any]:
+async def get_model(
+    all_data_provider: ProjectorAllDataProvider, collection: str, id: Any
+) -> Dict[str, Any]:
     """
     Tries to get the model identified by the collection and id.
     If the id is invalid or the model not found, ProjectorElementExceptions will be raised.
@@ -110,17 +152,19 @@ def get_model(all_data: AllData, collection: str, id: Any) -> Dict[str, Any]:
     if id is None:
         raise ProjectorElementException(f"id is required for {collection} slide")
 
-    try:
-        model = all_data[collection][id]
-    except KeyError:
+    model = await all_data_provider.get(collection, id)
+    if model is None:
         raise ProjectorElementException(f"{collection} with id {id} does not exist")
     return model
 
 
-def get_models(
-    all_data: AllData, collection: str, ids: List[Any]
+async def get_models(
+    all_data_provider: ProjectorAllDataProvider, collection: str, ids: List[Any]
 ) -> List[Dict[str, Any]]:
     """
     Tries to fetch all given models. Models are required to be all of the collection `collection`.
     """
-    return [get_model(all_data, collection, id) for id in ids]
+    logger.info(
+        f"Note: a call to `get_models` with {collection}/{ids}. This might be cache-intensive"
+    )
+    return [await get_model(all_data_provider, collection, id) for id in ids]

--- a/openslides/utils/projector.py
+++ b/openslides/utils/projector.py
@@ -35,9 +35,11 @@ class ProjectorAllDataProvider:
             if data is None:
                 data = ProjectorAllDataProvider.NON_EXISTENT_MARKER
             self.cache[collection][id] = data
-        elif cache_data == ProjectorAllDataProvider.NON_EXISTENT_MARKER:
+
+        cache_data = self.cache[collection][id]
+        if cache_data == ProjectorAllDataProvider.NON_EXISTENT_MARKER:
             return None
-        return self.cache[collection][id]
+        return cache_data
 
     async def get_collection(self, collection: str) -> Dict[int, Dict[str, Any]]:
         if not self.fetched_collection.get(collection, False):

--- a/openslides/utils/redis.py
+++ b/openslides/utils/redis.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 use_redis = False
 use_read_only_redis = False
 read_only_redis_amount_replicas = None
+read_only_redis_wait_timeout = None
 
 try:
     import aioredis
@@ -35,6 +36,8 @@ else:
 
             read_only_redis_amount_replicas = getattr(settings, "AMOUNT_REPLICAS", 1)
             logger.info(f"AMOUNT_REPLICAS={read_only_redis_amount_replicas}")
+            read_only_redis_wait_timeout = getattr(settings, "WAIT_TIMEOUT", 1000)
+            logger.info(f"WAIT_TIMEOUT={read_only_redis_wait_timeout}")
     else:
         logger.info("Redis is not configured.")
 

--- a/openslides/utils/timing.py
+++ b/openslides/utils/timing.py
@@ -1,0 +1,27 @@
+import time
+from typing import List, Optional
+
+from . import logging
+
+
+timelogger = logging.getLogger(__name__)
+
+
+class Timing:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.times: List[float] = [time.time()]
+
+    def __call__(self, done: Optional[bool] = False) -> None:
+        self.times.append(time.time())
+        if done:
+            self.printtime()
+
+    def printtime(self) -> None:
+        s = f"{self.name}: "
+        for i in range(1, len(self.times)):
+            diff = self.times[i] - self.times[i - 1]
+            s += f"{i}: {diff:.5f} "
+        diff = self.times[-1] - self.times[0]
+        s += f"sum: {diff:.5f}"
+        timelogger.info(s)

--- a/tests/integration/utils/test_consumers.py
+++ b/tests/integration/utils/test_consumers.py
@@ -1,4 +1,3 @@
-import asyncio
 from importlib import import_module
 from typing import Optional, Tuple
 from unittest.mock import patch
@@ -158,17 +157,7 @@ async def test_connection_with_too_big_change_id(get_communicator, set_config):
 
 
 @pytest.mark.asyncio
-async def test_changed_data_autoupdate_off(communicator, set_config):
-    await set_config("general_system_enable_anonymous", True)
-    await communicator.connect()
-
-    # Change a config value
-    await set_config("general_event_name", "Test Event")
-    assert await communicator.receive_nothing()
-
-
-@pytest.mark.asyncio
-async def test_changed_data_autoupdate_on(get_communicator, set_config):
+async def test_changed_data_autoupdate(get_communicator, set_config):
     await set_config("general_system_enable_anonymous", True)
     communicator = get_communicator("autoupdate=on")
     await communicator.connect()
@@ -422,12 +411,12 @@ async def test_send_connect_up_to_date(communicator, set_config):
         {"type": "getElements", "content": {"change_id": 0}, "id": "test_id"}
     )
     response1 = await communicator.receive_json_from()
-    first_change_id = response1.get("content")["to_change_id"]
+    max_change_id = response1.get("content")["to_change_id"]
 
     await communicator.send_json_to(
         {
             "type": "getElements",
-            "content": {"change_id": first_change_id + 1},
+            "content": {"change_id": max_change_id},
             "id": "test_id",
         }
     )
@@ -511,43 +500,6 @@ async def test_send_invalid_get_elements(communicator, set_config):
 
 
 @pytest.mark.asyncio
-async def test_turn_on_autoupdate(communicator, set_config):
-    await set_config("general_system_enable_anonymous", True)
-    await communicator.connect()
-
-    await communicator.send_json_to(
-        {"type": "autoupdate", "content": "on", "id": "test_id"}
-    )
-    await asyncio.sleep(0.01)
-    # Change a config value
-    await set_config("general_event_name", "Test Event")
-    response = await communicator.receive_json_from()
-
-    id = config.get_key_to_id()["general_event_name"]
-    type = response.get("type")
-    content = response.get("content")
-    assert type == "autoupdate"
-    assert content["changed"] == {
-        "core/config": [{"id": id, "key": "general_event_name", "value": "Test Event"}]
-    }
-
-
-@pytest.mark.asyncio
-async def test_turn_off_autoupdate(get_communicator, set_config):
-    await set_config("general_system_enable_anonymous", True)
-    communicator = get_communicator("autoupdate=on")
-    await communicator.connect()
-
-    await communicator.send_json_to(
-        {"type": "autoupdate", "content": False, "id": "test_id"}
-    )
-    await asyncio.sleep(0.01)
-    # Change a config value
-    await set_config("general_event_name", "Test Event")
-    assert await communicator.receive_nothing()
-
-
-@pytest.mark.asyncio
 async def test_listen_to_projector(communicator, set_config):
     await set_config("general_system_enable_anonymous", True)
     await communicator.connect()
@@ -588,10 +540,15 @@ async def test_update_projector(communicator, set_config):
             "id": "test_id",
         }
     )
-    await communicator.receive_json_from()
+    await communicator.receive_json_from()  # recieve initial projector data
 
     # Change a config value
     await set_config("general_event_name", "Test Event")
+
+    # We need two messages: The autoupdate and the projector data in this order
+    response = await communicator.receive_json_from()
+    assert response.get("type") == "autoupdate"
+
     response = await communicator.receive_json_from()
 
     type = response.get("type")
@@ -628,5 +585,9 @@ async def test_update_projector_to_current_value(communicator, set_config):
 
     # Change a config value to current_value
     await set_config("general_event_name", "OpenSlides")
+
+    # We await an autoupdate, bot no projector data
+    response = await communicator.receive_json_from()
+    assert response.get("type") == "autoupdate"
 
     assert await communicator.receive_nothing()

--- a/tests/integration/utils/test_consumers.py
+++ b/tests/integration/utils/test_consumers.py
@@ -50,7 +50,7 @@ async def prepare_element_cache(settings):
         ]
     )
     element_cache._cachables = None
-    await element_cache.async_ensure_cache(default_change_id=2)
+    await element_cache.async_ensure_cache(default_change_id=10)
     yield
     # Reset the cachable_provider
     element_cache.cachable_provider = orig_cachable_provider
@@ -159,7 +159,7 @@ async def test_connection_with_too_big_change_id(get_communicator, set_config):
 @pytest.mark.asyncio
 async def test_changed_data_autoupdate(get_communicator, set_config):
     await set_config("general_system_enable_anonymous", True)
-    communicator = get_communicator("autoupdate=on")
+    communicator = get_communicator()
     await communicator.connect()
 
     # Change a config value
@@ -201,7 +201,7 @@ async def create_user_session_cookie(user_id: int) -> Tuple[bytes, bytes]:
 @pytest.mark.asyncio
 async def test_with_user(get_communicator):
     cookie_header = await create_user_session_cookie(1)
-    communicator = get_communicator("autoupdate=on", headers=[cookie_header])
+    communicator = get_communicator(headers=[cookie_header])
 
     connected, __ = await communicator.connect()
 
@@ -211,7 +211,7 @@ async def test_with_user(get_communicator):
 @pytest.mark.asyncio
 async def test_skipping_autoupdate(set_config, get_communicator):
     cookie_header = await create_user_session_cookie(1)
-    communicator = get_communicator("autoupdate=on", headers=[cookie_header])
+    communicator = get_communicator(headers=[cookie_header])
 
     await communicator.connect()
 
@@ -254,7 +254,7 @@ async def test_skipping_autoupdate(set_config, get_communicator):
 @pytest.mark.asyncio
 async def test_receive_deleted_data(get_communicator, set_config):
     await set_config("general_system_enable_anonymous", True)
-    communicator = get_communicator("autoupdate=on")
+    communicator = get_communicator()
     await communicator.connect()
 
     # Delete test element
@@ -384,6 +384,7 @@ async def test_send_get_elements_too_big_change_id(communicator, set_config):
 
 @pytest.mark.asyncio
 async def test_send_get_elements_too_small_change_id(communicator, set_config):
+    # Note: this test depends on the default_change_id set in prepare_element_cache
     await set_config("general_system_enable_anonymous", True)
     await communicator.connect()
 
@@ -517,7 +518,7 @@ async def test_listen_to_projector(communicator, set_config):
     content = response.get("content")
     assert type == "projector"
     assert content == {
-        "change_id": 3,
+        "change_id": 11,
         "data": {
             "1": [
                 {
@@ -555,7 +556,7 @@ async def test_update_projector(communicator, set_config):
     content = response.get("content")
     assert type == "projector"
     assert content == {
-        "change_id": 4,
+        "change_id": 12,
         "data": {
             "1": [
                 {

--- a/tests/unit/agenda/test_projector.py
+++ b/tests/unit/agenda/test_projector.py
@@ -4,10 +4,12 @@ import pytest
 
 from openslides.agenda import projector
 
+from ...integration.helpers import get_all_data_provider
+
 
 @pytest.fixture
-def all_data():
-    all_data = {
+def all_data_provider():
+    data = {
         "agenda/item": {
             1: {
                 "id": 1,
@@ -82,14 +84,14 @@ def all_data():
         }
     }
 
-    return all_data
+    return get_all_data_provider(data)
 
 
 @pytest.mark.asyncio
-async def test_main_items(all_data):
+async def test_main_items(all_data_provider):
     element: Dict[str, Any] = {}
 
-    data = await projector.item_list_slide(all_data, element, 1)
+    data = await projector.item_list_slide(all_data_provider, element, 1)
 
     assert data == {
         "items": [
@@ -106,10 +108,10 @@ async def test_main_items(all_data):
 
 
 @pytest.mark.asyncio
-async def test_all_items(all_data):
+async def test_all_items(all_data_provider):
     element: Dict[str, Any] = {"only_main_items": False}
 
-    data = await projector.item_list_slide(all_data, element, 1)
+    data = await projector.item_list_slide(all_data_provider, element, 1)
 
     assert data == {
         "items": [

--- a/tests/unit/motions/test_projector.py
+++ b/tests/unit/motions/test_projector.py
@@ -4,14 +4,13 @@ import pytest
 
 from openslides.motions import projector
 
-from ...integration.helpers import all_data_config, all_data_users
+from ...integration.helpers import get_all_data_provider
 
 
 @pytest.fixture
-def all_data():
-    return_value = all_data_config()
-    return_value.update(all_data_users())
-    return_value["motions/motion"] = {
+def all_data_provider():
+    data = {}
+    data["motions/motion"] = {
         1: {
             "id": 1,
             "identifier": "4",
@@ -143,7 +142,7 @@ def all_data():
             "change_recommendations": [],
         },
     }
-    return_value["motions/workflow"] = {
+    data["motions/workflow"] = {
         1: {
             "id": 1,
             "name": "Simple Workflow",
@@ -151,7 +150,7 @@ def all_data():
             "first_state_id": 1,
         }
     }
-    return_value["motions/state"] = {
+    data["motions/state"] = {
         1: {
             "id": 1,
             "name": "submitted",
@@ -217,7 +216,7 @@ def all_data():
             "workflow_id": 1,
         },
     }
-    return_value["motions/statute-paragraph"] = {
+    data["motions/statute-paragraph"] = {
         1: {
             "id": 1,
             "title": "§1 Preamble",
@@ -225,7 +224,7 @@ def all_data():
             "weight": 10000,
         }
     }
-    return_value["motions/motion-change-recommendation"] = {
+    data["motions/motion-change-recommendation"] = {
         1: {
             "id": 1,
             "motion_id": 1,
@@ -251,14 +250,14 @@ def all_data():
             "creation_time": "2019-02-09T09:54:06.256378+01:00",
         },
     }
-    return return_value
+    return get_all_data_provider(data)
 
 
 @pytest.mark.asyncio
-async def test_motion_slide(all_data):
+async def test_motion_slide(all_data_provider):
     element: Dict[str, Any] = {"id": 1}
 
-    data = await projector.motion_slide(all_data, element, 1)
+    data = await projector.motion_slide(all_data_provider, element, 1)
 
     assert data == {
         "identifier": "4",
@@ -304,10 +303,10 @@ async def test_motion_slide(all_data):
 
 
 @pytest.mark.asyncio
-async def test_amendment_slide(all_data):
+async def test_amendment_slide(all_data_provider):
     element: Dict[str, Any] = {"id": 2}
 
-    data = await projector.motion_slide(all_data, element, 1)
+    data = await projector.motion_slide(all_data_provider, element, 1)
 
     assert data == {
         "identifier": "Ä1",
@@ -331,10 +330,10 @@ async def test_amendment_slide(all_data):
 
 
 @pytest.mark.asyncio
-async def test_statute_amendment_slide(all_data):
+async def test_statute_amendment_slide(all_data_provider):
     element: Dict[str, Any] = {"id": 3}
 
-    data = await projector.motion_slide(all_data, element, 1)
+    data = await projector.motion_slide(all_data_provider, element, 1)
 
     assert data == {
         "identifier": None,


### PR DESCRIPTION
This PR is in favor of #5360 (I'll leave it open, because it might be merged, to add tracing to important parts of the code).

Things changed:

- [x] Mutex for the client autoupdate code -> no parallel (concurrent) work on AUs
- [x] Parameter for the wait-timeout for read only redis synchronization
- [x] Rewrite projector code to not fetch all data
- [x] Added caching for data access during the projector data creation
- [x] Order autoupdates in consumers on server side
- [x] Delay autoupdates on server side
- [x] Be aware of skipped autoupdates and holes in the change-id-series
- [x] Add delay-parameter
- [x] Test this.
- [x] fix tests