### PR TITLE
Allow preset env variable for django secret

### DIFF
--- a/server/docker/entrypoint
+++ b/server/docker/entrypoint
@@ -3,7 +3,7 @@
 set -e
 
 # Set DJANGO_SECRET_KEY variable
-source /run/secrets/django
+source /run/secrets/django || true
 [[ -n "$DJANGO_SECRET_KEY" ]] || {
   echo "ERROR: Django secret key undefined!  Cannot continue."
   sleep 5

--- a/server/docker/entrypoint-db-setup
+++ b/server/docker/entrypoint-db-setup
@@ -16,7 +16,7 @@ EOF
 }
 
 # Set DJANGO_SECRET_KEY variable
-source /run/secrets/django
+source /run/secrets/django || true
 [[ -n "$DJANGO_SECRET_KEY" ]] || {
   echo "ERROR: Django secret key undefined!  Cannot continue."
   sleep 5


### PR DESCRIPTION
The source command fails if /run/secrets/django does not exist. This is however not important if DJANGO_SECRET_KEY is already set. This is checked in the next step