### PR TITLE
Add a transaction to speaker handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ server/.venv
 # OS4-Submodules
 /openslides-*/
 /haproxy/
+/docker/keys/
 # Plugin development
 openslides_*
 # Old OS3 stuff

--- a/server/openslides/agenda/views.py
+++ b/server/openslides/agenda/views.py
@@ -306,6 +306,7 @@ class ListOfSpeakersViewSet(
         return result
 
     @detail_route(methods=["POST", "PATCH", "DELETE"])
+    @transaction.atomic
     def manage_speaker(self, request, pk=None):
         """
         Special view endpoint to add users to the list of speakers or remove

--- a/server/tests/unit/agenda/test_views.py
+++ b/server/tests/unit/agenda/test_views.py
@@ -1,6 +1,8 @@
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from openslides.agenda.views import ListOfSpeakersViewSet
 
 
@@ -19,6 +21,7 @@ class ListOfSpeakersViewSetManageSpeaker(TestCase):
     @patch("openslides.agenda.views.inform_changed_data")
     @patch("openslides.agenda.views.has_perm")
     @patch("openslides.agenda.views.Speaker")
+    @pytest.mark.django_db(transaction=False)
     def test_add_oneself_as_speaker(self, mock_speaker, mock_has_perm, mock_icd):
         self.request.method = "POST"
         self.request.user = 1
@@ -36,6 +39,7 @@ class ListOfSpeakersViewSetManageSpeaker(TestCase):
     @patch("openslides.agenda.views.has_perm")
     @patch("openslides.agenda.views.get_user_model")
     @patch("openslides.agenda.views.Speaker")
+    @pytest.mark.django_db(transaction=False)
     def test_add_someone_else_as_speaker(
         self, mock_speaker, mock_get_user_model, mock_has_perm, mock_icd
     ):
@@ -56,6 +60,7 @@ class ListOfSpeakersViewSetManageSpeaker(TestCase):
         )
 
     @patch("openslides.agenda.views.Speaker")
+    @pytest.mark.django_db(transaction=False)
     def test_remove_oneself(self, mock_speaker):
         self.request.method = "DELETE"
         self.request.data = {}
@@ -66,6 +71,7 @@ class ListOfSpeakersViewSetManageSpeaker(TestCase):
     @patch("openslides.agenda.views.inform_changed_data")
     @patch("openslides.agenda.views.has_perm")
     @patch("openslides.agenda.views.Speaker")
+    @pytest.mark.django_db(transaction=False)
     def test_remove_someone_else(
         self, mock_speaker, mock_has_perm, mock_inform_changed_data
     ):


### PR DESCRIPTION
to prevent adding a users multiple times to the waiting queue of a list of speakers