### PR TITLE
Update nodeJS to 12.x in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN mkdir /app
 RUN apt -y update && \
   apt -y upgrade && \
   apt install -y libpq-dev curl wget xz-utils bzip2 git gcc gnupg2 make g++
-RUN curl -sL https://deb.nodesource.com/setup_11.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN apt -y install nodejs
 RUN npm install -g @angular/cli@latest
 RUN useradd -m openslides


### PR DESCRIPTION
I got the following error when trying to build the dockerfile:

```
Step 16/17 : RUN ng config -g cli.warnings.versionMismatch false &&   cd client &&   npm install
 ---> Running in 88b23532ce65
Node.js version v11.15.0 detected.
The Angular CLI requires a minimum Node.js version of either v10.13 or v12.0.                                                     

Please update your Node.js version or visit https://nodejs.org/ for additional instructions.                                      

The command '/bin/sh -c ng config -g cli.warnings.versionMismatch false &&   cd client &&   npm install' returned a non-zero code: 3
```

An easy fix seems to be to bump the nodeJS version to 12.x.