### PR TITLE
Add "represented by" to single votes table

### DIFF
--- a/client/src/app/shared/components/list-view-table/list-view-table.component.ts
+++ b/client/src/app/shared/components/list-view-table/list-view-table.component.ts
@@ -649,6 +649,8 @@ export class ListViewTableComponent<V extends BaseViewModel | BaseViewModelWithC
     private changeRowHeight(): void {
         if (this.vScrollFixed > 0) {
             document.documentElement.style.setProperty('--pbl-height', this.vScrollFixed + 'px');
+        } else {
+            document.documentElement.style.removeProperty('--pbl-height');
         }
     }
 

--- a/client/src/app/site/assignments/modules/assignment-poll/components/assignment-poll-detail/assignment-poll-detail.component.html
+++ b/client/src/app/site/assignments/modules/assignment-poll/components/assignment-poll-detail/assignment-poll-detail.component.html
@@ -71,11 +71,22 @@
                         <div *ngIf="vote.user">
                             {{ vote.user.getShortName() }}
                             <div class="user-subtitle">
+                                <!-- Level and number -->
                                 <div *ngIf="vote.user.getLevelAndNumber()">
                                     {{ vote.user.getLevelAndNumber() }}
                                 </div>
+
+                                <!-- Vote weight -->
                                 <div *ngIf="isVoteWeightActive">
                                     {{ 'Vote weight' | translate }}: {{ vote.user.vote_weight }}
+                                </div>
+
+                                <!-- Delegation -->
+                                <div *ngIf="userHasVoteDelegation(vote.user)">
+                                    <span>
+                                        ({{ 'represented by' | translate }}
+                                        {{ getUsersVoteDelegation(vote.user).getShortName().trim() }})
+                                    </span>
                                 </div>
                             </div>
                         </div>

--- a/client/src/app/site/assignments/modules/assignment-poll/components/assignment-poll-detail/assignment-poll-detail.component.ts
+++ b/client/src/app/site/assignments/modules/assignment-poll/components/assignment-poll-detail/assignment-poll-detail.component.ts
@@ -50,10 +50,22 @@ export class AssignmentPollDetailComponent extends BasePollDetailComponentDirect
         configService: ConfigService,
         protected pollService: AssignmentPollService,
         votesRepo: AssignmentVoteRepositoryService,
-        private operator: OperatorService,
+        protected operator: OperatorService,
         private router: Router
     ) {
-        super(title, translate, matSnackbar, repo, route, groupRepo, prompt, pollDialog, pollService, votesRepo);
+        super(
+            title,
+            translate,
+            matSnackbar,
+            repo,
+            route,
+            groupRepo,
+            prompt,
+            pollDialog,
+            pollService,
+            votesRepo,
+            operator
+        );
         configService
             .get<boolean>('users_activate_vote_weight')
             .subscribe(active => (this.isVoteWeightActive = active));

--- a/client/src/app/site/motions/modules/motion-poll/motion-poll-detail/motion-poll-detail.component.html
+++ b/client/src/app/site/motions/modules/motion-poll/motion-poll-detail/motion-poll-detail.component.html
@@ -58,13 +58,24 @@
                     <div *pblNgridCellDef="'user'; row as vote">
                         <div *ngIf="vote.user">
                             {{ vote.user.getShortName() }}
+
                             <div class="user-subtitle">
+                                <!-- Level and number -->
                                 <div *ngIf="vote.user.getLevelAndNumber()">
                                     {{ vote.user.getLevelAndNumber() }}
                                 </div>
 
+                                <!-- Vote weight -->
                                 <div *ngIf="isVoteWeightActive">
                                     {{ 'Vote weight' | translate }}: {{ vote.user.vote_weight }}
+                                </div>
+
+                                <!-- Delegation -->
+                                <div *ngIf="userHasVoteDelegation(vote.user)">
+                                    <span>
+                                        ({{ 'represented by' | translate }}
+                                        {{ getUsersVoteDelegation(vote.user).getShortName().trim() }})
+                                    </span>
                                 </div>
                             </div>
                         </div>

--- a/client/src/app/site/motions/modules/motion-poll/motion-poll-detail/motion-poll-detail.component.ts
+++ b/client/src/app/site/motions/modules/motion-poll/motion-poll-detail/motion-poll-detail.component.ts
@@ -56,10 +56,22 @@ export class MotionPollDetailComponent extends BasePollDetailComponentDirective<
         pollService: MotionPollService,
         votesRepo: MotionVoteRepositoryService,
         configService: ConfigService,
-        private operator: OperatorService,
+        protected operator: OperatorService,
         private router: Router
     ) {
-        super(title, translate, matSnackbar, repo, route, groupRepo, prompt, pollDialog, pollService, votesRepo);
+        super(
+            title,
+            translate,
+            matSnackbar,
+            repo,
+            route,
+            groupRepo,
+            prompt,
+            pollDialog,
+            pollService,
+            votesRepo,
+            operator
+        );
         configService
             .get<boolean>('users_activate_vote_weight')
             .subscribe(active => (this.isVoteWeightActive = active));

--- a/client/src/app/site/polls/components/base-poll-detail.component.ts
+++ b/client/src/app/site/polls/components/base-poll-detail.component.ts
@@ -8,6 +8,7 @@ import { Label } from 'ng2-charts';
 import { BehaviorSubject, from, Observable } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
 
+import { OperatorService } from 'app/core/core-services/operator.service';
 import { Deferred } from 'app/core/promises/deferred';
 import { BaseRepository } from 'app/core/repositories/base-repository';
 import { GroupRepositoryService } from 'app/core/repositories/users/group-repository.service';
@@ -104,7 +105,8 @@ export abstract class BasePollDetailComponentDirective<V extends ViewBasePoll, S
         protected promptService: PromptService,
         protected pollDialog: BasePollDialogService<V, S>,
         protected pollService: S,
-        protected votesRepo: BaseRepository<ViewBaseVote, BaseVote, object>
+        protected votesRepo: BaseRepository<ViewBaseVote, BaseVote, object>,
+        protected operator: OperatorService
     ) {
         super(title, translate, matSnackbar);
         this.setup();
@@ -209,6 +211,32 @@ export abstract class BasePollDetailComponentDirective<V extends ViewBasePoll, S
                     }
                 })
             );
+        }
+    }
+
+    protected userHasVoteDelegation(user: ViewUser): boolean {
+        /**
+         * This will be false if the operator does not have "can_see_extra_data"
+         */
+        if (user.isVoteRightDelegated) {
+            return true;
+        } else if (this.operator.viewUser.canVoteFor(user)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    protected getUsersVoteDelegation(user: ViewUser): ViewUser {
+        /**
+         * This will be false if the operator does not have "can_see_extra_data"
+         */
+        if (!!user.voteDelegatedTo) {
+            return user.voteDelegatedTo;
+        }
+
+        if (this.operator.viewUser.canVoteFor(user)) {
+            return this.operator.viewUser;
         }
     }
 }


### PR DESCRIPTION
Adds a "represented by" field to the single votes table, to indicate a
vote delegation.
Also fixes an height issue that occured in large single vote tables when
the user was navigating from a list view table to a single vote table