### PR TITLE
Change the category prefix to optional

### DIFF
--- a/docs/models.yml
+++ b/docs/models.yml
@@ -1246,7 +1246,6 @@ motion_category:
     required: true
   prefix:
     type: string
-    required: true
   weight:
     type: number
     default: 10000


### PR DESCRIPTION
The required prefix was a mistake when I created the schema. Changing it to an optional field must be adopted in several places:

- @GabrielInTheWorld Can you do the client? I guess the create/update dialogs may be changed, so an empty prefix is allowed
- @reiterl Please change `motion_category.create` to make the prefix optional
- @reiterl Please change `motion_category.update` to accept `None` or `""` as the prefix to clear an existing prefix.
- @reiterl You can merge this PR if you are ready to update the generated models.py in the backend
- I'll adjust `motion_category.number_motions`.