### PR TITLE
Add prefix to topic list of speaker slide

### DIFF
--- a/client/src/app/core/repositories/topics/topic-repository.service.ts
+++ b/client/src/app/core/repositories/topics/topic-repository.service.ts
@@ -69,8 +69,7 @@ export class TopicRepositoryService extends BaseIsAgendaItemAndListOfSpeakersCon
     };
 
     public getAgendaSlideTitle = (titleInformation: TopicTitleInformation) => {
-        // Do not append ' (Topic)' to the title.
-        return this.getTitle(titleInformation);
+        return this.getAgendaListTitle(titleInformation).title;
     };
 
     public getVerboseName = (plural: boolean = false) => {

--- a/client/src/app/site/agenda/components/list-of-speakers/list-of-speakers.component.html
+++ b/client/src/app/site/agenda/components/list-of-speakers/list-of-speakers.component.html
@@ -8,9 +8,8 @@
     <!-- Title -->
     <div class="title-slot">
         <h2>
-            <span *ngIf="!isCurrentListOfSpeakers && !isSortMode">{{ 'List of speakers' | translate }}</span>
-            <span *ngIf="isCurrentListOfSpeakers && !isSortMode">{{ 'Current list of speakers' | translate }}</span>
-            <span *ngIf="isSortMode">{{ 'Sort list of speakers' | translate }}</span>
+            <span *ngIf="!isCurrentListOfSpeakers">{{ 'List of speakers' | translate }}</span>
+            <span *ngIf="isCurrentListOfSpeakers">{{ 'Current list of speakers' | translate }}</span>
         </h2>
     </div>
     <div class="menu-slot" *osPerms="['agenda.can_manage_list_of_speakers', 'core.can_manage_projector']">


### PR DESCRIPTION
The topics prefix (number) was missing in the list of speakers slide
Also, removes "sort list of speakers" title in LOS