### PR TITLE
Lower chrome/chromium support version to version

### DIFF
--- a/client/src/app/site/login/services/browser-support.service.ts
+++ b/client/src/app/site/login/services/browser-support.service.ts
@@ -3,12 +3,12 @@ import { Injectable } from '@angular/core';
 import { DeviceDetectorService, DeviceInfo } from 'ngx-device-detector';
 
 const SmallestSupportedBrowserVersion = {
-    Chrome: 81,
+    Chrome: 80,
     Safari: 13,
     Firefox: 68,
     Opera: 66,
-    'MS-Edge': 81,
-    'MS-Edge-Chromium': 81
+    'MS-Edge': 80,
+    'MS-Edge-Chromium': 80
 };
 
 const BrowserBlacklist = ['IE'];


### PR DESCRIPTION
Lowers the supported version for chrome and chromium based browsers to
80. Keep in mind that you can always skip the checks!