### PR TITLE
Update saml-setup.sh

### DIFF
--- a/server/docker/saml-setup.sh
+++ b/server/docker/saml-setup.sh
@@ -4,7 +4,7 @@ if [[ "$ENABLE_SAML" = True ]]; then
   for i in /run/secrets/saml_{cert,key,config}; do
     [[ -f "$i" ]] || { echo "ERROR: $i not found!"; exit 3; }
   done
-  ln -s /run/secrets/saml_cert   /app/personal_data/var/certs/sp.crt
-  ln -s /run/secrets/saml_key    /app/personal_data/var/certs/sp.key
-  ln -s /run/secrets/saml_config /app/personal_data/var/saml_settings.json
+  test -L /app/personal_data/var/certs/sp.crt || { ln -s /run/secrets/saml_cert /app/personal_data/var/certs/sp.crt; }
+  test -L /app/personal_data/var/certs/sp.key || { ln -s /run/secrets/saml_key /app/personal_data/var/certs/sp.key; }
+  test -L /app/personal_data/var/saml_settings.json || { ln -s /run/secrets/saml_config /app/personal_data/var/saml_settings.json; }
 fi


### PR DESCRIPTION
If the server container is restarted e.g. after OS reboot, the saml-setup.sh script fails because the symbolic links to SP Crt / Key / Settings already exist.