### PR TITLE
Render left pdf footer image and page number

### DIFF
--- a/client/src/app/core/pdf-services/pdf-worker.worker.ts
+++ b/client/src/app/core/pdf-services/pdf-worker.worker.ts
@@ -77,10 +77,14 @@ function addPageNumbers(data: any): void {
 
     data.doc.footer = (currentPage, pageCount) => {
         const footer = data.doc.tmpfooter;
+
+        // if the tmpfooter starts with an image, the pagenumber will be found in column 1
+        const pageNumberColIndex = !!footer.columns[0].image ? 1 : 0;
+
         // "%PAGENR% needs to be found once. After that, the same position should always update page numbers"
-        if (footer.columns[0].stack[0] === '%PAGENR%' || countPageNumbers) {
+        if (footer.columns[pageNumberColIndex]?.stack[0] === '%PAGENR%' || countPageNumbers) {
             countPageNumbers = true;
-            footer.columns[0].stack[0] = `${currentPage} / ${pageCount}`;
+            footer.columns[pageNumberColIndex].stack[0] = `${currentPage} / ${pageCount}`;
         }
         return footer;
     };


### PR DESCRIPTION
Using the web worker, the PDF page number in combination with a left
footer image could not be rendered together.

resolves #5439 