### PR TITLE
Remove presence link in user multi select mode

### DIFF
--- a/client/src/app/site/users/components/user-list/user-list.component.html
+++ b/client/src/app/site/users/components/user-list/user-list.component.html
@@ -204,18 +204,6 @@
                 <span>{{ 'Add/remove groups ...' | translate }}</span>
             </button>
 
-            <div *ngIf="presenceViewConfigured">
-                <button
-                    mat-menu-item
-                    *osPerms="'users.can_manage'"
-                    [disabled]="!selectedRows.length"
-                    routerLink="presence"
-                >
-                    <mat-icon>transfer_within_a_station</mat-icon>
-                    <span>{{ 'Presence' | translate }}</span>
-                </button>
-            </div>
-
             <div *osPerms="'users.can_manage'">
                 <mat-divider></mat-divider>
 


### PR DESCRIPTION
Removes the link to "users/presence" while in the user lists multi
selection view. The link was duplicated to be present in both multi
select and single select view