### PR TITLE
Add "supporter" to motion export dialog

### DIFF
--- a/client/src/app/site/motions/motions.constants.ts
+++ b/client/src/app/site/motions/motions.constants.ts
@@ -21,6 +21,7 @@ export const PERSONAL_NOTE_ID = -1;
  */
 export type InfoToExport =
     | 'submitters'
+    | 'supporters'
     | 'state'
     | 'recommendation'
     | 'category'
@@ -99,6 +100,7 @@ export enum MotionEditNotificationType {
 export const motionImportExportHeaderOrder: string[] = [
     'identifier',
     'submitters',
+    'supporters',
     'title',
     'text',
     'reason',

--- a/client/src/app/site/motions/services/motion-pdf.service.ts
+++ b/client/src/app/site/motions/services/motion-pdf.service.ts
@@ -245,23 +245,25 @@ export class MotionPdfService {
         }
 
         // supporters
-        const minSupporters = this.configService.instant<number>('motions_min_supporters');
-        if (minSupporters && motion.supporters.length > 0) {
-            const supporters = motion.supporters
-                .map(supporter => {
-                    return supporter.full_name;
-                })
-                .join(', ');
+        if (!infoToExport || infoToExport.includes('supporters')) {
+            const minSupporters = this.configService.instant<number>('motions_min_supporters');
+            if (!!minSupporters && motion.supporters.length > 0) {
+                const supporters = motion.supporters
+                    .map(supporter => {
+                        return supporter.full_name;
+                    })
+                    .join(', ');
 
-            metaTableBody.push([
-                {
-                    text: `${this.translate.instant('Supporters')}:`,
-                    style: 'boldText'
-                },
-                {
-                    text: supporters
-                }
-            ]);
+                metaTableBody.push([
+                    {
+                        text: `${this.translate.instant('Supporters')}:`,
+                        style: 'boldText'
+                    },
+                    {
+                        text: supporters
+                    }
+                ]);
+            }
         }
 
         // state


### PR DESCRIPTION
Allows PDF, CSV and XLSX to export the supporter manually