### PR TITLE
Use a-tag for external link

### DIFF
--- a/SETTINGS.rst
+++ b/SETTINGS.rst
@@ -73,8 +73,7 @@ To enable the audio conference with Jitsi Meet, you have to set the following va
 
 - `JITSI_DOMAIN`: must contain an url to a Jitsi server
 - `JITSI_ROOM_NAME`: the name of the room that should be used
-- `JITSI_PASSWORD`: (optional) the password of the room. Will be
-applied automatically from the settings.
+- `JITSI_ROOM_PASSWORD`: (optional) the password of the room. Will be applied automatically from the settings.
 
 
 Logging

--- a/client/src/app/shared/components/jitsi/jitsi.component.html
+++ b/client/src/app/shared/components/jitsi/jitsi.component.html
@@ -3,15 +3,17 @@
     <mat-card class="jitsi-fake-dialog">
         <div class="jitsi-iframe-wrapper" #jitsi></div>
         <div class="jitsi-dialog-actions">
-            <button
+            <a
                 type="button"
                 mat-button
                 color="primary"
-                (click)="openExternal()"
                 matTooltip="{{ 'Open Jitsi in new tab' | translate }}"
+                target="_blank"
+                (click)="stopJitsi()"
+                [href]="jitsiMeetUrl"
             >
                 <mat-icon>open_in_new</mat-icon>
-            </button>
+            </a>
 
             <button type="button" mat-button color="primary" (click)="hideJitsiDialog()">
                 <span>{{ 'Minimize' | translate }}</span>

--- a/client/src/app/shared/components/jitsi/jitsi.component.ts
+++ b/client/src/app/shared/components/jitsi/jitsi.component.ts
@@ -128,6 +128,10 @@ export class JitsiComponent extends BaseViewComponent implements OnInit, OnDestr
         );
     }
 
+    public get jitsiMeetUrl(): string {
+        return `https://${this.jitsiDomain}/${this.roomName}`;
+    }
+
     /**
      * The conference state, to determine if the user consumes the stream or can
      * contribute to jitsi
@@ -440,10 +444,6 @@ export class JitsiComponent extends BaseViewComponent implements OnInit, OnDestr
         this.showJitsiWindow = !this.showJitsiWindow;
     }
 
-    private getJitsiMeetUrl(): string {
-        return `https://${this.jitsiDomain}/${this.roomName}`;
-    }
-
     public toggleConferenceDialog(): void {
         if (this.isJitsiDialogOpen) {
             this.hideJitsiDialog();
@@ -464,11 +464,6 @@ export class JitsiComponent extends BaseViewComponent implements OnInit, OnDestr
     public async viewStream(): Promise<void> {
         this.stopJitsi();
         this.setConferenceState(ConferenceState.stream);
-    }
-
-    public openExternal(): void {
-        this.stopJitsi();
-        window.open(this.getJitsiMeetUrl(), '_blank');
     }
 
     public onSteamStarted(): void {


### PR DESCRIPTION
Allows to left-click, right-click and middle-click the "open external"
button. Left clicking will disconnect from the current jitsi connection
in OpenSlides. Useful for tests and power using, such as multiple jitsi
connections or easier copying the link.