### PR TITLE
Fixed HTML attribute validation

### DIFF
--- a/server/openslides/utils/validate.py
+++ b/server/openslides/utils/validate.py
@@ -43,12 +43,40 @@ allowed_tags_permissive = allowed_tags_strict + [
     "video",
 ]
 
+allowed_attributes = [
+    "align",
+    "alt",
+    "autoplay",
+    "background",
+    "bgcolor",
+    "border",
+    "class",
+    "colspan",
+    "controls",
+    "dir",
+    "height",
+    "hidden",
+    "href",
+    "hreflang",
+    "id",
+    "lang",
+    "loop",
+    "muted",
+    "poster",
+    "preload",
+    "rel",
+    "rowspan",
+    "scope",
+    "sizes",
+    "src",
+    "srcset",
+    "start",
+    "style",
+    "target",
+    "title",
+    "width",
+]
 
-def allow_all(tag: str, name: str, value: str) -> bool:
-    return True
-
-
-allowed_attributes = allow_all
 allowed_styles = [
     "color",
     "background-color",


### PR DESCRIPTION
Copied all attributes from https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes that seemed to make sense for OpenSlides. It seems like the handlers (starting with `on...`) are the only cases which enable script execution. Please check if anything invaid is contained or something important is missing.