### PR TITLE
Ignore venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ personal_data
 tests
 .launch/
 .venv/
+.virtualenv/
 .vscode/
 package-lock.json
 server/


### PR DESCRIPTION
.virtualenv should be ignored since it might still exist from openslides
3.