### PR TITLE
Fix some delegate view bugs

### DIFF
--- a/client/src/app/shared/components/speaker-button/speaker-button.component.scss
+++ b/client/src/app/shared/components/speaker-button/speaker-button.component.scss
@@ -1,0 +1,8 @@
+.mat-basic-chip .mat-chip-ripple {
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    position: absolute;
+    pointer-events: none;
+}

--- a/client/src/app/shared/components/speaker-button/speaker-button.component.ts
+++ b/client/src/app/shared/components/speaker-button/speaker-button.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy } from '@angular/core';
+import { Component, Input, OnDestroy, ViewEncapsulation } from '@angular/core';
 
 import { Subscription } from 'rxjs';
 import { distinctUntilChanged } from 'rxjs/operators';
@@ -19,7 +19,9 @@ import {
  */
 @Component({
     selector: 'os-speaker-button',
-    templateUrl: './speaker-button.component.html'
+    templateUrl: './speaker-button.component.html',
+    styleUrls: ['./speaker-button.component.scss'],
+    encapsulation: ViewEncapsulation.None
 })
 export class SpeakerButtonComponent implements OnDestroy {
     @Input()

--- a/client/src/app/site/agenda/components/agenda-list/agenda-list.component.html
+++ b/client/src/app/site/agenda/components/agenda-list/agenda-list.component.html
@@ -155,22 +155,25 @@
             <mat-icon>cloud_upload</mat-icon>
             <span>{{ 'Import' | translate }}</span>
         </button>
-        <mat-divider></mat-divider>
-        <button
-            mat-menu-item
-            *osPerms="'agenda.can_manage'"
-            class="red-warning-text"
-            (click)="deleteAllSpeakersOfAllListsOfSpeakers()"
-        >
-            <mat-icon>delete</mat-icon>
-            <span>{{ 'Clear all list of speakers' | translate }}</span>
-        </button>
-        <mat-divider></mat-divider>
-        <!-- Settings -->
-        <button mat-menu-item *osPerms="'core.can_manage_config'" routerLink="/settings/agenda">
-            <mat-icon>settings</mat-icon>
-            <span>{{ 'Settings' | translate }}</span>
-        </button>
+        <div *osPerms="'agenda.can_manage'">
+            <mat-divider></mat-divider>
+            <button
+                mat-menu-item
+                class="red-warning-text"
+                (click)="deleteAllSpeakersOfAllListsOfSpeakers()"
+            >
+                <mat-icon>delete</mat-icon>
+                <span>{{ 'Clear all list of speakers' | translate }}</span>
+            </button>
+        </div>
+        <div *osPerms="'core.can_manage_config'">
+            <mat-divider></mat-divider>
+            <!-- Settings -->
+            <button mat-menu-item routerLink="/settings/agenda">
+                <mat-icon>settings</mat-icon>
+                <span>{{ 'Settings' | translate }}</span>
+            </button>
+        </div>
     </div>
 
     <div *ngIf="isMultiSelect">

--- a/client/src/app/site/assignments/components/assignment-list/assignment-list.component.html
+++ b/client/src/app/site/assignments/components/assignment-list/assignment-list.component.html
@@ -98,12 +98,14 @@
             <mat-icon>archive</mat-icon>
             <span>{{ 'Export ...' | translate }}</span>
         </button>
-        <mat-divider></mat-divider>
-        <!-- Settings -->
-        <button mat-menu-item *osPerms="'core.can_manage_config'" routerLink="/settings/elections">
-            <mat-icon>settings</mat-icon>
-            <span>{{ 'Settings' | translate }}</span>
-        </button>
+        <div *osPerms="'core.can_manage_config'">
+            <mat-divider></mat-divider>
+            <!-- Settings -->
+            <button mat-menu-item routerLink="/settings/elections">
+                <mat-icon>settings</mat-icon>
+                <span>{{ 'Settings' | translate }}</span>
+            </button>
+        </div>
     </div>
 
     <div *ngIf="isMultiSelect">

--- a/client/src/app/site/mediafiles/components/mediafile-list/mediafile-list.component.html
+++ b/client/src/app/site/mediafiles/components/mediafile-list/mediafile-list.component.html
@@ -209,7 +209,6 @@
             [object]="mediafile"
             [menuItem]="true"
         ></os-projector-button>
-        <os-speaker-button [object]="mediafile" [menuItem]="true"></os-speaker-button>
         <div *ngIf="canEdit">
             <button mat-menu-item (click)="onEditFile(mediafile)">
                 <mat-icon>edit</mat-icon>

--- a/client/src/app/site/mediafiles/components/mediafile-list/mediafile-list.component.ts
+++ b/client/src/app/site/mediafiles/components/mediafile-list/mediafile-list.component.ts
@@ -255,7 +255,6 @@ export class MediafileListComponent extends BaseListViewComponent<ViewMediafile>
      */
     public showFileMenu(file: ViewMediafile): boolean {
         return (
-            this.operator.hasPerms(Permission.agendaCanSeeListOfSpeakers) ||
             (file.isProjectable() && this.operator.hasPerms(Permission.coreCanManageProjector)) ||
             (file.isFont() && this.operator.hasPerms(Permission.coreCanManageLogosAndFonts)) ||
             (file.isImage() && this.operator.hasPerms(Permission.coreCanManageLogosAndFonts)) ||

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.html
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.html
@@ -64,7 +64,7 @@
                 <mat-icon>picture_as_pdf</mat-icon>
                 <span>{{ 'PDF' | translate }}</span>
             </button>
-            <mat-divider></mat-divider>
+            <mat-divider *osPerms="['core.can_manage_projector', 'agenda.can_manage', 'core.can_see_history']"></mat-divider>
             <!-- Project -->
             <os-projector-button
                 [object]="motion"
@@ -93,7 +93,7 @@
                     {{ 'History' | translate }}
                 </span>
             </button>
-            <mat-divider></mat-divider>
+            <mat-divider *ngIf="perms.isAllowed('update', motion) || perms.isAllowed('manage')"></mat-divider>
             <!-- Edit-->
             <button mat-menu-item (click)="setEditMode(true)" *ngIf="perms.isAllowed('update', motion)">
                 <mat-icon>edit</mat-icon>

--- a/client/src/app/site/motions/modules/motion-list/components/motion-list/motion-list.component.html
+++ b/client/src/app/site/motions/modules/motion-list/components/motion-list/motion-list.component.html
@@ -262,7 +262,8 @@
         </div>
 
         <mat-divider
-            *ngIf="categories.length || motionBlocks.length || hasAmendments() || perms.isAllowed('manage')"
+            *ngIf="(categories.length || motionBlocks.length || hasAmendments() || perms.isAllowed('manage'))
+            && (perms.isAllowed('manage') || selectedView === 'list' || operator.hasPerms('core.can_manage_config'))"
         ></mat-divider>
 
         <div *ngIf="perms.isAllowed('manage')">
@@ -313,13 +314,15 @@
             </button>
         </div>
 
-        <mat-divider></mat-divider>
+        <div *osPerms="'core.can_manage_config'">
+            <mat-divider></mat-divider>
 
-        <!-- Settings -->
-        <button mat-menu-item *osPerms="'core.can_manage_config'" routerLink="/settings/motions">
-            <mat-icon>settings</mat-icon>
-            <span>{{ 'Settings' | translate }}</span>
-        </button>
+            <!-- Settings -->
+            <button mat-menu-item routerLink="/settings/motions">
+                <mat-icon>settings</mat-icon>
+                <span>{{ 'Settings' | translate }}</span>
+            </button>
+        </div>
     </div>
     <div *ngIf="isMultiSelect">
         <button mat-menu-item (click)="selectAll()">

--- a/client/src/app/site/motions/modules/motion-list/components/motion-list/motion-list.component.ts
+++ b/client/src/app/site/motions/modules/motion-list/components/motion-list/motion-list.component.ts
@@ -7,6 +7,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { PblColumnDefinition } from '@pebula/ngrid';
 
+import { OperatorService } from 'app/core/core-services/operator.service';
 import { StorageService } from 'app/core/core-services/storage.service';
 import { CategoryRepositoryService } from 'app/core/repositories/motions/category-repository.service';
 import { MotionBlockRepositoryService } from 'app/core/repositories/motions/motion-block-repository.service';
@@ -222,7 +223,8 @@ export class MotionListComponent extends BaseListViewComponent<ViewMotion> imple
         public perms: LocalPermissionsService,
         private motionExport: MotionExportService,
         private overlayService: OverlayService,
-        public vp: ViewportService
+        public vp: ViewportService,
+        public operator: OperatorService
     ) {
         super(titleService, translate, matSnackBar, storage);
         this.canMultiSelect = true;

--- a/client/src/app/site/topics/components/topic-detail/topic-detail.component.html
+++ b/client/src/app/site/topics/components/topic-detail/topic-detail.component.html
@@ -105,9 +105,9 @@
 <mat-menu #topicExtraMenu="matMenu">
     <os-projector-button [object]="topic" [menuItem]="true"></os-projector-button>
     <os-speaker-button [object]="topic" [menuItem]="true"></os-speaker-button>
-    <div>
+    <div *osPerms="'agenda.can_manage'">
         <mat-divider></mat-divider>
-        <button *osPerms="'agenda.can_manage'" mat-menu-item class="red-warning-text" (click)="onDeleteButton()">
+        <button mat-menu-item class="red-warning-text" (click)="onDeleteButton()">
             <mat-icon>delete</mat-icon>
             <span>{{ 'Delete' | translate }}</span>
         </button>

--- a/client/src/app/site/users/components/user-list/user-list.component.html
+++ b/client/src/app/site/users/components/user-list/user-list.component.html
@@ -178,13 +178,15 @@
             <span>{{ 'Import' | translate }}</span>
         </button>
 
-        <mat-divider></mat-divider>
+        <div *osPerms="'core.can_manage_config'">
+            <mat-divider></mat-divider>
 
-        <!-- Settings -->
-        <button mat-menu-item *osPerms="'core.can_manage_config'" routerLink="/settings/participants">
-            <mat-icon>settings</mat-icon>
-            <span>{{ 'Settings' | translate }}</span>
-        </button>
+            <!-- Settings -->
+            <button mat-menu-item routerLink="/settings/participants">
+                <mat-icon>settings</mat-icon>
+                <span>{{ 'Settings' | translate }}</span>
+            </button>
+        </div>
     </div>
     <div *ngIf="isMultiSelect">
         <button mat-menu-item (click)="selectAll()">


### PR DESCRIPTION
fixes #5415 

Removes dividers and empty menus in several views.

The problem with the shifted `mat-chip` as mentioned in #5415 is the following: For some reason, the `TopicDetailComponent` doesn't load `client/node_modules/@angular/material/bundles/material-chips.umd.min.js` (and, most importantly, the there-defined styles). `AssignmentDetailComponent` (and all other components that have a list of speakers button, as far as I've verified) loads the styles and the chip is displayed correctly. I have absolutely no idea why that's the case, so I'm just copying the important styles to the speaker button. If anyone wants to look into why that's happening and find the cleaner solution, feel free.