### PR TITLE
Add vjs live steam poster url as config

### DIFF
--- a/client/src/app/shared/components/vjs-player/vjs-player.component.scss
+++ b/client/src/app/shared/components/vjs-player/vjs-player.component.scss
@@ -4,6 +4,20 @@
     .video-js {
         margin: auto;
 
+        // we keep the button for now
+        // .vjs-big-play-button {
+        //     left: 0;
+        //     top: 0;
+        //     width: 100%;
+        //     height: 100%;
+        //     border: 0;
+        //     border-radius: 0;
+        //     background-color: rgba(0, 0, 0, 0);
+        //     .vjs-icon-placeholder {
+        //         display: none !important;
+        //     }
+        // }
+
         .vjs-control-bar {
             .vjs-subs-caps-button {
                 display: none !important;

--- a/client/src/app/shared/components/vjs-player/vjs-player.component.ts
+++ b/client/src/app/shared/components/vjs-player/vjs-player.component.ts
@@ -12,6 +12,8 @@ import {
 
 import videojs from 'video.js';
 
+import { ConfigService } from 'app/core/ui-services/config.service';
+
 interface VideoSource {
     src: string;
     type: MimeType;
@@ -56,14 +58,21 @@ export class VjsPlayerComponent implements OnInit, OnDestroy {
         };
     }
 
-    public constructor() {}
+    private posterUrl: string;
+
+    public constructor(config: ConfigService) {
+        config.get<string>('general_system_stream_poster').subscribe(posterUrl => {
+            this.posterUrl = posterUrl;
+        });
+    }
 
     public async ngOnInit(): Promise<void> {
         this.player = videojs(this.videoPlayer.nativeElement, {
             textTrackSettings: false,
             fluid: true,
             autoplay: 'any',
-            liveui: true
+            liveui: true,
+            poster: this.posterUrl
         });
         this.playVideo();
     }

--- a/server/openslides/core/config_variables.py
+++ b/server/openslides/core/config_variables.py
@@ -130,6 +130,15 @@ def get_config_variables():
         subgroup="Live conference",
     )
 
+    yield ConfigVariable(
+        name="general_system_stream_poster",
+        default_value="",
+        label="Livestream poster image url",
+        help_text="Shows if livestream is not started. Recommended image format: 500x281px, PNG or JPG",
+        weight=144,
+        subgroup="Live conference",
+    )
+
     # General System
 
     yield ConfigVariable(


### PR DESCRIPTION
Adds a new config to show a poster url in the live stream view