### PR TITLE
Fix duration service for non chrome browsers

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -17,6 +17,7 @@
         "build-debug": "ng build",
         "test": "ng test",
         "test-silently": "npm run test -- --watch=false --no-progress --browsers=ChromeHeadlessNoSandbox",
+        "test-live": "npm run test -- --watch=true --browsers=ChromeHeadlessNoSandbox",
         "lint-check": "ng lint",
         "lint-write": "ng lint --fix",
         "e2e": "ng e2e",

--- a/client/src/app/core/ui-services/duration.service.spec.ts
+++ b/client/src/app/core/ui-services/duration.service.spec.ts
@@ -1,18 +1,35 @@
-import { inject, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 
 import { E2EImportsModule } from 'e2e-imports.module';
 
 import { DurationService } from './duration.service';
 
 describe('DurationService', () => {
-    beforeEach(() =>
+    let service: DurationService;
+
+    beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [E2EImportsModule],
             providers: [DurationService]
-        })
-    );
+        }),
+            (service = TestBed.inject(DurationService));
+    });
 
-    it('should be created', inject([DurationService], (service: DurationService) => {
+    it('should be created', () => {
         expect(service).toBeTruthy();
-    }));
+    });
+
+    it('should return a valid duration', () => {
+        expect(service.durationToString(1, 'm')).toBe('0:01 m');
+        expect(service.durationToString(23, 'm')).toBe('0:23 m');
+        expect(service.durationToString(60, 'm')).toBe('1:00 m');
+        expect(service.durationToString(65, 'm')).toBe('1:05 m');
+        expect(service.durationToString(0, 'm')).toBe('0:00 m');
+        expect(service.durationToString(-23, 'm')).toBe('-0:23 m');
+        expect(service.durationToString(-65, 'm')).toBe('-1:05 m');
+        expect(service.durationToString(null, null)).toBe('');
+        expect(service.durationToString(NaN, 'h')).toBe('');
+        expect(service.durationToString(Infinity, 'h')).toBe('');
+        expect(service.durationToString(-Infinity, 'h')).toBe('');
+    });
 });

--- a/client/src/app/core/ui-services/duration.service.ts
+++ b/client/src/app/core/ui-services/duration.service.ts
@@ -88,11 +88,12 @@ export class DurationService {
      * @returns a more human readable time representation
      */
     public durationToString(duration: number, suffix: 'h' | 'm'): string {
-        const major = duration < 0 ? Math.ceil(duration / 60) : Math.floor(duration / 60);
-        const minor = `0${duration % 60}`.slice(-2);
-        if (!isNaN(+major) && !isNaN(+minor)) {
-            // converting the number '-0' to string results in '0'
-            return `${major === -0 ? '-' + major : major}:${minor} ${suffix}`;
+        const negative = duration < 0;
+        const major = negative ? Math.ceil(duration / 60) : Math.floor(duration / 60);
+        const minor = `0${Math.abs(duration) % 60}`.slice(-2);
+        if (!isNaN(+major) && !isNaN(+minor) && suffix) {
+            // converting the number '-0' to string results in '0', depending on the browser.
+            return `${major === 0 && negative ? '-' + Math.abs(major) : major}:${minor} ${suffix}`;
         } else {
             return '';
         }

--- a/client/src/tslint.json
+++ b/client/src/tslint.json
@@ -23,6 +23,7 @@
             "parameter",
             "object-destructuring",
             "array-destructuring"
-        ]
+        ],
+        "ban": [true, ["fdescribe"]]
     }
 }


### PR DESCRIPTION
-0, 0 and other uses of negative values in the duration service hat a
change of producing undesired results.
Added tests and fixed the function