### PR TITLE
Performance tweak for creating line numbers

### DIFF
--- a/client/src/app/core/ui-services/diff.service.ts
+++ b/client/src/app/core/ui-services/diff.service.ts
@@ -470,15 +470,9 @@ export class DiffService {
      * @return {DocumentFragment}
      */
     public htmlToFragment(html: string): DocumentFragment {
-        const fragment = document.createDocumentFragment(),
-            div = document.createElement('DIV');
-        div.innerHTML = html;
-        while (div.childElementCount) {
-            const child = div.childNodes[0];
-            div.removeChild(child);
-            fragment.appendChild(child);
-        }
-        return fragment;
+        const template = document.createElement('template');
+        template.innerHTML = html;
+        return template.content;
     }
 
     /**

--- a/client/src/app/core/ui-services/linenumbering.service.spec.ts
+++ b/client/src/app/core/ui-services/linenumbering.service.spec.ts
@@ -6,20 +6,20 @@ describe('LinenumberingService', () => {
     const brMarkup = (no: number): string => {
             return (
                 '<br class="os-line-break">' +
-                '<span class="os-line-number line-number-' +
+                '<span contenteditable="false" class="os-line-number line-number-' +
                 no +
                 '" data-line-number="' +
                 no +
-                '" contenteditable="false">&nbsp;</span>'
+                '">&nbsp;</span>'
             );
         },
         noMarkup = (no: number): string => {
             return (
-                '<span class="os-line-number line-number-' +
+                '<span contenteditable="false" class="os-line-number line-number-' +
                 no +
                 '" data-line-number="' +
                 no +
-                '" contenteditable="false">&nbsp;</span>'
+                '">&nbsp;</span>'
             );
         },
         longstr = (length: number): string => {

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.html
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.html
@@ -538,7 +538,7 @@
                     mat-button
                     [matMenuTriggerFor]="changeRecoMenu"
                     *ngIf="
-                        motion && ((allChangingObjects && allChangingObjects.length) || motion.modified_final_version)
+                        motion && (hasChangingObjects() || motion.modified_final_version)
                     "
                 >
                     <mat-icon>rate_review</mat-icon>
@@ -1009,7 +1009,7 @@
         mat-menu-item
         (click)="setChangeRecoMode(ChangeRecoMode.Changed)"
         [ngClass]="{ selected: crMode === ChangeRecoMode.Changed }"
-        *ngIf="allChangingObjects && allChangingObjects.length"
+        *ngIf="hasChangingObjects()"
     >
         {{ 'Changed version' | translate }}
     </button>
@@ -1017,7 +1017,7 @@
         mat-menu-item
         (click)="setChangeRecoMode(ChangeRecoMode.Diff)"
         [ngClass]="{ selected: crMode === ChangeRecoMode.Diff }"
-        *ngIf="allChangingObjects && allChangingObjects.length"
+        *ngIf="hasChangingObjects()"
     >
         {{ 'Diff version' | translate }}
     </button>
@@ -1025,7 +1025,7 @@
         mat-menu-item
         (click)="setChangeRecoMode(ChangeRecoMode.Final)"
         [ngClass]="{ selected: crMode === ChangeRecoMode.Final }"
-        *ngIf="motion && !motion.isParagraphBasedAmendment() && allChangingObjects && allChangingObjects.length"
+        *ngIf="motion && !motion.isParagraphBasedAmendment() && hasChangingObjects()"
     >
         {{ 'Final version' | translate }}
     </button>


### PR DESCRIPTION
Main points:
- motion-details: the refactoring tries to avoid calculating the full list of changing objects (especially of paragraph-based amendments) when it's not actually needed. Hence a getter-function getAllChangingObjectsSorted is used that calculates it on demand, with the subscriptions on amendments/changerecos only setting it to null and triggering the change detection.
- getLineNumberRange: Regular-expression-based detection of line numbers is less elegant, but a lot more efficient than converting it to DOM first.
- htmlToFragment: using a template and innerHTML instead of the previous iteration over the child elements is notably more efficient
- lineNumberToClone: this is a rather minor improvement; cloneNode seems to be more efficient than setting the attributes over and over again.