### PR TITLE
Enhance the action interface

### DIFF
--- a/docs/interfaces/action-service.txt
+++ b/docs/interfaces/action-service.txt
@@ -3,11 +3,11 @@
 /**
  * Executes multiple actions in the context of the user given by the user_id.
  * There are two modes of execution:
- * single_validation=false (default):
+ * atomic=false (default):
  *   All actions are validated in common, so if one action or one payload of
  *   one action fails, the request is aborted with an ActionException indicating
  *   the problematic action with both indices.
- * single_validation=true:
+ * atomic=true:
  *   Each action is validated by it's own. If there is an error, the error must
  *   be reported via an ActionError in the ActionsResponse. The actions result
  *   is not written into the Datastore. It might raise an ActionException if the
@@ -22,7 +22,7 @@ handle_request(payload: Action[], user_id: Id): ActionsResponse
 interface Action {
     action: string;
     data: object[];
-    single_validation?: boolean;
+    atomic?: boolean;
 }
 
 interace ActionsResponse {
@@ -59,7 +59,7 @@ interface ActionError {
  * use the action_error_index and action_payload_error_index to indicate the errored
  * action and payload. If there were general errors, both indices must be omitted.
  *
- * If the single_validation Flag was true in the request, it is not allowed to send
+ * If the atomic flag was true in the request, it is not allowed to send
  * action-specific errors with this exception. It must be responded through ActionsResponse.
  */
 Exception ActionException {

--- a/docs/interfaces/action-service.txt
+++ b/docs/interfaces/action-service.txt
@@ -1,33 +1,28 @@
-# Actions Service Interface
-
-/**
- * JSON resonse with a status code of !=200:
- * {
- *     success: false;
- *     message: string;
- * }
- *
- */
-Exception ActionException(message: string);
+// Actions Service Interface
 
 /**
  * Executes multiple actions in the context of the user given by the user_id.
- * All actions are depdend: If one fails, nothing is written to the DataStore.
- * It can be seen as one transaction.
- *
- * For each action an ActionResult is returned. If an action has an error,
- * ActionError is used in combination wuth error_index to indicate, which action
- * resulted in an error.
+ * There are two modes of execution:
+ * single_validation=false (default):
+ *   All actions are validated in common, so if one action or one payload of
+ *   one action fails, the request is aborted with an ActionException indicating
+ *   the problematic action with both indices.
+ * single_validation=true:
+ *   Each action is validated by it's own. If there is an error, the error must
+ *   be reported via an ActionError in the ActionsResponse. The actions result
+ *   is not written into the Datastore. It might raise an ActionException if the
+ *   single write request to the Datastore fails (e.g. because of locking there)
  *
  * For general, non specific action-related, errors an ActionException is used.
  *
  * @throws ActionException
  */
-handle_request (payload: Action[], user_id: Id): ActionsResponse | ActionError
+handle_request(payload: Action[], user_id: Id): ActionsResponse
 
 interface Action {
     action: string;
-    data: object[];  # An array of action specific data.
+    data: object[];
+    single_validation?: boolean;
 }
 
 interace ActionsResponse {
@@ -35,19 +30,21 @@ interace ActionsResponse {
     message: string;
 
     /**
-     * this is a potentially double-array with entries for each action
+     * This is a potentially double-array with entries for each action
      * and, if not null, an array for each data provided for each action.
      *
-     *
-     * If an action does not producy a result, the inner array can be omitted and
+     * If an action does not produce a result, the inner array can be omitted and
      * null can be used. If the inner array is given, each entry must be an object
      * with the result (e.g. for a create action `{id: <the id>}`) or null.
-
+     *
      * E.g. for valid arrays (two actions with two data entries each):
      * - [null, null]
      * - [null, [null, null]]
      * - [null, [{id: 2}, null]]
      * - [[{id: 2}, {id: 3}], [{id: 5}, {id: 8}]]
+     *
+     *
+     * To report errors, use the ActionError format!
      **/
     results: ((object | null)[] | null )[]
 }
@@ -55,5 +52,19 @@ interace ActionsResponse {
 interface ActionError {
     success: false;
     message: string;
-    error_index: number;
+}
+
+/**
+ * JSON resonse with a status code of !=200. If a specific action raised the error,
+ * use the action_error_index and action_payload_error_index to indicate the errored
+ * action and payload. If there were general errors, both indices must be omitted.
+ *
+ * If the single_validation Flag was true in the request, it is not allowed to send
+ * action-specific errors with this exception. It must be responded through ActionsResponse.
+ */
+Exception ActionException {
+    success: false;
+    message: string;
+    action_error_index: number;
+    action_payload_error_index: number;
 }

--- a/docs/interfaces/action-service.txt
+++ b/docs/interfaces/action-service.txt
@@ -46,7 +46,7 @@ interace ActionsResponse {
      *
      * To report errors, use the ActionError format!
      **/
-    results: ((object | null)[] | null )[]
+    results: ((object | ActionError | null)[] | null )[]
 }
 
 interface ActionError {

--- a/docs/interfaces/action-service.txt
+++ b/docs/interfaces/action-service.txt
@@ -17,12 +17,11 @@
  *
  * @throws ActionException
  */
-handle_request(payload: Action[], user_id: Id): ActionsResponse
+handle_request(payload: Action[], user_id: Id, atomic?: boolean): ActionsResponse
 
 interface Action {
     action: string;
     data: object[];
-    atomic?: boolean;
 }
 
 interace ActionsResponse {

--- a/docs/interfaces/action-service.txt
+++ b/docs/interfaces/action-service.txt
@@ -23,14 +23,14 @@ Exception ActionException(message: string);
  *
  * @throws ActionException
  */
-handle_request (payload: Action[], user_id: Id): ActionsResult | ActionError
+handle_request (payload: Action[], user_id: Id): ActionsResponse | ActionError
 
 interface Action {
     action: string;
     data: object[];  # An array of action specific data.
 }
 
-interace ActionsResult {
+interace ActionsResponse {
     success: true;
     message: string;
 

--- a/docs/interfaces/action-service.txt
+++ b/docs/interfaces/action-service.txt
@@ -56,14 +56,15 @@ interface ActionError {
 /**
  * JSON resonse with a status code of !=200. If a specific action raised the error,
  * use the action_error_index and action_payload_error_index to indicate the errored
- * action and payload. If there were general errors, both indices must be omitted.
+ * action and payload. If there were general errors, both indices must be omitted or null.
  *
  * If the atomic flag was true in the request, it is not allowed to send
- * action-specific errors with this exception. It must be responded through ActionsResponse.
+ * action-specific errors with this exception. It must be responded with an
+ * ActionError through ActionsResponse (resulting in a status code of 200).
  */
 Exception ActionException {
     success: false;
     message: string;
-    action_error_index: number;
-    action_payload_error_index: number;
+    action_error_index?: number;
+    action_payload_error_index?: number;
 }

--- a/docs/interfaces/actions-service.txt
+++ b/docs/interfaces/actions-service.txt
@@ -1,25 +1,59 @@
 # Actions Service Interface
 
+/**
+ * JSON resonse with a status code of !=200:
+ * {
+ *     success: false;
+ *     message: string;
+ * }
+ *
+ */
 Exception ActionException(message: string);
-
 
 /**
  * Executes multiple actions in the context of the user given by the user_id.
- * All actions are processed independently.
+ * All actions are depdend: If one fails, nothing is written to the DataStore.
+ * It can be seen as one transaction.
  *
- * TODO: Maybe we do not want to run them independently.
+ * For each action an ActionResult is returned. If an action has an error,
+ * ActionError is used in combination wuth error_index to indicate, which action
+ * resulted in an error.
  *
+ * For general, non specific action-related, errors an ActionException is used.
  *
  * @throws ActionException
  */
-handle_request (payload: Action[], user_id: Id): ActionResult[]
+handle_request (payload: Action[], user_id: Id): ActionsResult | ActionError
 
 interface Action {
     action: string;
-    data: object[];  # An array of action specific data. See JSON schema defintions.
+    data: object[];  # An array of action specific data.
 }
 
-interface ActionResult {
-    success: boolean;
+interace ActionsResult {
+    success: true;
     message: string;
+
+    /**
+     * this is a potentially double-array with entries for each action
+     * and, if not null, an array for each data provided for each action.
+     *
+     *
+     * If an action does not producy a result, the inner array can be omitted and
+     * null can be used. If the inner array is given, each entry must be an object
+     * with the result (e.g. for a create action `{id: <the id>}`) or null.
+
+     * E.g. for valid arrays (two actions with two data entries each):
+     * - [null, null]
+     * - [null, [null, null]]
+     * - [null, [{id: 2}, null]]
+     * - [[{id: 2}, {id: 3}], [{id: 5}, {id: 8}]]
+     **/
+    results: ((object | null)[] | null )[]
+}
+
+interface ActionError {
+    success: false;
+    message: string;
+    error_index: number;
 }


### PR DESCRIPTION
@jsangmeister @normanjaeckel I make this proposal regarding some changes.

- https://github.com/OpenSlides/openslides-backend/issues/261 We have three cases, what can be returned by calling `handle_request`:
    1) No error, everything is fine: An object with `success=true` is returned with a result array for each action containing an array for each payload of each action.  Examples are given in the interface
    2) One action had an error: An object is returned with `success=false`, the `error_index` of the error-causing action and a message.
    3) A general error occured (->`ActionException`): An object with `success=false` but no `error_index` is returned.

The thing is, that everytime an object is returned and it is easy decideable, which of these cases happened (not the current case).

- https://github.com/OpenSlides/openslides-backend/issues/259 The interface is extended (or recreated - the original version hat the result, but someone removed it...), so every action and "partial"-action can provide a result with the flexibility to not give a bunch of null-arrays by omitting them.

Please discuss here - If we decided to stick to an (hopefully final) interface, we all know what to expect from the service, so it can universally be used without any quirks and special return structures.