### PR TITLE
Fix assignment polldata discovery in percent pipe

### DIFF
--- a/client/src/app/shared/components/assignment-poll-detail-content/assignment-poll-detail-content.component.html
+++ b/client/src/app/shared/components/assignment-poll-detail-content/assignment-poll-detail-content.component.html
@@ -30,7 +30,7 @@
                     <div class="single-result" [ngClass]="getVoteClass(vote)" *ngIf="vote && voteFitsMethod(vote)">
                         <span>
                             <span *ngIf="vote.showPercent">
-                                {{ vote.amount | pollPercentBase: poll }}
+                                {{ vote.amount | pollPercentBase: poll:'assignment' }}
                             </span>
                             {{ vote.amount | parsePollNumber }}
                         </span>

--- a/client/src/app/shared/components/motion-poll-detail-content/motion-poll-detail-content.component.html
+++ b/client/src/app/shared/components/motion-poll-detail-content/motion-poll-detail-content.component.html
@@ -20,7 +20,7 @@
                 <!-- Percent numbers -->
                 <td class="result-cell-definition">
                     <span *ngIf="row.value[0].showPercent">
-                        {{ row.value[0].amount | pollPercentBase: poll }}
+                        {{ row.value[0].amount | pollPercentBase: poll:'motion' }}
                     </span>
                 </td>
 

--- a/client/src/app/shared/pipes/poll-percent-base.pipe.ts
+++ b/client/src/app/shared/pipes/poll-percent-base.pipe.ts
@@ -14,7 +14,7 @@ import { PollData } from 'app/site/polls/services/poll.service';
  *
  * @example
  * ```html
- * <span> {{ voteYes | pollPercentBase: poll }} </span>
+ * <span> {{ voteYes | pollPercentBase: poll:'assignment' }} </span>
  * ```
  */
 @Pipe({
@@ -26,10 +26,16 @@ export class PollPercentBasePipe implements PipeTransform {
         private motionPollService: MotionPollService
     ) {}
 
-    public transform(value: number, poll: PollData): string | null {
+    public transform(value: number, poll: PollData, type: 'motion' | 'assignment'): string | null {
         // logic handles over the pollService to avoid circular dependencies
         let voteValueInPercent: string;
-        if ((<any>poll).assignment) {
+
+        /**
+         * PollData has not enough explicit information to simply guess the type correctly.
+         * This should not be a problem when PollData is a real model or a real type. Since
+         * we cannot expect the projector to work with real types for now, we need to provice the type
+         */
+        if (type === 'assignment') {
             voteValueInPercent = this.assignmentPollService.getVoteValueInPercent(value, poll);
         } else {
             voteValueInPercent = this.motionPollService.getVoteValueInPercent(value, poll);

--- a/client/src/app/site/assignments/services/assignment-pdf.service.ts
+++ b/client/src/app/site/assignments/services/assignment-pdf.service.ts
@@ -232,7 +232,7 @@ export class AssignmentPdfService {
             .map((singleResult: VotingResult) => {
                 const votingKey = this.translate.instant(this.pollKeyVerbose.transform(singleResult.vote));
                 const resultValue = this.parsePollNumber.transform(singleResult.amount);
-                const resultInPercent = this.pollPercentBase.transform(singleResult.amount, poll);
+                const resultInPercent = this.pollPercentBase.transform(singleResult.amount, poll, 'assignment');
                 return `${votingKey}${!!votingKey ? ': ' : ''}${resultValue} ${
                     singleResult.showPercent && resultInPercent ? resultInPercent : ''
                 }`;

--- a/client/src/app/site/motions/modules/motion-poll/motion-poll/motion-poll.component.html
+++ b/client/src/app/site/motions/modules/motion-poll/motion-poll/motion-poll.component.html
@@ -94,7 +94,7 @@
                 <os-icon-container [icon]="row.value[0].icon" size="large">
                     {{ row.value[0].amount | parsePollNumber }}
                     <span *ngIf="row.value[0].showPercent">
-                        {{ row.value[0].amount | pollPercentBase: poll }}
+                        {{ row.value[0].amount | pollPercentBase: poll:'motion' }}
                     </span>
                 </os-icon-container>
             </div>


### PR DESCRIPTION
Fixes an issue where projector data was not delivering enough
information to guess if a poll data belongs to an assignment or a
motion.
This error resulted that the percent base pipe used the percent bases
for motions to calculate for assignments

fixes #5585