### PR TITLE
Detect if the parent motion was deleted

### DIFF
--- a/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.html
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.html
@@ -878,9 +878,10 @@
         <!-- If the array exists, we do not have an error -->
         <div *ngIf="motion.diffLines">
             <div class="alert alert-info" *ngIf="motion.diffLines.length === 0">
-                <span>{{ 'No changes at the text.' | translate }}</span>
+                <i *ngIf="motion.parent">{{ 'No changes at the text.' | translate }}</i>
+                <i *ngIf="!motion.parent">{{ 'The parent motion was deleted' | translate }}</i>
             </div>
-            <ng-container *ngIf="!isRecoMode(ChangeRecoMode.Diff) && !isFinalEdit">
+            <ng-container *ngIf="motion.parent && !isRecoMode(ChangeRecoMode.Diff) && !isFinalEdit">
                 <div
                     *ngFor="let paragraph of getAmendmentParagraphs()"
                     class="motion-text motion-text-diff amendment-view"


### PR DESCRIPTION
Fixes an error where the motion detail page would not open if the parent
motion to an amendment was deleted.
Show a warning if the parent motion to an amendment is missing