### PR TITLE
Add amendment projection defaults

### DIFF
--- a/client/src/app/site/motions/models/view-motion.ts
+++ b/client/src/app/site/motions/models/view-motion.ts
@@ -334,6 +334,13 @@ export class ViewMotion extends BaseViewModelWithAgendaItemAndListOfSpeakers<Mot
             }
         ];
 
+        let projectionDefaultName: string;
+        if (this.isParagraphBasedAmendment()) {
+            projectionDefaultName = 'amendments';
+        } else {
+            projectionDefaultName = 'motions';
+        }
+
         return {
             getBasicProjectorElement: options => ({
                 name: Motion.COLLECTIONSTRING,
@@ -341,7 +348,7 @@ export class ViewMotion extends BaseViewModelWithAgendaItemAndListOfSpeakers<Mot
                 getIdentifiers: () => ['name', 'id']
             }),
             slideOptions: slideOptions,
-            projectionDefaultName: 'motions',
+            projectionDefaultName: projectionDefaultName,
             getDialogTitle: this.getAgendaSlideTitle
         };
     }

--- a/server/openslides/core/migrations/0034_amendment_projection_defaults.py
+++ b/server/openslides/core/migrations/0034_amendment_projection_defaults.py
@@ -1,0 +1,32 @@
+from django.db import migrations
+
+
+def add_amendment_projection_defaults(apps, schema_editor):
+    """
+    Adds projectiondefaults for messages and countdowns.
+    """
+    Projector = apps.get_model("core", "Projector")
+    ProjectionDefault = apps.get_model("core", "ProjectionDefault")
+    default_projector = Projector.objects.order_by("pk").first()
+
+    projectiondefaults = []
+
+    projectiondefaults.append(
+        ProjectionDefault(
+            name="amendments", display_name="Amendments", projector=default_projector
+        )
+    )
+
+    # Create all new projectiondefaults
+    ProjectionDefault.objects.bulk_create(projectiondefaults)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0033_live_stream_permission"),
+    ]
+
+    operations = [
+        migrations.RunPython(add_amendment_projection_defaults),
+    ]


### PR DESCRIPTION
Creates projection defaults for (paragraph based) amendments.
Adds a migration to add amendments as projection defaults.

Will only work for paragraph based amendments, other amendments will
still be considered motions