### PR TITLE
Hide motion preamble in final state

### DIFF
--- a/client/src/app/site/motions/models/view-motion.ts
+++ b/client/src/app/site/motions/models/view-motion.ts
@@ -142,6 +142,10 @@ export class ViewMotion extends BaseViewModelWithAgendaItemAndListOfSpeakers<Mot
         return this.speakerAmount > 0;
     }
 
+    public get showPreamble(): boolean {
+        return !this.state?.isFinalState ?? true;
+    }
+
     /**
      * Translate the state's css class into a color
      *

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-detail-diff/motion-detail-diff.component.html
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-detail-diff/motion-detail-diff.component.html
@@ -40,7 +40,7 @@
     <div *ngIf="changes.length === 0" class="no-changes">{{ 'No change recommendations yet' | translate }}</div>
 </section>
 
-<span class="text-prefix-label">{{ preamble | translate }}</span>
+<span class="text-prefix-label" *ngIf="showPreamble">{{ preamble | translate }}</span>
 
 <!-- The actual diff view -->
 <div class="motion-text-with-diffs">
@@ -126,7 +126,7 @@
             <div class="status-row" *ngIf="isChangeRecommendation(change) && change.isRejected()">
                 <i class="grey">{{ 'Rejected' | translate }}</i>
             </div>
-            
+
             <!-- If it's an amendment, only accepted ones will be passed to this component
                  by default (== !showAllAmendments). In this case, don't show the prefix.
                  However, if showAllAmendments === true, the prefix should be shown alwayes,

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-detail-diff/motion-detail-diff.component.ts
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-detail-diff/motion-detail-diff.component.ts
@@ -85,6 +85,10 @@ export class MotionDetailDiffComponent extends BaseViewComponent implements Afte
 
     public preamble: string;
 
+    public get showPreamble(): boolean {
+        return this.motion.showPreamble;
+    }
+
     /**
      * @param title
      * @param translate

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.html
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.html
@@ -667,7 +667,7 @@
         </div>
 
         <!-- Text (hide preamble, if diff mode. The preample is included in the motion-detail-diff component) -->
-        <span *ngIf="!isRecoMode(ChangeRecoMode.Diff)" class="text-prefix-label">{{ preamble | translate }}</span>
+        <span *ngIf="showPreamble && !isRecoMode(ChangeRecoMode.Diff)" class="text-prefix-label">{{ preamble | translate }}</span>
 
         <!-- Regular motions or traditional amendments -->
         <ng-container *ngIf="!editMotion && !motion.isStatuteAmendment() && !motion.isParagraphBasedAmendment()">

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.ts
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.ts
@@ -167,6 +167,10 @@ export class MotionDetailComponent extends BaseViewComponent implements OnInit, 
         );
     }
 
+    public get showPreamble(): boolean {
+        return this.motion.showPreamble;
+    }
+
     /**
      * Saves the target motion. Accessed via the getter and setter.
      */

--- a/client/src/app/site/motions/services/motion-pdf.service.ts
+++ b/client/src/app/site/motions/services/motion-pdf.service.ts
@@ -132,8 +132,10 @@ export class MotionPdfService {
         }
 
         if (!contentToExport || contentToExport.includes('text')) {
-            const preamble = this.createPreamble(motion);
-            motionPdfContent.push(preamble);
+            if (motion.showPreamble) {
+                const preamble = this.createPreamble(motion);
+                motionPdfContent.push(preamble);
+            }
             const text = this.createText(motion, lineLength, lnMode, crMode);
             motionPdfContent.push(text);
         }


### PR DESCRIPTION
If a motion is in final state, the preamble does not get shown in detail
view and PDF