### PR TITLE
Avoid stream/jitsi cases without information

### DIFF
--- a/client/src/app/shared/components/jitsi/jitsi.component.html
+++ b/client/src/app/shared/components/jitsi/jitsi.component.html
@@ -200,8 +200,7 @@
                         *ngIf="(canSeeLiveStream && !streamActiveInAnotherTab) || streamRunning"
                     ></os-vjs-player>
                     <div class="disconnected" *ngIf="streamActiveInAnotherTab && !streamRunning">
-                        <span>{{ 'The livestream is already running in your OpenSlides session.' | translate }}</span>
-                        <button mat-button color="warn" (click)="deleteStreamingLock()">
+                        <button class="restart-stream-button" mat-button color="warn" (click)="deleteStreamingLock()">
                             <span>{{ 'Restart livestream' | translate }}</span>
                         </button>
                     </div>


### PR DESCRIPTION
Rewrites the jitsi/stream state management.
After every reload and after a stream becomes available (while not
currently in a jitsi conference) you will switch to live stream, if
available