### PR TITLE
Always show the toolbar in jitsi iframe

### DIFF
--- a/client/src/app/shared/components/jitsi/jitsi.component.ts
+++ b/client/src/app/shared/components/jitsi/jitsi.component.ts
@@ -151,11 +151,11 @@ export class JitsiComponent extends BaseViewComponent implements OnInit, OnDestr
 
     private interfaceConfigOverwrite = {
         DISABLE_VIDEO_BACKGROUND: true,
-        SHOW_JITSI_WATERMARK: true,
-        SHOW_WATERMARK_FOR_GUESTS: true,
         INVITATION_POWERED_BY: false,
         DISABLE_JOIN_LEAVE_NOTIFICATIONS: true,
-        DISABLE_PRESENCE_STATUS: true
+        DISABLE_PRESENCE_STATUS: true,
+        TOOLBAR_ALWAYS_VISIBLE: true,
+        TOOLBAR_TIMEOUT: 10000000
     };
 
     public constructor(


### PR DESCRIPTION
Try to prevent that the toolbar hides itself.

Ultimately, this does not yet hide the toolbar.
However, once the user interacted with the iFrame after the initial toolbar timeout is over (which also cannot be configured currently: see https://github.com/jitsi/jitsi-meet/issues/6667) the toolbar hides after roughly two hours, which should be an adequate compromise for the time being.

See also: https://github.com/jitsi/jitsi-meet/issues/5455