### PR TITLE
Force http2 on requests to the autoupdate-service.

### DIFF
--- a/caddy/Caddyfile.dev
+++ b/caddy/Caddyfile.dev
@@ -5,9 +5,22 @@
 
 localhost:8000
 
-reverse_proxy /system/* autoupdate:8002 {
+@autoupdate {
+    path /system/*
+    expression {http.request.proto}.startsWith("HTTP/2")
+}
+reverse_proxy @autoupdate autoupdate:8002 {
     flush_interval -1
 }
+
+@autoupdate_http1 {
+    path /system/*
+    expression {http.request.proto}.startsWith("HTTP/1")
+}
+respond @autoupdate_http1 "HTTP1 not supported" 400 {
+    close
+}
+
 
 @server {
     path /apps/*
@@ -15,6 +28,7 @@ reverse_proxy /system/* autoupdate:8002 {
     path /server-version.txt
     path /media/*
 }
+
 reverse_proxy @server server:8000
 
 reverse_proxy client:4200

--- a/caddy/Caddyfile.dev
+++ b/caddy/Caddyfile.dev
@@ -7,7 +7,7 @@ localhost:8000
 
 @autoupdate {
     path /system/*
-    expression {http.request.proto}.startsWith("HTTP/2")
+    expression `{http.request.proto} == "HTTP/2.0"`
 }
 reverse_proxy @autoupdate autoupdate:8002 {
     flush_interval -1


### PR DESCRIPTION
This should only be done in situations, where the browser directly connects to caddy. If another proxy is in between, then this is not necessary.

See: https://caddy.community/t/match-on-http-version/11405

I am not 100% sure if we should merge this. All modern browsers use http2 on https when it is supported by the server. The situation, that a browser connects with a http1 connection should not happen. But it is more configuration, that can be confusing. On the other hand, it is a good example, how to force http2 with caddy.