### PR TITLE
Update Dockerfile to allow build via docker-compose on arm architectures

### DIFF
--- a/server/docker/Dockerfile
+++ b/server/docker/Dockerfile
@@ -29,7 +29,9 @@ RUN apt-get -y update && apt-get -y upgrade && \
     rsync \
     wait-for-it \
     wget \
-    xz-utils
+    xz-utils \
+    zlib1g-dev \
+    libffi-dev # install of zlib1g-dev and libffi-dev is required on armhf architectures
 
 # Install additional tools
 RUN apt-get install --no-install-recommends -y \


### PR DESCRIPTION
As stated in issue #5638 the installation via docker-compose fails on arm architectures since two librariers are not correctly installed. This is fixed by installing those manually in the /server/docker/Dockerfile