### PR TITLE
Adds migration to remove deprecated slides

### DIFF
--- a/openslides/assignments/migrations/0014_remove_deprecated_slides.py
+++ b/openslides/assignments/migrations/0014_remove_deprecated_slides.py
@@ -1,0 +1,27 @@
+from django.db import migrations
+
+
+def remove_deprecated_slides(apps, schema_editor):
+    Projector = apps.get_model("core", "Projector")
+    for projector in Projector.objects.all():
+        new_history = []
+        for entry in projector.elements_history:
+            new_entry = []
+            for subentry in entry:
+                if subentry["name"] != "assignments/poll":
+                    new_entry.append(subentry)
+            if len(new_entry):
+                new_history.append(new_entry)
+        projector.elements_history = new_history
+        projector.save(skip_autoupdate=True)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("assignments", "0013_rename_verbose_poll_types"),
+    ]
+
+    operations = [
+        migrations.RunPython(remove_deprecated_slides),
+    ]


### PR DESCRIPTION
@FinnStutzenstein is the `elements_history` always double nested? If so, why? If not, the migration has to be corrected. Please check that I missed nothing important.