### PR TITLE
Smaller timeouts for HaProxy

### DIFF
--- a/haproxy/src/haproxy.cfg
+++ b/haproxy/src/haproxy.cfg
@@ -3,13 +3,14 @@ global
 
 defaults
     option http-use-htx
-    timeout connect 10s
+    timeout connect 3s
     timeout client 10s
     timeout client-fin 10s
     timeout server 10s
     timeout server-fin 10s
-    timeout check 10s
+    timeout check 2s
     timeout tunnel 10s
+    timeout queue 2s
     log global
     option httplog
 


### PR DESCRIPTION
This is needed to quickly detect the downage from a service. With these timeouts 12 seonds are needed for HaProxy to return an initial 503. All other 503 are instance since the service is not detected up again.