### PR TITLE
server: Fix database config in Docker entrypoint

### DIFF
--- a/server/docker/entrypoint-db-setup
+++ b/server/docker/entrypoint-db-setup
@@ -24,12 +24,7 @@ source /run/secrets/django
 }
 export SECRET_KEY="$DJANGO_SECRET_KEY"
 
-# Configure database
-# TODO: env variables??
-echo "postgres:5432:instancecfg:openslides:openslides" > "${HOME}/.pgpass"
-chmod 600 "${HOME}/.pgpass"
-
-until pg_isready -h db; do
+until pg_isready -h "${DATABASE_HOST}" -p "${DATABASE_PORT:-5432}"; do
   echo "Waiting for Postgres cluster to become available..."
   sleep 3
 done


### PR DESCRIPTION
Firstly, this patch ensures that the server connects to the database
according to the given configuration variables.  Up until now, there was
a pg_isready check for the hard-coded hostname "db".  While this
generally worked in the default setup – db is an alias for pgbouncer in
the provided YAML configuration files – it is obviously wrong and would
lead to unexpected behavior in customized setups.

Secondly, the .pgpass setup, which was a remnant of another time and not
used anymore, has been removed.