### PR TITLE
separate stream permission from jitsi

### DIFF
--- a/client/src/app/shared/components/jitsi/jitsi.component.html
+++ b/client/src/app/shared/components/jitsi/jitsi.component.html
@@ -25,7 +25,7 @@
     </div>
 </ng-template>
 
-<div class="jitsi-integration" *ngIf="canSeeLiveStream && (enableJitsi || videoStreamUrl)">
+<div class="jitsi-integration" *ngIf="enableJitsi || (videoStreamUrl && canSeeLiveStream)">
     <!-- Audio-Conference-bar -->
     <div
         class="jitsi-bar"
@@ -47,7 +47,7 @@
                     color="accent"
                     (click)="viewStream()"
                     matTooltip="{{ 'Exit live conference and continue livestream' | translate }}"
-                    *ngIf="videoStreamUrl"
+                    *ngIf="videoStreamUrl && canSeeLiveStream"
                 >
                     <mat-icon color="warn">
                         meeting_room
@@ -78,7 +78,7 @@
                     (click)="enterConversation()"
                     matTooltip="{{ 'Enter live conference' | translate }}"
                 >
-                    <mat-icon color="">meeting_room</mat-icon>
+                    <mat-icon color="primary">meeting_room</mat-icon>
                 </button>
 
                 <mat-icon *ngIf="enableJitsi && !isAccessPermitted" class="indicator">no_meeting_room</mat-icon>
@@ -172,7 +172,7 @@
                     <os-vjs-player
                         [videoUrl]="videoStreamUrl"
                         (started)="onSteamStarted()"
-                        *ngIf="!streamActiveInAnotherTab || streamRunning"
+                        *ngIf="canSeeLiveStream && !streamActiveInAnotherTab || streamRunning"
                     ></os-vjs-player>
                     <div class="disconnected" *ngIf="streamActiveInAnotherTab && !streamRunning">
                         <span>{{ 'The livestream is already running in your OpenSlides session.' | translate }}</span>

--- a/client/src/app/shared/components/jitsi/jitsi.component.ts
+++ b/client/src/app/shared/components/jitsi/jitsi.component.ts
@@ -272,9 +272,9 @@ export class JitsiComponent extends BaseComponent implements OnInit, OnDestroy {
             .pipe(distinctUntilChanged())
             .subscribe((confState: ConferenceState) => {
                 if (confState in ConferenceState) {
-                    if (this.enableJitsi && !this.videoStreamUrl) {
+                    if (this.enableJitsi && (!this.videoStreamUrl || !this.canSeeLiveStream)) {
                         this.currentState = ConferenceState.jitsi;
-                    } else if (!this.enableJitsi && this.videoStreamUrl) {
+                    } else if (!this.enableJitsi && this.videoStreamUrl && this.canSeeLiveStream) {
                         this.currentState = ConferenceState.stream;
                     } else {
                         this.currentState = confState;
@@ -496,7 +496,7 @@ export class JitsiComponent extends BaseComponent implements OnInit, OnDestroy {
     }
 
     private setDefaultConfState(): void {
-        this.videoStreamUrl
+        this.videoStreamUrl && this.canSeeLiveStream
             ? this.setConferenceState(ConferenceState.stream)
             : this.setConferenceState(ConferenceState.jitsi);
     }


### PR DESCRIPTION
Allows jitsi conferences without stream permission,
allowing detailed separation from users who can jitsi streams and see
stream