### PR TITLE
Add user_id validation for LOS and assignment candidates

### DIFF
--- a/server/openslides/agenda/views.py
+++ b/server/openslides/agenda/views.py
@@ -346,6 +346,9 @@ class ListOfSpeakersViewSet(
                     raise ValidationError({"detail": "The list of speakers is closed."})
                 user = self.request.user
             else:
+                if not isinstance(user_id, int):
+                    raise ValidationError({"detail": "user_id has to be an int."})
+
                 point_of_order = False  # not for someone else
                 # Add someone else.
                 if not has_perm(
@@ -353,8 +356,8 @@ class ListOfSpeakersViewSet(
                 ):
                     self.permission_denied(request)
                 try:
-                    user = get_user_model().objects.get(pk=int(user_id))
-                except (ValueError, get_user_model().DoesNotExist):
+                    user = get_user_model().objects.get(pk=user_id)
+                except get_user_model().DoesNotExist:
                     raise ValidationError({"detail": "User does not exist."})
 
             # Try to add the user. This ensurse that a user is not twice in the

--- a/server/tests/integration/agenda/test_viewset.py
+++ b/server/tests/integration/agenda/test_viewset.py
@@ -356,6 +356,13 @@ class ManageSpeaker(TestCase):
             ).exists()
         )
 
+    def test_add_someone_else_no_id(self):
+        response = self.client.post(
+            reverse("listofspeakers-manage-speaker", args=[self.list_of_speakers.pk]),
+            {"user": ["not valid"]},
+        )
+        self.assertEqual(response.status_code, 400)
+
     def test_point_of_order_single(self):
         config["agenda_enable_point_of_order_speakers"] = True
         self.assertEqual(Speaker.objects.all().count(), 0)

--- a/server/tests/integration/assignments/test_viewset.py
+++ b/server/tests/integration/assignments/test_viewset.py
@@ -279,6 +279,14 @@ class CandidatureOther(TestCase):
             .exists()
         )
 
+    def test_nominate_other_invalid_id(self):
+        response = self.client.post(
+            reverse("assignment-candidature-other", args=[self.assignment.pk]),
+            {"user": ["not valid"]},
+        )
+
+        self.assertEqual(response.status_code, 400)
+
     def test_nominate_other_twice(self):
         self.assignment.add_candidate(
             get_user_model().objects.get(username="test_user_eeheekai4Phue6cahtho")

--- a/server/tests/unit/agenda/test_views.py
+++ b/server/tests/unit/agenda/test_views.py
@@ -46,7 +46,7 @@ class ListOfSpeakersViewSetManageSpeaker(TestCase):
         self.request.method = "POST"
         self.request.user = 1
         self.request.data = {
-            "user": "2"
+            "user": 2
         }  # It is assumed that the request user has pk!=2.
         mock_get_user_model.return_value = MockUser = MagicMock()
         MockUser.objects.get.return_value = mock_user = MagicMock()


### PR DESCRIPTION
This PR adds missing serverside validation for #5688 @tsiegleauq I noticed, that the client sends the request (e.g. for adding a speaker) twice: Once with an array, once with an id (-> `[2]` and just `2`).