### PR TITLE
Update Makefiles for Caddy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 build-dev:
-	make -C haproxy build-dev
+	make -C caddy build-dev
 	git submodule foreach 'make build-dev'
 	docker-compose -f docker/docker-compose.dev.yml build
 
@@ -8,9 +8,6 @@ run-dev: | build-dev
 
 stop-dev:
 	docker-compose -f docker/docker-compose.dev.yml down
-
-reload-haproxy:
-	docker-compose -f docker/docker-compose.dev.yml kill -s HUP haproxy
 
 get-server-shell:
 	docker-compose -f docker/docker-compose.dev.yml run server bash

--- a/caddy/Makefile
+++ b/caddy/Makefile
@@ -1,0 +1,2 @@
+build-dev:
+	docker build -t os3-proxy-dev -f Dockerfile .


### PR DESCRIPTION
The reload-haproxy target has simply been removed due to time
constraints.