### PR TITLE
Remove allow_multiple_votes_per_candidate

### DIFF
--- a/docs/models.yml
+++ b/docs/models.yml
@@ -1521,9 +1521,6 @@ poll:
   max_votes_amount:
     type: number
     default: 1
-  allow_multiple_votes_per_candidate:
-    type: boolean
-    default: false
   global_yes:
     type: boolean
     default: false


### PR DESCRIPTION
The setting is no longer needed, as we don't want to allow it.