### PR TITLE
Hide group selector without manage rights

### DIFF
--- a/client/src/app/site/users/components/user-detail/user-detail.component.html
+++ b/client/src/app/site/users/components/user-detail/user-detail.component.html
@@ -154,7 +154,7 @@
             </mat-form-field>
         </div>
 
-        <div>
+        <div *osPerms="permission.usersCanManage">
             <!-- Groups -->
             <mat-form-field>
                 <os-search-value-selector
@@ -253,7 +253,9 @@
                 <mat-icon *ngIf="user.is_present && isAllowed('seeName')" matTooltip="{{ 'Is present' | translate }}"
                     >check_box</mat-icon
                 >
-                <mat-icon *ngIf="user.is_committee && isAllowed('seeName')" matTooltip="{{ 'Is committee' | translate }}"
+                <mat-icon
+                    *ngIf="user.is_committee && isAllowed('seeName')"
+                    matTooltip="{{ 'Is committee' | translate }}"
                     >account_balance</mat-icon
                 >
                 <mat-icon *ngIf="!user.is_active && isAllowed('seeExtra')" matTooltip="{{ 'Inactive' | translate }}"


### PR DESCRIPTION
Fixes a bug where the user group selector was shown even though the user
had not permission to manage the users