### PR TITLE
Improve client-side password generation

### DIFF
--- a/client/src/app/core/repositories/users/user-repository.service.ts
+++ b/client/src/app/core/repositories/users/user-repository.service.ts
@@ -181,11 +181,21 @@ export class UserRepositoryService extends BaseRepository<ViewUser, User, UserTi
      */
     public getRandomPassword(length: number = 10): string {
         let pw = '';
-        const array = new Uint8Array(length);
-        window.crypto.getRandomValues(array);
         const characters = 'abcdefghijkmnpqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ23456789';
-        for (let i = 0; i < length; i++) {
-            pw += characters.charAt(array[i] % characters.length);
+        // set charactersLengthPower2 to characters.length rounded up to the next power of two
+        let charactersLengthPower2 = 1;
+        while (characters.length > charactersLengthPower2) {
+            charactersLengthPower2 *= 2;
+        }
+        while (pw.length < length) {
+            const random = new Uint8Array(length - pw.length);
+            window.crypto.getRandomValues(random);
+            for (let i = 0; i < random.length; i++) {
+                const r = random[i] % charactersLengthPower2;
+                if (r < characters.length) {
+                    pw += characters.charAt(r);
+                }
+            }
         }
         return pw;
     }


### PR DESCRIPTION
The currently implemented client-side password generation algorithm does not choose all allowed characters with equal probability, but chooses some more often than others.

The reason is that generating an 8-bit random number and reducing it modulo 56 (`characters.length`, the number of allowed characters) does not choose all numbers 0 to 55 with equal probability, but chooses 0 to 31 with higher probability than 32 to 55.

This change improves the password generation algorithms by choosing all characters with equal probability.