### PR TITLE
Add package lock to dockerfile

### DIFF
--- a/client/docker/Dockerfile
+++ b/client/docker/Dockerfile
@@ -11,10 +11,11 @@ RUN ng config -g cli.warnings.versionMismatch false
 
 USER openslides
 COPY package.json .
+COPY package-lock.json .
 RUN npm ci
 COPY browserslist *.json ./
 COPY src ./src
-RUN npm run build
+RUN npm run build-to-dir /build/app/static
 
 COPY docker/client-version.txt static/
 

--- a/client/package.json
+++ b/client/package.json
@@ -13,6 +13,7 @@
         "start": "ng serve --proxy-config proxy.conf.json --host=0.0.0.0",
         "start-es5": "ng serve --proxy-config proxy.conf.json --host=0.0.0.0 --configuration es5",
         "build": "ng build --prod",
+        "build-to-dir": "npm run build -- --output-path",
         "postinstall": "ngcc",
         "build-debug": "ng build",
         "test": "ng test",


### PR DESCRIPTION
Adds the package-lock file to the clients dockerfile, so npm-ci works