### PR TITLE
Fixed incomplete autoupdates

### DIFF
--- a/client/src/app/site/assignments/components/assignment-poll/assignment-poll.component.html
+++ b/client/src/app/site/assignments/components/assignment-poll/assignment-poll.component.html
@@ -113,11 +113,19 @@
             <span>{{ 'Ballot papers' | translate }}</span>
         </button>
         <mat-divider></mat-divider>
+        <!-- Refresh Button -->
+        <button mat-menu-item (click)="refreshPoll()">
+            <mat-icon>refresh</mat-icon>
+            <span>{{ 'Refresh' | translate }}</span>
+        </button>
+
         <!-- Reset Button -->
         <button mat-menu-item (click)="resetState()">
             <mat-icon color="warn">replay</mat-icon>
             <span>{{ 'Reset state' | translate }}</span>
         </button>
+
+        <!-- Delete button -->
         <button mat-menu-item class="red-warning-text" (click)="onDeletePoll()">
             <mat-icon>delete</mat-icon>
             <span>{{ 'Delete' | translate }}</span>

--- a/client/src/app/site/motions/modules/motion-poll/motion-poll/motion-poll.component.html
+++ b/client/src/app/site/motions/modules/motion-poll/motion-poll/motion-poll.component.html
@@ -123,6 +123,12 @@
     </button>
     <div *osPerms="'motions.can_manage_polls'">
         <mat-divider></mat-divider>
+        <!-- Refresh Button -->
+        <button mat-menu-item (click)="refreshPoll()">
+            <mat-icon>refresh</mat-icon>
+            <span>{{ 'Refresh' | translate }}</span>
+        </button>
+
         <!-- Reset Button -->
         <button mat-menu-item (click)="resetState()">
             <mat-icon color="warn">replay</mat-icon>

--- a/client/src/app/site/polls/components/base-poll.component.ts
+++ b/client/src/app/site/polls/components/base-poll.component.ts
@@ -89,4 +89,8 @@ export abstract class BasePollComponent<V extends ViewBasePoll, S extends PollSe
     protected initPoll(model: V): void {
         this._poll = model;
     }
+
+    public refreshPoll(): void {
+        this.repo.refresh(this._poll);
+    }
 }

--- a/client/src/app/site/polls/services/base-poll-repository.service.ts
+++ b/client/src/app/site/polls/services/base-poll-repository.service.ts
@@ -72,16 +72,19 @@ export abstract class BasePollRepositoryService<
         }
     }
 
-    public resetPoll(poll: BasePoll): Promise<void> {
-        return this.http.post(`${this.restPath(poll)}/reset/`);
-    }
-
     private restPath(poll: BasePoll): string {
         return `/rest/${poll.collectionString}/${poll.id}`;
     }
 
+    public resetPoll(poll: BasePoll): Promise<void> {
+        return this.http.post(`${this.restPath(poll)}/reset/`);
+    }
+
     public pseudoanonymize(poll: BasePoll): Promise<void> {
-        const path = this.restPath(poll);
-        return this.http.post(`${path}/pseudoanonymize/`);
+        return this.http.post(`${this.restPath(poll)}/pseudoanonymize/`);
+    }
+
+    public refresh(poll: BasePoll): Promise<void> {
+        return this.http.post(`${this.restPath(poll)}/refresh/`);
     }
 }

--- a/openslides/poll/views.py
+++ b/openslides/poll/views.py
@@ -222,6 +222,15 @@ class BasePollViewSet(ModelViewSet):
 
         return Response()
 
+    @detail_route(methods=["POST"])
+    @transaction.atomic
+    def refresh(self, request, pk):
+        poll = self.get_object()
+        inform_changed_data(poll, final_data=True)
+        inform_changed_data(poll.get_options(), final_data=True)
+        inform_changed_data(poll.get_votes(), final_data=True)
+        return Response()
+
     def assert_can_vote(self, poll, request):
         """
         Raises a permission denied, if the user is not allowed to vote (or has already voted).
@@ -262,6 +271,12 @@ class BasePollViewSet(ModelViewSet):
                 }
             )
         return value
+
+    def has_manage_permissions(self):
+        """
+        Returns true, if the request user has manage perms.
+        """
+        raise NotImplementedError()
 
     def convert_option_data(self, poll, data):
         """

--- a/openslides/utils/rest_api.py
+++ b/openslides/utils/rest_api.py
@@ -139,9 +139,9 @@ class ErrorLoggingMixin:
         prefix = f"{path} {user_id}"
         if isinstance(exc, APIException):
             detail = self._detail_to_string(exc.detail)
-            error_logger.warn(f"{prefix} {str(detail)}")
+            error_logger.warning(f"{prefix} {str(detail)}")
         else:
-            error_logger.warn(f"{prefix} unknown exception: {exc}")
+            error_logger.warning(f"{prefix} unknown exception: {exc}")
         return super().handle_exception(exc)  # type: ignore
 
     def _detail_to_string(self, detail: Any) -> Any:

--- a/tests/test_case.py
+++ b/tests/test_case.py
@@ -42,7 +42,7 @@ class TestCase(_TestCase):
         """
         user_id = None if user is None else user.id
         current_change_id = async_to_sync(element_cache.get_current_change_id)()
-        _changed_elements, deleted_element_ids = async_to_sync(
+        _, _changed_elements, deleted_element_ids = async_to_sync(
             element_cache.get_data_since
         )(user_id=user_id, change_id=current_change_id)
 


### PR DESCRIPTION
A conceptional issue in `get_data_since` leads to incomplete
autoupdates. The behaviour was long time in the code, but only with a
lot of autoupdates (high concurrency) and the autoupdate delay I noticed
the bug during testing. I'm sure, that this issue might have caused
incomplete autoupdates (which the user may experience as "lost
autoupdates") in previous productive instances. Instead of quering a
range (from_change_id to to_change_id) one now can only get data from a
change id up to the max change id in the element cache. The max change
id gets now returned by `get_data_since`.

I also added a get_all_data with the capability of returning the
max_change_id at this point of time.

As a usability-"fix" (more like a fix the result of a bug, not the bug
itself) a refresh button for a poll was added, that issues an autoupdate
for the poll and all options.