### PR TITLE
Fix list views for safari

### DIFF
--- a/client/src/app/shared/components/list-view-table/list-view-table.component.scss
+++ b/client/src/app/shared/components/list-view-table/list-view-table.component.scss
@@ -19,6 +19,7 @@ $pbl-height: var(--pbl-height);
 
     .vscroll-list-view {
         flex: 1 1 auto;
+        height: 100%;
 
         .projector-button {
             margin: auto;


### PR DESCRIPTION
Usually useless height information fixes rendering issues on safari
browsers

resolves: #5459 