### PR TITLE
Add helpdesk icon and feature

### DIFF
--- a/client/src/app/shared/components/jitsi/jitsi.component.html
+++ b/client/src/app/shared/components/jitsi/jitsi.component.html
@@ -61,7 +61,7 @@
                     matTooltip="{{ 'Exit live conference and continue livestream' | translate }}"
                     *ngIf="videoStreamUrl && canSeeLiveStream && !isJitsiDialogOpen"
                 >
-                    <mat-icon color="warn"> meeting_room </mat-icon>
+                    <mat-icon color="warn">meeting_room</mat-icon>
                 </button>
 
                 <!-- mute/unmute button -->
@@ -85,7 +85,7 @@
                     *ngIf="enableJitsi && isAccessPermitted"
                     class="quick-icon indicator"
                     mat-mini-fab
-                    (click)="enterConversation()"
+                    (click)="enterConferenceRoom()"
                     matTooltip="{{ 'Enter live conference' | translate }}"
                 >
                     <mat-icon
@@ -108,6 +108,18 @@
                     <mat-icon> no_meeting_room </mat-icon>
                 </a>
             </ng-container>
+
+            <!-- Call support button -->
+            <button
+                class="indicator quick-icon"
+                mat-mini-fab
+                (click)="enterSupportRoom()"
+                [disabled]="isJitsiActive"
+                matTooltip="{{ 'Access help desk' | translate }}"
+                *ngIf="canAccessSupport"
+            >
+                <mat-icon color="primary">live_help</mat-icon>
+            </button>
 
             <!-- applause button -->
             <button
@@ -137,7 +149,8 @@
             <!-- open-window button -->
             <button class="toggle-list-button" mat-button (click)="toggleShowJitsi()">
                 <ng-container *ngIf="currentState == state.jitsi">
-                    <div class="ellipsis-overflow">{{ 'Live conference' | translate }}</div>
+                    <div *ngIf="!connectToHelpDesk" class="ellipsis-overflow">{{ 'Live conference' | translate }}</div>
+                    <div *ngIf="connectToHelpDesk" class="ellipsis-overflow">{{ 'Help desk' | translate }}</div>
                     <div class="one-line">
                         &nbsp;
                         <span *ngIf="currentDominantSpeaker">
@@ -248,7 +261,7 @@
                                 <button
                                     mat-mini-fab
                                     color="accent"
-                                    (click)="enterConversation()"
+                                    (click)="enterConferenceRoom()"
                                     [disabled]="
                                         !enableJitsi || isJitsiActive || isJitsiActiveInAnotherTab || !isAccessPermitted
                                     "

--- a/server/openslides/core/config_variables.py
+++ b/server/openslides/core/config_variables.py
@@ -169,6 +169,20 @@ def get_config_variables():
         subgroup="Live conference",
     )
 
+    yield ConfigVariable(
+        name="general_system_conference_enable_helpdesk",
+        default_value=False,
+        input_type="boolean",
+        label="Enable help desk",
+        help_text="""
+            Shows a help icon in the conference bar.
+            Users can connect to a dedicated conference.
+            The conference host has to manually ensure the coverage of the help desk.
+        """,
+        weight=148,
+        subgroup="Live conference",
+    )
+
     # Applause
 
     yield ConfigVariable(


### PR DESCRIPTION
Adds a "helpdesk" Jitsi room feature.
Can be enabled using the OpenSlides config page

Shows a 'Call support' button in the conference control bar
clicking the support button will connect the user
to a "support" jitsi room
The name of the support room will be
`JITSI_ROOM_NAME`-SUPPORT