### PR TITLE
Fix error for freely editable amendments

### DIFF
--- a/client/src/app/core/repositories/motions/motion-repository.service.ts
+++ b/client/src/app/core/repositories/motions/motion-repository.service.ts
@@ -798,7 +798,7 @@ export class MotionRepositoryService extends BaseIsAgendaItemAndListOfSpeakersCo
             }
         });
 
-        return amendment.amendment_paragraphs.map((newText: string, paraNo: number) => {
+        return amendment.amendment_paragraphs?.map((newText: string, paraNo: number) => {
             let paragraph: string;
             let paragraphHasChanges;
 
@@ -866,7 +866,7 @@ export class MotionRepositoryService extends BaseIsAgendaItemAndListOfSpeakersCo
         }
 
         return amendmentParagraphs
-            .map(
+            ?.map(
                 (newText: string, paraNo: number): DiffLinesInParagraph => {
                     if (newText !== null) {
                         return this.diff.getAmendmentParagraphsLines(
@@ -937,7 +937,7 @@ export class MotionRepositoryService extends BaseIsAgendaItemAndListOfSpeakersCo
         const changedAmendmentParagraphs = this.applyChangesToAmendment(amendment, lineLength, changeRecos, false);
 
         return changedAmendmentParagraphs
-            .map(
+            ?.map(
                 (newText: string, paraNo: number): ViewMotionAmendedParagraph => {
                     if (newText === null) {
                         return null;

--- a/client/src/app/site/motions/modules/amendment-list/amendment-list.component.ts
+++ b/client/src/app/site/motions/modules/amendment-list/amendment-list.component.ts
@@ -134,12 +134,14 @@ export class AmendmentListComponent extends BaseListViewComponent<ViewMotion> im
      */
     public getAmendmentSummary(amendment: ViewMotion): string {
         const diffLines = amendment.diffLines;
-        if (diffLines) {
+        if (diffLines.length) {
             return diffLines
                 .map(diffLine => {
                     return this.linenumberingService.stripLineNumbers(diffLine.text);
                 })
                 .join('[...]');
+        } else {
+            return amendment.text;
         }
     }
 


### PR DESCRIPTION
Recent changes to amendment had various bugs.
This one regarded the amendment list, where amendments without amendments
paragraphs returned several errors.