### PR TITLE
Add roboto-condensed-bold as default

### DIFF
--- a/openslides/core/config_variables.py
+++ b/openslides/core/config_variables.py
@@ -386,7 +386,7 @@ def get_config_variables():
         name="font_monospace",
         default_value={
             "display_name": "Font monospace",
-            "default": "assets/fonts/courier-prime.woff",
+            "default": "assets/fonts/roboto-condensed-bold.woff",
             "path": "",
         },
         input_type="static",


### PR DESCRIPTION
Fixes a severe regression. New databases could not generate any PDF or use
the countdown.