### PR TITLE
Prevent double "TOP" in agenda PDF

### DIFF
--- a/client/src/app/core/repositories/topics/topic-repository.service.ts
+++ b/client/src/app/core/repositories/topics/topic-repository.service.ts
@@ -53,16 +53,19 @@ export class TopicRepositoryService extends BaseIsAgendaItemAndListOfSpeakersCon
     }
 
     public getTitle = (titleInformation: TopicTitleInformation) => {
+        return titleInformation.title;
+    };
+
+    public getListTitle = (titleInformation: TopicTitleInformation) => {
         if (titleInformation.agenda_item_number && titleInformation.agenda_item_number()) {
             return `${titleInformation.agenda_item_number()} · ${titleInformation.title}`;
         } else {
-            return titleInformation.title;
+            return this.getTitle(titleInformation);
         }
     };
 
     public getAgendaListTitle = (titleInformation: TopicTitleInformation) => {
-        // Do not append ' (Topic)' to the title.
-        return { title: this.getTitle(titleInformation) };
+        return { title: this.getListTitle(titleInformation) };
     };
 
     public getAgendaSlideTitle = (titleInformation: TopicTitleInformation) => {

--- a/client/src/app/site/agenda/services/agenda-pdf.service.ts
+++ b/client/src/app/site/agenda/services/agenda-pdf.service.ts
@@ -87,7 +87,7 @@ export class AgendaPdfService {
                         text: nodeItem.item.item_number
                     },
                     {
-                        text: nodeItem.item.contentObject.getListTitle()
+                        text: nodeItem.item.contentObject.getTitle()
                     }
                 ]
             };

--- a/client/src/app/site/base/base-view-model-with-agenda-item.ts
+++ b/client/src/app/site/base/base-view-model-with-agenda-item.ts
@@ -68,7 +68,7 @@ export abstract class BaseViewModelWithAgendaItem<
      */
     public getProjectorTitle(): ProjectorTitle {
         const subtitle = this.item ? this.item.comment : null;
-        return { title: this.getTitle(), subtitle };
+        return { title: this.getListTitle(), subtitle };
     }
 
     /**

--- a/client/src/app/site/topics/components/topic-detail/topic-detail.component.html
+++ b/client/src/app/site/topics/components/topic-detail/topic-detail.component.html
@@ -27,7 +27,7 @@
 
 <mat-card *ngIf="topic || editTopic" [ngClass]="editTopic ? 'os-form-card' : 'os-card'">
     <div *ngIf="!editTopic">
-        <h1>{{ topic.getTitle() }}</h1>
+        <h1>{{ topic.getListTitle() }}</h1>
     </div>
     <div>
         <span *ngIf="!editTopic">


### PR DESCRIPTION
Also: changes the definition of "getTitle" and "getAgendaTitle" to be more
consistent and easier to guess. getTitle will simply return the title, while getAgendaTitle
returns the title with the agenda-prefix