### PR TITLE
Map debug port for openslides-backend in docker-compose.dev

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -53,6 +53,8 @@ services:
     env_file: services.env
     volumes:
       - ../openslides-backend/openslides_backend:/app/openslides_backend
+    ports:
+      - 5678:5678
   autoupdate:
     image: openslides-autoupdate-dev
     depends_on:


### PR DESCRIPTION
Opens port for remote debugger, only for dev