### PR TITLE
Bugfix non paragraph based amendments

### DIFF
--- a/client/src/app/core/repositories/motions/motion-repository.service.ts
+++ b/client/src/app/core/repositories/motions/motion-repository.service.ts
@@ -324,7 +324,7 @@ export class MotionRepositoryService extends BaseIsAgendaItemAndListOfSpeakersCo
             type: 'custom',
             ownKey: 'diffLines',
             get: (motion: Motion, viewMotion: ViewMotion) => {
-                if (viewMotion.parent) {
+                if (viewMotion.parent && viewMotion.isParagraphBasedAmendment()) {
                     const changeRecos = viewMotion.changeRecommendations.filter(changeReco =>
                         changeReco.showInFinalView()
                     );
@@ -335,6 +335,8 @@ export class MotionRepositoryService extends BaseIsAgendaItemAndListOfSpeakersCo
                         changeRecos,
                         false
                     );
+                } else {
+                    return [];
                 }
             },
             getCacheObjectToCheck: (viewMotion: ViewMotion) => viewMotion.parent
@@ -835,7 +837,9 @@ export class MotionRepositoryService extends BaseIsAgendaItemAndListOfSpeakersCo
     }
 
     /**
-     * Returns all paragraph lines that are affected by the given amendment in diff-format, including context
+     * Returns all paragraph lines that are affected by the given amendment in diff-format, including context.
+     *
+     * Should only be called for paragraph-based amendments.
      *
      * @param {ViewMotion} amendment
      * @param {number} lineLength

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.ts
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.ts
@@ -1547,6 +1547,16 @@ export class MotionDetailComponent extends BaseViewComponent implements OnInit, 
              * a change reco. The autoupdate has to come "after" this routine
              */
             return ChangeRecoMode.Original;
+        } else if (
+            mode === ChangeRecoMode.Diff &&
+            !this.changeRecommendations?.length &&
+            this.motion?.isParagraphBasedAmendment()
+        ) {
+            /**
+             * The Diff view for paragraph-based amendments is only relevant for change recommendations;
+             * the regular amendment changes are shown in the "original" view.
+             */
+            return ChangeRecoMode.Original;
         }
         return mode;
     }


### PR DESCRIPTION
Fixes:
- No motion text is pre-filled if a new amendment is created with the setting "use full motion text"
- A Javscript error in the amendment list if there is a non-paragraph-based amendment in the list

Improvement:
- Recalculating the amendments is slightly faster, due to additional caching. This is an issue when the whole motion is reloaded including all amendment, e.g. when the "favorite star" is set.

Change:
- The Change-recommendation-diff-view in a paragraph-based motion currently always shows the whole motion text with both the changes made by the original amendment and the changes made by the change recommendations to the amendment. In the normal case, there are no change recommandations, and we want to show only the parts of the motion affected by the amendment (+ a checkbox to show the whole motion text). This MR therefore sets the view mode to "Original amendment" if there is no change recommendation to an amendment. A more complex implementation would be to implement this "show only affected areas"-functionality into the Diff-view of the amendment.