### PR TITLE
Consider show-seq-number config during pdf export

### DIFF
--- a/client/src/app/site/motions/services/motion-pdf.service.ts
+++ b/client/src/app/site/motions/services/motion-pdf.service.ts
@@ -115,7 +115,8 @@ export class MotionPdfService {
         }
 
         const title = this.createTitle(motion, crMode, lineLength);
-        const sequential = !infoToExport || infoToExport.includes('id');
+        const sequential =
+            infoToExport?.includes('id') ?? this.configService.instant<boolean>('motions_show_sequential_numbers');
         const subtitle = this.createSubtitle(motion, sequential);
 
         motionPdfContent = [title, subtitle];


### PR DESCRIPTION
If not stated in the export dialog, the sequential
motion number will not be printed in the PDF if the config
option is unset