### PR TITLE
Bug fix preventing undesired recreation of poll-collection

### DIFF
--- a/client/src/app/site/cinema/components/poll-collection/poll-collection.component.html
+++ b/client/src/app/site/cinema/components/poll-collection/poll-collection.component.html
@@ -1,4 +1,4 @@
-<mat-card class="os-card" *ngFor="let poll of polls">
+<mat-card class="os-card" *ngFor="let poll of polls; trackBy: identifyPoll">
     <p class="subtitle-text">
         <a [routerLink]="getPollDetailLink(poll)" [state]="{ back: 'true' }">{{ getPollVoteTitle(poll) }}</a>
     </p>

--- a/client/src/app/site/cinema/components/poll-collection/poll-collection.component.ts
+++ b/client/src/app/site/cinema/components/poll-collection/poll-collection.component.ts
@@ -53,6 +53,10 @@ export class PollCollectionComponent extends BaseViewComponentDirective implemen
         );
     }
 
+    public identifyPoll(index: number, poll: ViewBasePoll): number {
+        return poll.id;
+    }
+
     public getPollVoteTitle(poll: ViewBasePoll): string {
         const contentObject = poll.getContentObject();
         const listTitle = contentObject.getListTitle();


### PR DESCRIPTION
This is a fix for a **major** problem occurring in cinema mode:

When a motion or assignment poll is active and a delegate makes (1) a vote selection and then wants to send the vote,  (2) his selection is cancelled and he needs to start again as soon as another delegate sends his vote. The reason for the behavior is that a poll change occurs causing angular to recreate the poll-collection.

This is a major problem basically preventing simultaneous vote casting.

(1)
![image](https://user-images.githubusercontent.com/20415092/98089304-cf740100-1e82-11eb-96c2-fc9c53152bae.png)

(2)
![image](https://user-images.githubusercontent.com/20415092/98089429-03e7bd00-1e83-11eb-92d4-21ff7f724358.png)
