### PR TITLE
Added missing client part for cookie checking on login

### DIFF
--- a/client/src/app/core/core-services/auth.service.ts
+++ b/client/src/app/core/core-services/auth.service.ts
@@ -10,6 +10,12 @@ import { HttpService } from './http.service';
 import { OpenSlidesService } from './openslides.service';
 import { StorageService } from './storage.service';
 
+interface LoginData {
+    username: string;
+    password: string;
+    cookies?: boolean;
+}
+
 /**
  * Authenticates an OpenSlides user with username and password
  */
@@ -47,11 +53,14 @@ export class AuthService {
         earlySuccessCallback: () => void
     ): Promise<void> {
         if (authType === 'default') {
-            const user = {
+            const data: LoginData = {
                 username: username,
                 password: password
             };
-            const response = await this.http.post<WhoAmI>(environment.urlPrefix + '/users/login/', user);
+            if (!navigator.cookieEnabled) {
+                data.cookies = false;
+            }
+            const response = await this.http.post<WhoAmI>(environment.urlPrefix + '/users/login/', data);
             earlySuccessCallback();
             await this.OpenSlides.shutdown();
             await this.operator.setWhoAmI(response);


### PR DESCRIPTION
closes #5538

Done by using `navigator.cookieEnabled`, which might not catch every usecase due to implementation differences, but should be good enough. Note: This is a leftover from 2.3.x: It is still present in the server, but wasn't in the client: https://github.com/OpenSlides/OpenSlides/blob/stable/2.3.x/openslides/users/static/js/users/site.js#L1749