### PR TITLE
saml: commands: create-saml-settings: Fix check on wrong variable

### DIFF
--- a/server/openslides/saml/management/commands/create-saml-settings.py
+++ b/server/openslides/saml/management/commands/create-saml-settings.py
@@ -25,7 +25,7 @@ class Command(BaseCommand):
 
         if settings_dir is not None:
             settings_path = os.path.join(settings_dir, "saml_settings.json")
-            if not os.path.isdir(settings_path):
+            if not os.path.isdir(settings_dir):
                 print(f"The directory '{settings_dir}' does not exist. Aborting...")
                 return
         else:


### PR DESCRIPTION
The script is not usable as it uses the wrong variable when checking for the existance of a given directory parameter.