### PR TITLE
Allow motion of non existing change recos

### DIFF
--- a/client/src/app/site/motions/models/view-motion.ts
+++ b/client/src/app/site/motions/models/view-motion.ts
@@ -9,6 +9,7 @@ import { TitleInformationWithAgendaItem } from 'app/site/base/base-view-model-wi
 import { BaseViewModelWithAgendaItemAndListOfSpeakers } from 'app/site/base/base-view-model-with-agenda-item-and-list-of-speakers';
 import { ProjectorElementBuildDeskriptor } from 'app/site/base/projectable';
 import { Searchable } from 'app/site/base/searchable';
+import { SlideOptions } from 'app/site/base/slide-options';
 import { ViewMediafile } from 'app/site/mediafiles/models/view-mediafile';
 import { ViewTag } from 'app/site/tags/models/view-tag';
 import { ViewUser } from 'app/site/users/models/view-user';
@@ -315,12 +316,8 @@ export class ViewMotion extends BaseViewModelWithAgendaItemAndListOfSpeakers<Mot
     }
 
     public getSlide(configService: ConfigService): ProjectorElementBuildDeskriptor {
-        const slideOptions = [];
-        if (
-            (this.changeRecommendations && this.changeRecommendations.length) ||
-            (this.amendments && this.amendments.length)
-        ) {
-            slideOptions.push({
+        const slideOptions: SlideOptions = [
+            {
                 key: 'mode',
                 displayName: _('Which version?'),
                 default: configService.instant('motions_recommendation_text_mode'),
@@ -330,8 +327,8 @@ export class ViewMotion extends BaseViewModelWithAgendaItemAndListOfSpeakers<Mot
                     { value: 'diff', displayName: 'Diff version' },
                     { value: 'agreed', displayName: 'Final version' }
                 ]
-            });
-        }
+            }
+        ];
 
         return {
             getBasicProjectorElement: options => ({


### PR DESCRIPTION
Allows to project any version of the motions, event if they do not yet
exist.
Gives the user more control about the content they want to project.
Currently, if a motion has no logical changed version, they would
always project the original version which does not automatically
update if a changed version exists. This behaviour would require the
user to update their current projection