### PR TITLE
Hide users presence and info columns by extradata

### DIFF
--- a/client/src/app/site/users/components/user-detail/user-detail.component.html
+++ b/client/src/app/site/users/components/user-detail/user-detail.component.html
@@ -250,8 +250,10 @@
             <h4>{{ 'Name' | translate }}</h4>
             <span class="state-icons">
                 <span>{{ user.short_name }}</span>
-                <mat-icon *ngIf="user.is_present" matTooltip="{{ 'Is present' | translate }}">check_box</mat-icon>
-                <mat-icon *ngIf="user.is_committee" matTooltip="{{ 'Is committee' | translate }}"
+                <mat-icon *ngIf="user.is_present && isAllowed('seeExtra')" matTooltip="{{ 'Is present' | translate }}"
+                    >check_box</mat-icon
+                >
+                <mat-icon *ngIf="user.is_committee && isAllowed('seeExtra')" matTooltip="{{ 'Is committee' | translate }}"
                     >account_balance</mat-icon
                 >
                 <mat-icon *ngIf="!user.is_active && isAllowed('seeExtra')" matTooltip="{{ 'Inactive' | translate }}"

--- a/client/src/app/site/users/components/user-list/user-list.component.html
+++ b/client/src/app/site/users/components/user-list/user-list.component.html
@@ -24,6 +24,7 @@
     [filterProps]="filterProps"
     [showListOfSpeakers]="false"
     [multiSelect]="isMultiSelect"
+    [restricted]="restrictedColumns"
     [hiddenInMobile]="['group', 'presence']"
     listStorageKey="user"
     [(selectedRows)]="selectedRows"

--- a/client/src/app/site/users/components/user-list/user-list.component.ts
+++ b/client/src/app/site/users/components/user-list/user-list.component.ts
@@ -16,6 +16,7 @@ import { ChoiceService } from 'app/core/ui-services/choice.service';
 import { ConfigService } from 'app/core/ui-services/config.service';
 import { CsvExportService } from 'app/core/ui-services/csv-export.service';
 import { PromptService } from 'app/core/ui-services/prompt.service';
+import { ColumnRestriction } from 'app/shared/components/list-view-table/list-view-table.component';
 import { genders } from 'app/shared/models/users/user';
 import { infoDialogSettings } from 'app/shared/utils/dialog-settings';
 import { BaseListViewComponent } from 'app/site/base/base-list-view';
@@ -133,6 +134,17 @@ export class UserListComponent extends BaseListViewComponent<ViewUser> implement
         {
             prop: 'presence',
             width: '100px'
+        }
+    ];
+
+    public restrictedColumns: ColumnRestriction[] = [
+        {
+            columnName: 'infos',
+            permission: Permission.usersCanSeeExtraData
+        },
+        {
+            columnName: 'presence',
+            permission: Permission.usersCanSeeExtraData
         }
     ];
 


### PR DESCRIPTION
In the user list, hides the "info" and "presence" column if users do not
have the "can see extra data" permission