### PR TITLE
Add electron app and build environment [WIP]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,8 @@ client/dist
 client/static
 client/tmp
 client/out-tsc
+client/electron-main.js
+client/electron-main.js.map
 # docs
 client/documentation
 Compodoc

--- a/DEVELOPMENT.rst
+++ b/DEVELOPMENT.rst
@@ -91,3 +91,40 @@ Fix the code format and lint it with::
 To extract translations run::
 
     npm run extract
+
+Building electron applications
+------------
+
+As above, you need `node` and `npm` installed.
+Change to the client's directory. For the first time, install all dependencies::
+
+    cd client
+    npm install
+
+To test OpenSlides using electron without creating a productive build:
+
+    npm run electron-build-debug &&
+    npm run electron-test
+
+This will build the OpenSlides with debug information and mount the build into electron
+
+To create production ready electon packages, build the client in prod mode first.
+
+    npm run build
+
+Use electron builder to create a desktop application for either Windows Linux or macOS.
+Electron builder will use the production ready files from `server/openslides/static/`
+You can find the build applications under `client/dist/electron-builds`
+
+To create a windows portable ".exe"
+
+    npm run electron-build-win
+
+To create a linux portable .AppImage
+
+    npm run electron-build-lin
+
+To create a macOS (Intel) portable .dmg
+(This was not tested because we cannot sign applications for macOS)
+
+    npm run electron-build-mac

--- a/client/electron-builder.json
+++ b/client/electron-builder.json
@@ -1,0 +1,41 @@
+{
+    "productName": "OpenSlides",
+    "asar": true,
+    "directories": {
+        "output": "dist/electron-builds"
+    },
+    "files": [
+        "**/*",
+        "!**/*.ts",
+        "!**/*.json",
+        "!**.*.md",
+        "!*.sh",
+        "!*.code-workspace",
+        "!.dockerignore",
+        "!.prettierrc",
+        "!docker/",
+        "!node_modules/",
+        "!src/",
+        "!e2e/",
+        "!hooks/",
+        "!_config.yml",
+        "!karma.conf.js",
+        {
+            "from": "../server/openslides/static",
+            "to": "./dist/os3",
+            "filter": ["**/*"]
+        }
+    ],
+    "win": {
+        "icon": "dist/assets/icons/icon-512x512.png",
+        "target": ["nsis, portable"]
+    },
+    "mac": {
+        "icon": "dist/assets/icons/icon-512x512.png",
+        "target": ["dmg"]
+    },
+    "linux": {
+        "icon": "dist/assets/icons/icon-512x512.png",
+        "target": ["AppImage"]
+    }
+}

--- a/client/electron-main.ts
+++ b/client/electron-main.ts
@@ -1,0 +1,236 @@
+import { app, protocol, BrowserWindow, Menu, session, shell, screen, ipcMain, globalShortcut } from 'electron';
+import { BrowserWindowConstructorOptions, MenuItemConstructorOptions } from 'electron/main';
+import { autoUpdater } from 'electron-updater';
+import * as path from 'path';
+import * as url from 'url';
+
+/**
+ * cannot combine angular and electron modules, so this variable has to be copied
+ */
+const ELECTRON_NEW_SERVER_CHANNEL = 'newserver';
+const args = process.argv.slice(1);
+const debug = args.some(val => val === '--debug');
+
+let win = null;
+let osBackendUrl = '';
+
+/**
+ * Extract the openSlidesCsrfToken from a cookie, return it as string
+ */
+function extractToken(cookie: string): string {
+    if (cookie) {
+        /**
+         * one might make this less ugly or find something smarter.
+         * The shape is:
+         * OpenSlidesCsrfToken=AAA; OpenSlidesSessionID=BBB
+         */
+        return cookie.split(';')[0].split('=')[1];
+    }
+}
+
+/**
+ * Configures the session for OpenSlides
+ */
+function configureSession(): void {
+    const filter = { urls: ['http://*/*', 'https://*/*'] };
+
+    /**
+     * Remap the cookies SameSite directive from "Lax" to "None"
+     * So electron will not simply throw them away
+     */
+    session.defaultSession.webRequest.onHeadersReceived(filter, (details, callback) => {
+        const cookies = (details.responseHeaders['set-cookie'] || []).map(cookie =>
+            cookie.replace('SameSite=Lax', 'SameSite=None')
+        );
+
+        if (cookies.length > 0) {
+            details.responseHeaders['set-cookie'] = cookies;
+        }
+        callback({ cancel: false, responseHeaders: details.responseHeaders });
+    });
+
+    session.defaultSession.webRequest.onBeforeSendHeaders(filter, (details, callback) => {
+        /**
+         * after the login, the "requestHeaders" has a "Cookie" field "with capital C"
+         * This contains somethin like:
+         * OpenSlidesCsrfToken=AAA; OpenSlidesSessionID=BBB
+         * using extractToken we extract the token value and set it as
+         * `requestHeaders['x-csrftoken'] = xcsrftoken;`
+         * It's ugly and it works
+         */
+        const xcsrftoken = extractToken(details.requestHeaders['Cookie']);
+        details.requestHeaders['x-csrftoken'] = xcsrftoken;
+        callback({ requestHeaders: details.requestHeaders });
+    });
+}
+
+function createMenu(): void {
+    const template: MenuItemConstructorOptions[] = [
+        {
+            label: 'File',
+            submenu: [
+                { role: 'reload' },
+                { label: 'Logout', click: async () => cleanStorage() },
+                { type: 'separator' },
+                { role: 'quit' }
+            ]
+        },
+        {
+            label: 'View',
+            submenu: [{ role: 'toggleDevTools' }, { role: 'togglefullscreen' }]
+        },
+        {
+            role: 'help',
+            submenu: [
+                {
+                    label: 'Report Issue',
+                    click: async () => openExternal('https://github.com/OpenSlides/OpenSlides/issues/new/choose')
+                },
+                {
+                    label: 'OpenSlides',
+                    click: async () => openExternal('https://openslides.com/de')
+                },
+                {
+                    label: 'Electron',
+                    click: async () => openExternal('https://electronjs.org')
+                }
+            ]
+        }
+    ];
+    const menu = Menu.buildFromTemplate(template);
+    Menu.setApplicationMenu(menu);
+}
+
+function createWindow(): void {
+    createMenu();
+
+    /**
+     * configure session for utter cookie madness
+     */
+    configureSession();
+
+    const size = screen.getPrimaryDisplay().workAreaSize;
+    const windowProperties: BrowserWindowConstructorOptions = {
+        x: 0,
+        y: 0,
+        width: size.width,
+        height: size.height,
+        webPreferences: {
+            /**
+             * Third party script support
+             */
+            nodeIntegration: true,
+            // nodeIntegrationInWorker: true,
+            enableRemoteModule: true,
+            webSecurity: !debug,
+            allowRunningInsecureContent: debug
+        }
+    };
+
+    win = new BrowserWindow(windowProperties);
+
+    const urlFormat = url.format({
+        pathname: 'index.html',
+        protocol: 'file',
+        slashes: true
+    });
+
+    win.loadURL(urlFormat);
+
+    win.webContents.on('did-fail-load', () => {
+        win.loadURL(urlFormat);
+    });
+
+    /**
+     * Open links externally
+     */
+    win.webContents.on('new-window', (e, url) => {
+        e.preventDefault();
+        /**
+         * If external links start with "file://"
+         * replace them with the backendURL instead
+         */
+        if (url.startsWith('file://')) {
+            url = url.substr(7);
+            url = osBackendUrl + url;
+        }
+        shell.openExternal(url);
+    });
+
+    win.on('closed', () => {
+        win = null;
+    });
+}
+
+async function cleanStorage(): Promise<void> {
+    await session.defaultSession.clearStorageData();
+    console.log('Cleaned storage data');
+    win.reload();
+}
+
+async function openExternal(link: string): Promise<void> {
+    await shell.openExternal(link);
+}
+
+try {
+    /**
+     * On certificate error we disable default behaviour (stop loading the page)
+     * and we then say "it is all fine - true" to the callback.
+     * This is necessary to develop against self signed certificates
+     */
+    app.on('certificate-error', (event, webContents, url, error, certificate, callback) => {
+        if (debug) {
+            event.preventDefault();
+            callback(true);
+        }
+    });
+
+    /**
+     * Intercept the file protocol, so we cann access the assets folder to
+     * call css, js and json files.
+     * In pure electron, this would not be required
+     */
+    app.on('ready', () => {
+        /**
+         * Add custom global shortcuts
+         */
+        globalShortcut.register('f12', () => {
+            if (win) {
+                win.toggleDevTools();
+            }
+        });
+
+        protocol.interceptFileProtocol('file', (request, callback) => {
+            /**
+             * all urls start with 'file://'
+             */
+            const url = request.url.substr(7);
+            callback({ path: path.normalize(`${__dirname}/dist/os3/${url}`) });
+        });
+        createWindow();
+    });
+
+    // on macOS, closing the window doesn't quit the app
+    app.on('window-all-closed', () => {
+        if (process.platform !== 'darwin') {
+            app.quit();
+        }
+    });
+
+    app.on('activate', () => {
+        if (win === null) {
+            createWindow();
+        }
+    });
+
+    /**
+     * Get information from angulars "attach-external-server" service
+     */
+    ipcMain.on(ELECTRON_NEW_SERVER_CHANNEL, (_, arg: string) => {
+        if (arg) {
+            osBackendUrl = arg;
+        }
+    });
+} catch (e) {
+    console.error(e);
+}

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,9 +1,15 @@
 {
     "name": "OpenSlides3-Client",
-    "version": "3.3.0",
+    "version": "3.4.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "7zip-bin": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.0.3.tgz",
+            "integrity": "sha512-GLyWIFBbGvpKPGo55JyRZAo4lVbnBiD52cKlw/0Vt+wnmKvWJkpZvsjVoaIolyBXDeAQKSicRtqFNPem9w0WYA==",
+            "dev": true
+        },
         "@angular-devkit/architect": {
             "version": "0.1000.8",
             "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1000.8.tgz",
@@ -115,6 +121,16 @@
                     "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
                     "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==",
                     "dev": true
+                },
+                "open": {
+                    "version": "7.0.4",
+                    "resolved": "https://registry.npmjs.org/open/-/open-7.0.4.tgz",
+                    "integrity": "sha512-brSA+/yq+b08Hsr4c8fsEW2CRzk1BmfN3SAK/5VCHQ9bdoZJ4qa/+AfR0xHjlbbZUyPkUHs1b8x1RqdyZdkVqQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-docker": "^2.0.0",
+                        "is-wsl": "^2.1.1"
+                    }
                 },
                 "parse5": {
                     "version": "4.0.0",
@@ -370,6 +386,16 @@
                     "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
                     "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
                     "dev": true
+                },
+                "open": {
+                    "version": "7.0.4",
+                    "resolved": "https://registry.npmjs.org/open/-/open-7.0.4.tgz",
+                    "integrity": "sha512-brSA+/yq+b08Hsr4c8fsEW2CRzk1BmfN3SAK/5VCHQ9bdoZJ4qa/+AfR0xHjlbbZUyPkUHs1b8x1RqdyZdkVqQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-docker": "^2.0.0",
+                        "is-wsl": "^2.1.1"
+                    }
                 },
                 "rimraf": {
                     "version": "3.0.2",
@@ -2245,6 +2271,16 @@
                 "viz.js": "^1.8.0"
             }
         },
+        "@develar/schema-utils": {
+            "version": "2.6.5",
+            "resolved": "https://registry.npmjs.org/@develar/schema-utils/-/schema-utils-2.6.5.tgz",
+            "integrity": "sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==",
+            "dev": true,
+            "requires": {
+                "ajv": "^6.12.0",
+                "ajv-keywords": "^3.4.1"
+            }
+        },
         "@dsherret/to-absolute-glob": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
@@ -2253,6 +2289,42 @@
             "requires": {
                 "is-absolute": "^1.0.0",
                 "is-negated-glob": "^1.0.0"
+            }
+        },
+        "@electron/get": {
+            "version": "1.12.4",
+            "resolved": "https://registry.npmjs.org/@electron/get/-/get-1.12.4.tgz",
+            "integrity": "sha512-6nr9DbJPUR9Xujw6zD3y+rS95TyItEVM0NVjt1EehY2vUWfIgPiIPVHxCvaTS0xr2B+DRxovYVKbuOWqC35kjg==",
+            "dev": true,
+            "requires": {
+                "debug": "^4.1.1",
+                "env-paths": "^2.2.0",
+                "fs-extra": "^8.1.0",
+                "global-agent": "^2.0.2",
+                "global-tunnel-ng": "^2.7.1",
+                "got": "^9.6.0",
+                "progress": "^2.0.3",
+                "semver": "^6.2.0",
+                "sumchecker": "^3.0.1"
+            },
+            "dependencies": {
+                "fs-extra": {
+                    "version": "8.1.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+                    "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.2.0",
+                        "jsonfile": "^4.0.0",
+                        "universalify": "^0.1.0"
+                    }
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                }
             }
         },
         "@istanbuljs/schema": {
@@ -2532,6 +2604,21 @@
                 }
             }
         },
+        "@sindresorhus/is": {
+            "version": "0.14.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+            "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+            "dev": true
+        },
+        "@szmarczak/http-timer": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+            "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+            "dev": true,
+            "requires": {
+                "defer-to-connect": "^1.0.1"
+            }
+        },
         "@tinymce/tinymce-angular": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/@tinymce/tinymce-angular/-/tinymce-angular-4.1.0.tgz",
@@ -2553,6 +2640,21 @@
             "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
             "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
             "dev": true
+        },
+        "@types/debug": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
+            "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==",
+            "dev": true
+        },
+        "@types/fs-extra": {
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.7.tgz",
+            "integrity": "sha512-YGq2A6Yc3bldrLUlm17VNWOnUbnEzJ9CMgOeLFtQF3HOCN5lQBO8VyjG00a5acA5NNSM30kHVGp1trZgnVgi1Q==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
         },
         "@types/glob": {
             "version": "7.1.3",
@@ -2623,6 +2725,11 @@
             "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-3.0.17.tgz",
             "integrity": "sha512-tGomyEuzSC1H28y2zlW6XPCaDaXFaD6soTdb4GNdmte2qfHtrKqhy0ZFs4r/1hpazCfEZqeTSRLvSasmEx89uw==",
             "dev": true
+        },
+        "@types/semver": {
+            "version": "7.3.4",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.4.tgz",
+            "integrity": "sha512-+nVsLKlcUCeMzD2ufHEYuJ9a2ovstb6Dp52A5VsoKxDXgvE051XgHI/33I1EymwkRGQkwnA0LkhnUzituGs4EQ=="
         },
         "@types/source-list-map": {
             "version": "0.1.2",
@@ -3197,6 +3304,109 @@
             "integrity": "sha512-sbLEIMQrkV7RkIruqTPXxeCMkAAycv4yzTkBzRgOR1BrR5UB7qZtupqxkersTJSf0HZ3sbaNRrNV80TnnM7cUw==",
             "dev": true
         },
+        "app-builder-bin": {
+            "version": "3.5.10",
+            "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-3.5.10.tgz",
+            "integrity": "sha512-Jd+GW68lR0NeetgZDo47PdWBEPdnD+p0jEa7XaxjRC8u6Oo/wgJsfKUkORRgr2NpkD19IFKN50P6JYy04XHFLQ==",
+            "dev": true
+        },
+        "app-builder-lib": {
+            "version": "22.9.1",
+            "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-22.9.1.tgz",
+            "integrity": "sha512-KfXim/fiNwFW2SKffsjEMdAU7RbbEXn62x5YyXle1b4j9X/wEHW9iwox8De6y0hJdR+/kCC/49lI+VgNwLhV7A==",
+            "dev": true,
+            "requires": {
+                "7zip-bin": "~5.0.3",
+                "@develar/schema-utils": "~2.6.5",
+                "async-exit-hook": "^2.0.1",
+                "bluebird-lst": "^1.0.9",
+                "builder-util": "22.9.1",
+                "builder-util-runtime": "8.7.2",
+                "chromium-pickle-js": "^0.2.0",
+                "debug": "^4.3.0",
+                "ejs": "^3.1.5",
+                "electron-publish": "22.9.1",
+                "fs-extra": "^9.0.1",
+                "hosted-git-info": "^3.0.5",
+                "is-ci": "^2.0.0",
+                "isbinaryfile": "^4.0.6",
+                "js-yaml": "^3.14.0",
+                "lazy-val": "^1.0.4",
+                "minimatch": "^3.0.4",
+                "normalize-package-data": "^2.5.0",
+                "read-config-file": "6.0.0",
+                "sanitize-filename": "^1.6.3",
+                "semver": "^7.3.2",
+                "temp-file": "^3.3.7"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.3.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+                    "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "fs-extra": {
+                    "version": "9.1.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+                    "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+                    "dev": true,
+                    "requires": {
+                        "at-least-node": "^1.0.0",
+                        "graceful-fs": "^4.2.0",
+                        "jsonfile": "^6.0.1",
+                        "universalify": "^2.0.0"
+                    }
+                },
+                "js-yaml": {
+                    "version": "3.14.1",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+                    "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+                    "dev": true,
+                    "requires": {
+                        "argparse": "^1.0.7",
+                        "esprima": "^4.0.0"
+                    }
+                },
+                "jsonfile": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+                    "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.6",
+                        "universalify": "^2.0.0"
+                    }
+                },
+                "lru-cache": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+                    "dev": true,
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
+                },
+                "semver": {
+                    "version": "7.3.4",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+                    "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                },
+                "universalify": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+                    "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+                    "dev": true
+                }
+            }
+        },
         "app-root-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-3.0.0.tgz",
@@ -3512,6 +3722,12 @@
             "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
             "dev": true
         },
+        "async-exit-hook": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
+            "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
+            "dev": true
+        },
         "async-limiter": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
@@ -3522,6 +3738,11 @@
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+        },
+        "at-least-node": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+            "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
         },
         "atob": {
             "version": "2.1.2",
@@ -3832,6 +4053,23 @@
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
             "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM="
         },
+        "bluebird-lst": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/bluebird-lst/-/bluebird-lst-1.0.9.tgz",
+            "integrity": "sha512-7B1Rtx82hjnSD4PGLAjVWeYH3tHAcVUmChh85a3lltKQm6FresXh9ErQo6oAv6CqxttczC3/kEg8SY5NluPuUw==",
+            "dev": true,
+            "requires": {
+                "bluebird": "^3.5.5"
+            },
+            "dependencies": {
+                "bluebird": {
+                    "version": "3.7.2",
+                    "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+                    "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+                    "dev": true
+                }
+            }
+        },
         "bn.js": {
             "version": "5.1.3",
             "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
@@ -3912,6 +4150,13 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
             "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+        },
+        "boolean": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.0.2.tgz",
+            "integrity": "sha512-RwywHlpCRc3/Wh81MiCKun4ydaIFyW5Ea6JbL6sRCVx5q5irDw7pMXBUFYF/jArQ6YrG36q0kpovc9P/Kd3I4g==",
+            "dev": true,
+            "optional": true
         },
         "boxen": {
             "version": "4.2.0",
@@ -4254,6 +4499,129 @@
                 }
             }
         },
+        "builder-util": {
+            "version": "22.9.1",
+            "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-22.9.1.tgz",
+            "integrity": "sha512-5hN/XOaYu4ZQUS6F+5CXE6jTo+NAnVqAxDuKGSaHWb9bejfv/rluChTLoY3/nJh7RFjkoyVjvFJv7zQDB1QmHw==",
+            "dev": true,
+            "requires": {
+                "7zip-bin": "~5.0.3",
+                "@types/debug": "^4.1.5",
+                "@types/fs-extra": "^9.0.1",
+                "app-builder-bin": "3.5.10",
+                "bluebird-lst": "^1.0.9",
+                "builder-util-runtime": "8.7.2",
+                "chalk": "^4.1.0",
+                "debug": "^4.3.0",
+                "fs-extra": "^9.0.1",
+                "is-ci": "^2.0.0",
+                "js-yaml": "^3.14.0",
+                "source-map-support": "^0.5.19",
+                "stat-mode": "^1.0.0",
+                "temp-file": "^3.3.7"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "debug": {
+                    "version": "4.3.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+                    "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "fs-extra": {
+                    "version": "9.1.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+                    "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+                    "dev": true,
+                    "requires": {
+                        "at-least-node": "^1.0.0",
+                        "graceful-fs": "^4.2.0",
+                        "jsonfile": "^6.0.1",
+                        "universalify": "^2.0.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "js-yaml": {
+                    "version": "3.14.1",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+                    "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+                    "dev": true,
+                    "requires": {
+                        "argparse": "^1.0.7",
+                        "esprima": "^4.0.0"
+                    }
+                },
+                "jsonfile": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+                    "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.6",
+                        "universalify": "^2.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                },
+                "universalify": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+                    "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+                    "dev": true
+                }
+            }
+        },
+        "builder-util-runtime": {
+            "version": "8.7.2",
+            "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.7.2.tgz",
+            "integrity": "sha512-xBqv+8bg6cfnzAQK1k3OGpfaHg+QkPgIgpEkXNhouZ0WiUkyZCftuRc2LYzQrLucFywpa14Xbc6+hTbpq83yRA==",
+            "requires": {
+                "debug": "^4.1.1",
+                "sax": "^1.2.4"
+            }
+        },
         "builtin-modules": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -4349,6 +4717,50 @@
                 "to-object-path": "^0.3.0",
                 "union-value": "^1.0.0",
                 "unset-value": "^1.0.0"
+            }
+        },
+        "cacheable-request": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+            "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+            "dev": true,
+            "requires": {
+                "clone-response": "^1.0.2",
+                "get-stream": "^5.1.0",
+                "http-cache-semantics": "^4.0.0",
+                "keyv": "^3.0.0",
+                "lowercase-keys": "^2.0.0",
+                "normalize-url": "^4.1.0",
+                "responselike": "^1.0.2"
+            },
+            "dependencies": {
+                "get-stream": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+                    "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+                    "dev": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                },
+                "http-cache-semantics": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+                    "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+                    "dev": true
+                },
+                "lowercase-keys": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+                    "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+                    "dev": true
+                },
+                "normalize-url": {
+                    "version": "4.5.0",
+                    "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+                    "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
+                    "dev": true
+                }
             }
         },
         "call-bind": {
@@ -4553,6 +4965,12 @@
                 "tslib": "^1.9.0"
             }
         },
+        "chromium-pickle-js": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
+            "integrity": "sha1-BKEGZywYsIWrd02YPfo+oTjyIgU=",
+            "dev": true
+        },
         "ci-info": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
@@ -4690,6 +5108,15 @@
                 "is-plain-object": "^2.0.4",
                 "kind-of": "^6.0.2",
                 "shallow-clone": "^3.0.0"
+            }
+        },
+        "clone-response": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+            "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+            "dev": true,
+            "requires": {
+                "mimic-response": "^1.0.0"
             }
         },
         "coa": {
@@ -4979,6 +5406,48 @@
                         "string_decoder": "~1.1.1",
                         "util-deprecate": "~1.0.1"
                     }
+                }
+            }
+        },
+        "config-chain": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
+            "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "ini": "^1.3.4",
+                "proto-list": "~1.2.1"
+            }
+        },
+        "configstore": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
+            "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
+            "dev": true,
+            "requires": {
+                "dot-prop": "^5.2.0",
+                "graceful-fs": "^4.1.2",
+                "make-dir": "^3.0.0",
+                "unique-string": "^2.0.0",
+                "write-file-atomic": "^3.0.0",
+                "xdg-basedir": "^4.0.0"
+            },
+            "dependencies": {
+                "make-dir": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+                    "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+                    "dev": true,
+                    "requires": {
+                        "semver": "^6.0.0"
+                    }
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
                 }
             }
         },
@@ -5377,6 +5846,12 @@
             "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.3.0.tgz",
             "integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q=="
         },
+        "crypto-random-string": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+            "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+            "dev": true
+        },
         "css": {
             "version": "2.2.4",
             "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
@@ -5700,7 +6175,6 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
             "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-            "dev": true,
             "requires": {
                 "ms": "^2.1.1"
             }
@@ -5732,6 +6206,15 @@
             "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
             "dev": true
         },
+        "decompress-response": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+            "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+            "dev": true,
+            "requires": {
+                "mimic-response": "^1.0.0"
+            }
+        },
         "deep-equal": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
@@ -5744,6 +6227,12 @@
                 "object-keys": "^1.1.1",
                 "regexp.prototype.flags": "^1.2.0"
             }
+        },
+        "deep-extend": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+            "dev": true
         },
         "deep-is": {
             "version": "0.1.3",
@@ -5768,6 +6257,12 @@
             "requires": {
                 "clone": "^1.0.2"
             }
+        },
+        "defer-to-connect": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+            "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
+            "dev": true
         },
         "define-properties": {
             "version": "1.1.3",
@@ -5969,6 +6464,69 @@
                 }
             }
         },
+        "dmg-builder": {
+            "version": "22.9.1",
+            "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-22.9.1.tgz",
+            "integrity": "sha512-jc+DAirqmQrNT6KbDHdfEp8D1kD0DBTnsLhwUR3MX+hMBun5bT134LQzpdK0GKvd22GqF8L1Cz/NOgaVjscAXQ==",
+            "dev": true,
+            "requires": {
+                "app-builder-lib": "22.9.1",
+                "builder-util": "22.9.1",
+                "fs-extra": "^9.0.1",
+                "iconv-lite": "^0.6.2",
+                "js-yaml": "^3.14.0",
+                "sanitize-filename": "^1.6.3"
+            },
+            "dependencies": {
+                "fs-extra": {
+                    "version": "9.1.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+                    "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+                    "dev": true,
+                    "requires": {
+                        "at-least-node": "^1.0.0",
+                        "graceful-fs": "^4.2.0",
+                        "jsonfile": "^6.0.1",
+                        "universalify": "^2.0.0"
+                    }
+                },
+                "iconv-lite": {
+                    "version": "0.6.2",
+                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+                    "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+                    "dev": true,
+                    "requires": {
+                        "safer-buffer": ">= 2.1.2 < 3.0.0"
+                    }
+                },
+                "js-yaml": {
+                    "version": "3.14.1",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+                    "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+                    "dev": true,
+                    "requires": {
+                        "argparse": "^1.0.7",
+                        "esprima": "^4.0.0"
+                    }
+                },
+                "jsonfile": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+                    "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.6",
+                        "universalify": "^2.0.0"
+                    }
+                },
+                "universalify": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+                    "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+                    "dev": true
+                }
+            }
+        },
         "dns-equal": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
@@ -6063,6 +6621,18 @@
                 "is-obj": "^2.0.0"
             }
         },
+        "dotenv": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+            "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+            "dev": true
+        },
+        "dotenv-expand": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
+            "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
+            "dev": true
+        },
         "duplexer": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
@@ -6092,6 +6662,12 @@
                     }
                 }
             }
+        },
+        "duplexer3": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+            "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+            "dev": true
         },
         "duplexify": {
             "version": "3.7.1",
@@ -6137,11 +6713,376 @@
             "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
             "dev": true
         },
+        "ejs": {
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.6.tgz",
+            "integrity": "sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==",
+            "dev": true,
+            "requires": {
+                "jake": "^10.6.1"
+            }
+        },
+        "electron": {
+            "version": "11.2.3",
+            "resolved": "https://registry.npmjs.org/electron/-/electron-11.2.3.tgz",
+            "integrity": "sha512-6yxOc42nDAptHKNlUG/vcOh2GI9x2fqp2nQbZO0/3sz2CrwsJkwR3i3oMN9XhVJaqI7GK1vSCJz0verOkWlXcQ==",
+            "dev": true,
+            "requires": {
+                "@electron/get": "^1.0.1",
+                "@types/node": "^12.0.12",
+                "extract-zip": "^1.0.3"
+            },
+            "dependencies": {
+                "@types/node": {
+                    "version": "12.20.0",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.0.tgz",
+                    "integrity": "sha512-0/41wHcurotvSOTHQUFkgL702c3pyWR1mToSrrX3pGPvGfpHTv3Ksx0M4UVuU5VJfjVb62Eyr1eKO1tWNUCg2Q==",
+                    "dev": true
+                }
+            }
+        },
+        "electron-builder": {
+            "version": "22.9.1",
+            "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-22.9.1.tgz",
+            "integrity": "sha512-GXPt8l5Mxwm1QKYopUM6/Tdh9W3695G6Ax+IFyj5pQ51G4SD5L1uq4/RkPSsOgs3rP7jNSV6g6OfDzdtVufPdA==",
+            "dev": true,
+            "requires": {
+                "@types/yargs": "^15.0.5",
+                "app-builder-lib": "22.9.1",
+                "bluebird-lst": "^1.0.9",
+                "builder-util": "22.9.1",
+                "builder-util-runtime": "8.7.2",
+                "chalk": "^4.1.0",
+                "dmg-builder": "22.9.1",
+                "fs-extra": "^9.0.1",
+                "is-ci": "^2.0.0",
+                "lazy-val": "^1.0.4",
+                "read-config-file": "6.0.0",
+                "sanitize-filename": "^1.6.3",
+                "update-notifier": "^4.1.1",
+                "yargs": "^16.0.3"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "cliui": {
+                    "version": "7.0.4",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+                    "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^4.2.0",
+                        "strip-ansi": "^6.0.0",
+                        "wrap-ansi": "^7.0.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "fs-extra": {
+                    "version": "9.1.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+                    "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+                    "dev": true,
+                    "requires": {
+                        "at-least-node": "^1.0.0",
+                        "graceful-fs": "^4.2.0",
+                        "jsonfile": "^6.0.1",
+                        "universalify": "^2.0.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+                    "dev": true
+                },
+                "jsonfile": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+                    "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.6",
+                        "universalify": "^2.0.0"
+                    }
+                },
+                "string-width": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+                    "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^8.0.0",
+                        "is-fullwidth-code-point": "^3.0.0",
+                        "strip-ansi": "^6.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^5.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                },
+                "universalify": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+                    "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+                    "dev": true
+                },
+                "wrap-ansi": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+                    "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.0.0",
+                        "string-width": "^4.1.0",
+                        "strip-ansi": "^6.0.0"
+                    }
+                },
+                "y18n": {
+                    "version": "5.0.5",
+                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+                    "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
+                    "dev": true
+                },
+                "yargs": {
+                    "version": "16.2.0",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+                    "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^7.0.2",
+                        "escalade": "^3.1.1",
+                        "get-caller-file": "^2.0.5",
+                        "require-directory": "^2.1.1",
+                        "string-width": "^4.2.0",
+                        "y18n": "^5.0.5",
+                        "yargs-parser": "^20.2.2"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "20.2.4",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+                    "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+                    "dev": true
+                }
+            }
+        },
+        "electron-publish": {
+            "version": "22.9.1",
+            "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-22.9.1.tgz",
+            "integrity": "sha512-ducLjRJLEeU87FaTCWaUyDjCoLXHkawkltP2zqS/n2PyGke54ZIql0tBuUheht4EpR8AhFbVJ11spSn1gy8r6w==",
+            "dev": true,
+            "requires": {
+                "@types/fs-extra": "^9.0.1",
+                "bluebird-lst": "^1.0.9",
+                "builder-util": "22.9.1",
+                "builder-util-runtime": "8.7.2",
+                "chalk": "^4.1.0",
+                "fs-extra": "^9.0.1",
+                "lazy-val": "^1.0.4",
+                "mime": "^2.4.6"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "fs-extra": {
+                    "version": "9.1.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+                    "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+                    "dev": true,
+                    "requires": {
+                        "at-least-node": "^1.0.0",
+                        "graceful-fs": "^4.2.0",
+                        "jsonfile": "^6.0.1",
+                        "universalify": "^2.0.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "jsonfile": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+                    "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.6",
+                        "universalify": "^2.0.0"
+                    }
+                },
+                "mime": {
+                    "version": "2.5.0",
+                    "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.0.tgz",
+                    "integrity": "sha512-ft3WayFSFUVBuJj7BMLKAQcSlItKtfjsKDDsii3rqFDAZ7t11zRe8ASw/GlmivGwVUYtwkQrxiGGpL6gFvB0ag==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                },
+                "universalify": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+                    "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+                    "dev": true
+                }
+            }
+        },
         "electron-to-chromium": {
             "version": "1.3.642",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.642.tgz",
             "integrity": "sha512-cev+jOrz/Zm1i+Yh334Hed6lQVOkkemk2wRozfMF4MtTR7pxf3r3L5Rbd7uX1zMcEqVJ7alJBnJL7+JffkC6FQ==",
             "dev": true
+        },
+        "electron-updater": {
+            "version": "4.3.5",
+            "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-4.3.5.tgz",
+            "integrity": "sha512-5jjN7ebvfj1cLI0VZMdCnJk6aC4bP+dy7ryBf21vArR0JzpRVk0OZHA2QBD+H5rm6ZSeDYHOY6+8PrMEqJ4wlQ==",
+            "requires": {
+                "@types/semver": "^7.3.1",
+                "builder-util-runtime": "8.7.2",
+                "fs-extra": "^9.0.1",
+                "js-yaml": "^3.14.0",
+                "lazy-val": "^1.0.4",
+                "lodash.isequal": "^4.5.0",
+                "semver": "^7.3.2"
+            },
+            "dependencies": {
+                "fs-extra": {
+                    "version": "9.1.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+                    "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+                    "requires": {
+                        "at-least-node": "^1.0.0",
+                        "graceful-fs": "^4.2.0",
+                        "jsonfile": "^6.0.1",
+                        "universalify": "^2.0.0"
+                    }
+                },
+                "js-yaml": {
+                    "version": "3.14.1",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+                    "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+                    "requires": {
+                        "argparse": "^1.0.7",
+                        "esprima": "^4.0.0"
+                    }
+                },
+                "jsonfile": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+                    "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+                    "requires": {
+                        "graceful-fs": "^4.1.6",
+                        "universalify": "^2.0.0"
+                    }
+                },
+                "lru-cache": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
+                },
+                "semver": {
+                    "version": "7.3.4",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+                    "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                },
+                "universalify": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+                    "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+                }
+            }
         },
         "elliptic": {
             "version": "6.5.3",
@@ -6303,6 +7244,12 @@
             "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
             "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
         },
+        "env-paths": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
+            "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
+            "dev": true
+        },
         "err-code": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
@@ -6364,6 +7311,13 @@
                 "es6-symbol": "~3.1.3",
                 "next-tick": "~1.0.0"
             }
+        },
+        "es6-error": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+            "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+            "dev": true,
+            "optional": true
         },
         "es6-iterator": {
             "version": "2.0.3",
@@ -6441,6 +7395,12 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
             "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+            "dev": true
+        },
+        "escape-goat": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-2.1.1.tgz",
+            "integrity": "sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==",
             "dev": true
         },
         "escape-html": {
@@ -6890,6 +7850,35 @@
                 }
             }
         },
+        "extract-zip": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
+            "integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
+            "dev": true,
+            "requires": {
+                "concat-stream": "^1.6.2",
+                "debug": "^2.6.9",
+                "mkdirp": "^0.5.4",
+                "yauzl": "^2.10.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
+            }
+        },
         "extsprintf": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -6998,6 +7987,15 @@
                 "websocket-driver": ">=0.5.1"
             }
         },
+        "fd-slicer": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+            "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+            "dev": true,
+            "requires": {
+                "pend": "~1.2.0"
+            }
+        },
         "figgy-pudding": {
             "version": "3.5.2",
             "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
@@ -7049,6 +8047,15 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
             "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+        },
+        "filelist": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.2.tgz",
+            "integrity": "sha512-z7O0IS8Plc39rTCq6i6iHxk43duYOn8uFJiWSewIq0Bww1RNybVHSCjahmcC87ZqAm4OTvFzlzeGu3XAzG1ctQ==",
+            "dev": true,
+            "requires": {
+                "minimatch": "^3.0.4"
+            }
         },
         "fill-range": {
             "version": "7.0.1",
@@ -7602,11 +8609,89 @@
                 "process": "^0.11.10"
             }
         },
+        "global-agent": {
+            "version": "2.1.12",
+            "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-2.1.12.tgz",
+            "integrity": "sha512-caAljRMS/qcDo69X9BfkgrihGUgGx44Fb4QQToNQjsiWh+YlQ66uqYVAdA8Olqit+5Ng0nkz09je3ZzANMZcjg==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "boolean": "^3.0.1",
+                "core-js": "^3.6.5",
+                "es6-error": "^4.1.1",
+                "matcher": "^3.0.0",
+                "roarr": "^2.15.3",
+                "semver": "^7.3.2",
+                "serialize-error": "^7.0.1"
+            },
+            "dependencies": {
+                "lru-cache": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
+                },
+                "semver": {
+                    "version": "7.3.4",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+                    "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                }
+            }
+        },
+        "global-dirs": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.1.0.tgz",
+            "integrity": "sha512-MG6kdOUh/xBnyo9cJFeIKkLEc1AyFq42QTU4XiX51i2NEdxLxLWXIjEjmqKeSuKR7pAZjTqUVoT2b2huxVLgYQ==",
+            "dev": true,
+            "requires": {
+                "ini": "1.3.7"
+            },
+            "dependencies": {
+                "ini": {
+                    "version": "1.3.7",
+                    "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
+                    "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==",
+                    "dev": true
+                }
+            }
+        },
+        "global-tunnel-ng": {
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/global-tunnel-ng/-/global-tunnel-ng-2.7.1.tgz",
+            "integrity": "sha512-4s+DyciWBV0eK148wqXxcmVAbFVPqtc3sEtUE/GTQfuU80rySLcMhUmHKSHI7/LDj8q0gDYI1lIhRRB7ieRAqg==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "encodeurl": "^1.0.2",
+                "lodash": "^4.17.10",
+                "npm-conf": "^1.1.3",
+                "tunnel": "^0.0.6"
+            }
+        },
         "globals": {
             "version": "11.12.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
             "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
             "dev": true
+        },
+        "globalthis": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.1.tgz",
+            "integrity": "sha512-mJPRTc/P39NH/iNG4mXa9aIhNymaQikTrnspeCa2ZuJ+mH2QN/rXwtX3XwKrHqWgUQFbNZKtHM105aHzJalElw==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "define-properties": "^1.1.3"
+            }
         },
         "globby": {
             "version": "11.0.2",
@@ -7679,6 +8764,25 @@
                     "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
                     "dev": true
                 }
+            }
+        },
+        "got": {
+            "version": "9.6.0",
+            "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+            "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+            "dev": true,
+            "requires": {
+                "@sindresorhus/is": "^0.14.0",
+                "@szmarczak/http-timer": "^1.1.2",
+                "cacheable-request": "^6.0.0",
+                "decompress-response": "^3.3.0",
+                "duplexer3": "^0.1.4",
+                "get-stream": "^4.1.0",
+                "lowercase-keys": "^1.0.1",
+                "mimic-response": "^1.0.1",
+                "p-cancelable": "^1.0.0",
+                "to-readable-stream": "^1.0.0",
+                "url-parse-lax": "^3.0.0"
             }
         },
         "graceful-fs": {
@@ -7834,6 +8938,12 @@
                     }
                 }
             }
+        },
+        "has-yarn": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
+            "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
+            "dev": true
         },
         "hash-base": {
             "version": "3.1.0",
@@ -8388,6 +9498,12 @@
                 "resolve-from": "^3.0.0"
             }
         },
+        "import-lazy": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+            "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+            "dev": true
+        },
         "import-local": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
@@ -8662,6 +9778,15 @@
             "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
             "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
         },
+        "is-ci": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+            "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+            "dev": true,
+            "requires": {
+                "ci-info": "^2.0.0"
+            }
+        },
         "is-color-stop": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-color-stop/-/is-color-stop-1.1.0.tgz",
@@ -8766,6 +9891,24 @@
                 "is-extglob": "^2.1.1"
             }
         },
+        "is-installed-globally": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.3.2.tgz",
+            "integrity": "sha512-wZ8x1js7Ia0kecP/CHM/3ABkAmujX7WPvQk6uu3Fly/Mk44pySulQpnHG46OMjHGXApINnV4QhY3SWnECO2z5g==",
+            "dev": true,
+            "requires": {
+                "global-dirs": "^2.0.1",
+                "is-path-inside": "^3.0.1"
+            },
+            "dependencies": {
+                "is-path-inside": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
+                    "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
+                    "dev": true
+                }
+            }
+        },
         "is-interactive": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
@@ -8782,6 +9925,12 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
             "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+            "dev": true
+        },
+        "is-npm": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-4.0.0.tgz",
+            "integrity": "sha512-96ECIfh9xtDDlPylNPXhzjsykHsMJZ18ASpaWzQyBr4YRTcVjUvzaHayDAES2oU/3KpljhHUjtSRNiDwi0F0ig==",
             "dev": true
         },
         "is-number": {
@@ -8916,6 +10065,12 @@
                 "is-docker": "^2.0.0"
             }
         },
+        "is-yarn-global": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
+            "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
+            "dev": true
+        },
         "isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -9043,6 +10198,26 @@
                 "istanbul-lib-report": "^3.0.0"
             }
         },
+        "jake": {
+            "version": "10.8.2",
+            "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.2.tgz",
+            "integrity": "sha512-eLpKyrfG3mzvGE2Du8VoPbeSkRry093+tyNjdYaBbJS9v17knImYGNXQCUV0gLxQtF82m3E8iRb/wdSQZLoq7A==",
+            "dev": true,
+            "requires": {
+                "async": "0.9.x",
+                "chalk": "^2.4.2",
+                "filelist": "^1.0.1",
+                "minimatch": "^3.0.4"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "0.9.2",
+                    "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+                    "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+                    "dev": true
+                }
+            }
+        },
         "jasmine": {
             "version": "2.8.0",
             "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.8.0.tgz",
@@ -9147,6 +10322,12 @@
             "version": "2.5.2",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
             "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+            "dev": true
+        },
+        "json-buffer": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+            "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
             "dev": true
         },
         "json-parse-better-errors": {
@@ -9353,6 +10534,15 @@
             "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.0.tgz",
             "integrity": "sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ="
         },
+        "keyv": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
+            "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+            "dev": true,
+            "requires": {
+                "json-buffer": "3.0.0"
+            }
+        },
         "killable": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
@@ -9364,6 +10554,20 @@
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
             "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
             "dev": true
+        },
+        "latest-version": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
+            "integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
+            "dev": true,
+            "requires": {
+                "package-json": "^6.3.0"
+            }
+        },
+        "lazy-val": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.4.tgz",
+            "integrity": "sha512-u93kb2fPbIrfzBuLjZE+w+fJbUUMhNDXxNmMfaqNgpfQf1CO5ZSe2LfsnBqVAk7i/2NF48OSoRj+Xe2VT+lE8Q=="
         },
         "lazystream": {
             "version": "1.0.0",
@@ -10007,6 +11211,12 @@
                 "js-tokens": "^3.0.0 || ^4.0.0"
             }
         },
+        "lowercase-keys": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+            "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+            "dev": true
+        },
         "lru-cache": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -10177,6 +11387,25 @@
             "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
             "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==",
             "dev": true
+        },
+        "matcher": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+            "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "escape-string-regexp": "^4.0.0"
+            },
+            "dependencies": {
+                "escape-string-regexp": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+                    "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+                    "dev": true,
+                    "optional": true
+                }
+            }
         },
         "material-icon-font": {
             "version": "git+https://github.com/petergng/materialIconFont.git#02159f59597bc29e2f81152fd74a336b3bad1412",
@@ -10431,6 +11660,12 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
             "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+            "dev": true
+        },
+        "mimic-response": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+            "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
             "dev": true
         },
         "min-document": {
@@ -10702,8 +11937,7 @@
         "ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "multicast-dns": {
             "version": "6.2.3",
@@ -11090,6 +12324,26 @@
             "dev": true,
             "requires": {
                 "npm-normalize-package-bin": "^1.0.1"
+            }
+        },
+        "npm-conf": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/npm-conf/-/npm-conf-1.1.3.tgz",
+            "integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "config-chain": "^1.1.11",
+                "pify": "^3.0.0"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+                    "dev": true,
+                    "optional": true
+                }
             }
         },
         "npm-install-checks": {
@@ -11511,16 +12765,6 @@
                 "mimic-fn": "^2.1.0"
             }
         },
-        "open": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/open/-/open-7.0.4.tgz",
-            "integrity": "sha512-brSA+/yq+b08Hsr4c8fsEW2CRzk1BmfN3SAK/5VCHQ9bdoZJ4qa/+AfR0xHjlbbZUyPkUHs1b8x1RqdyZdkVqQ==",
-            "dev": true,
-            "requires": {
-                "is-docker": "^2.0.0",
-                "is-wsl": "^2.1.1"
-            }
-        },
         "opencollective-postinstall": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
@@ -11678,6 +12922,12 @@
                 "os-tmpdir": "^1.0.0"
             }
         },
+        "p-cancelable": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+            "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
+            "dev": true
+        },
         "p-finally": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -11725,6 +12975,26 @@
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
             "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
             "dev": true
+        },
+        "package-json": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
+            "integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
+            "dev": true,
+            "requires": {
+                "got": "^9.6.0",
+                "registry-auth-token": "^4.0.0",
+                "registry-url": "^5.0.0",
+                "semver": "^6.2.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                }
+            }
         },
         "pacote": {
             "version": "9.5.12",
@@ -12152,6 +13422,12 @@
                     }
                 }
             }
+        },
+        "pend": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+            "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+            "dev": true
         },
         "performance-now": {
             "version": "2.1.0",
@@ -12928,6 +14204,12 @@
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
         },
+        "progress": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+            "dev": true
+        },
         "promise-inflight": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -12951,6 +14233,13 @@
                     "dev": true
                 }
             }
+        },
+        "proto-list": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+            "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
+            "dev": true,
+            "optional": true
         },
         "protoduck": {
             "version": "5.0.1",
@@ -13206,6 +14495,15 @@
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
             "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
         },
+        "pupa": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/pupa/-/pupa-2.1.1.tgz",
+            "integrity": "sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==",
+            "dev": true,
+            "requires": {
+                "escape-goat": "^2.0.0"
+            }
+        },
         "q": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -13325,6 +14623,18 @@
                 "schema-utils": "^2.6.5"
             }
         },
+        "rc": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+            "dev": true,
+            "requires": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+            }
+        },
         "read-cache": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -13340,6 +14650,19 @@
                     "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                     "dev": true
                 }
+            }
+        },
+        "read-config-file": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/read-config-file/-/read-config-file-6.0.0.tgz",
+            "integrity": "sha512-PHjROSdpceKUmqS06wqwP92VrM46PZSTubmNIMJ5DrMwg1OgenSTSEHIkCa6TiOJ+y/J0xnG1fFwG3M+Oi1aNA==",
+            "dev": true,
+            "requires": {
+                "dotenv": "^8.2.0",
+                "dotenv-expand": "^5.1.0",
+                "js-yaml": "^3.13.1",
+                "json5": "^2.1.2",
+                "lazy-val": "^1.0.4"
             }
         },
         "read-installed": {
@@ -13539,6 +14862,24 @@
                 "unicode-match-property-value-ecmascript": "^1.2.0"
             }
         },
+        "registry-auth-token": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
+            "integrity": "sha512-6gkSb4U6aWJB4SF2ZvLb76yCBjcvufXBqvvEx1HbmKPkutswjW1xNVRY0+daljIYRbogN7O0etYSlbiaEQyMyw==",
+            "dev": true,
+            "requires": {
+                "rc": "^1.2.8"
+            }
+        },
+        "registry-url": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
+            "integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
+            "dev": true,
+            "requires": {
+                "rc": "^1.2.8"
+            }
+        },
         "regjsgen": {
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.2.tgz",
@@ -13726,6 +15067,15 @@
                 }
             }
         },
+        "responselike": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+            "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+            "dev": true,
+            "requires": {
+                "lowercase-keys": "^1.0.0"
+            }
+        },
         "restore-cursor": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
@@ -13822,6 +15172,30 @@
                 "inherits": "^2.0.1"
             }
         },
+        "roarr": {
+            "version": "2.15.4",
+            "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+            "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "boolean": "^3.0.1",
+                "detect-node": "^2.0.4",
+                "globalthis": "^1.0.1",
+                "json-stringify-safe": "^5.0.1",
+                "semver-compare": "^1.0.0",
+                "sprintf-js": "^1.1.2"
+            },
+            "dependencies": {
+                "sprintf-js": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+                    "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+                    "dev": true,
+                    "optional": true
+                }
+            }
+        },
         "rollup": {
             "version": "2.10.9",
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.10.9.tgz",
@@ -13894,6 +15268,15 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+        },
+        "sanitize-filename": {
+            "version": "1.6.3",
+            "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+            "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+            "dev": true,
+            "requires": {
+                "truncate-utf8-bytes": "^1.0.0"
+            }
         },
         "sass": {
             "version": "1.26.5",
@@ -14055,6 +15438,23 @@
             "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
             "dev": true
         },
+        "semver-diff": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
+            "integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
+            "dev": true,
+            "requires": {
+                "semver": "^6.3.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                }
+            }
+        },
         "semver-dsl": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/semver-dsl/-/semver-dsl-1.0.1.tgz",
@@ -14122,6 +15522,25 @@
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
                     "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
                     "dev": true
+                }
+            }
+        },
+        "serialize-error": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+            "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "type-fest": "^0.13.1"
+            },
+            "dependencies": {
+                "type-fest": {
+                    "version": "0.13.1",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+                    "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -14838,6 +16257,12 @@
             "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
             "dev": true
         },
+        "stat-mode": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
+            "integrity": "sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==",
+            "dev": true
+        },
         "static-eval": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.1.0.tgz",
@@ -15108,6 +16533,12 @@
             "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
             "dev": true
         },
+        "strip-json-comments": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+            "dev": true
+        },
         "style-loader": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.2.1.tgz",
@@ -15218,6 +16649,15 @@
                         "json5": "^1.0.1"
                     }
                 }
+            }
+        },
+        "sumchecker": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+            "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+            "dev": true,
+            "requires": {
+                "debug": "^4.1.0"
             }
         },
         "supports-color": {
@@ -15405,6 +16845,29 @@
                 "readable-stream": "^3.1.1"
             }
         },
+        "temp-file": {
+            "version": "3.3.7",
+            "resolved": "https://registry.npmjs.org/temp-file/-/temp-file-3.3.7.tgz",
+            "integrity": "sha512-9tBJKt7GZAQt/Rg0QzVWA8Am8c1EFl+CAv04/aBVqlx5oyfQ508sFIABshQ0xbZu6mBrFLWIUXO/bbLYghW70g==",
+            "dev": true,
+            "requires": {
+                "async-exit-hook": "^2.0.1",
+                "fs-extra": "^8.1.0"
+            },
+            "dependencies": {
+                "fs-extra": {
+                    "version": "8.1.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+                    "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.2.0",
+                        "jsonfile": "^4.0.0",
+                        "universalify": "^0.1.0"
+                    }
+                }
+            }
+        },
         "term-size": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.0.tgz",
@@ -15583,6 +17046,12 @@
                 }
             }
         },
+        "to-readable-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+            "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
+            "dev": true
+        },
         "to-regex": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
@@ -15649,6 +17118,15 @@
             "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
             "integrity": "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==",
             "dev": true
+        },
+        "truncate-utf8-bytes": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+            "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
+            "dev": true,
+            "requires": {
+                "utf8-byte-length": "^1.0.1"
+            }
         },
         "ts-node": {
             "version": "9.0.0",
@@ -15827,6 +17305,13 @@
             "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
             "dev": true
         },
+        "tunnel": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+            "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+            "dev": true,
+            "optional": true
+        },
         "tunnel-agent": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -15873,6 +17358,15 @@
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
             "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+        },
+        "typedarray-to-buffer": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+            "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+            "dev": true,
+            "requires": {
+                "is-typedarray": "^1.0.0"
+            }
         },
         "typescript": {
             "version": "3.9.7",
@@ -16013,6 +17507,15 @@
                 "imurmurhash": "^0.1.4"
             }
         },
+        "unique-string": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+            "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+            "dev": true,
+            "requires": {
+                "crypto-random-string": "^2.0.0"
+            }
+        },
         "universal-analytics": {
             "version": "0.4.20",
             "resolved": "https://registry.npmjs.org/universal-analytics/-/universal-analytics-0.4.20.tgz",
@@ -16138,6 +17641,72 @@
             "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
             "dev": true
         },
+        "update-notifier": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-4.1.3.tgz",
+            "integrity": "sha512-Yld6Z0RyCYGB6ckIjffGOSOmHXj1gMeE7aROz4MG+XMkmixBX4jUngrGXNYz7wPKBmtoD4MnBa2Anu7RSKht/A==",
+            "dev": true,
+            "requires": {
+                "boxen": "^4.2.0",
+                "chalk": "^3.0.0",
+                "configstore": "^5.0.1",
+                "has-yarn": "^2.1.0",
+                "import-lazy": "^2.1.0",
+                "is-ci": "^2.0.0",
+                "is-installed-globally": "^0.3.1",
+                "is-npm": "^4.0.0",
+                "is-yarn-global": "^0.3.0",
+                "latest-version": "^5.0.0",
+                "pupa": "^2.0.1",
+                "semver-diff": "^3.1.1",
+                "xdg-basedir": "^4.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
         "uri-js": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -16180,6 +17749,23 @@
                 "requires-port": "^1.0.0"
             }
         },
+        "url-parse-lax": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+            "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+            "dev": true,
+            "requires": {
+                "prepend-http": "^2.0.0"
+            },
+            "dependencies": {
+                "prepend-http": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+                    "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+                    "dev": true
+                }
+            }
+        },
         "url-toolkit": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/url-toolkit/-/url-toolkit-2.2.0.tgz",
@@ -16189,6 +17775,12 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
             "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+            "dev": true
+        },
+        "utf8-byte-length": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
+            "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E=",
             "dev": true
         },
         "util": {
@@ -17530,6 +19122,18 @@
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
+        "write-file-atomic": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+            "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+            "dev": true,
+            "requires": {
+                "imurmurhash": "^0.1.4",
+                "is-typedarray": "^1.0.0",
+                "signal-exit": "^3.0.2",
+                "typedarray-to-buffer": "^3.1.5"
+            }
+        },
         "ws": {
             "version": "6.2.1",
             "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
@@ -17538,6 +19142,12 @@
             "requires": {
                 "async-limiter": "~1.0.0"
             }
+        },
+        "xdg-basedir": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+            "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
+            "dev": true
         },
         "xml2js": {
             "version": "0.4.23",
@@ -17593,8 +19203,7 @@
         "yallist": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "yaml": {
             "version": "1.10.0",
@@ -17697,6 +19306,16 @@
             "requires": {
                 "camelcase": "^5.0.0",
                 "decamelize": "^1.2.0"
+            }
+        },
+        "yauzl": {
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+            "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+            "dev": true,
+            "requires": {
+                "buffer-crc32": "~0.2.3",
+                "fd-slicer": "~1.1.0"
             }
         },
         "yeast": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "OpenSlides3-Client",
-    "version": "3.3.0",
+    "version": "3.4.0",
     "repository": {
         "type": "git",
         "url": "git://github.com/OpenSlides/OpenSlides.git"
@@ -32,7 +32,14 @@
         "prettify-check": "prettier --config ./.prettierrc --list-different \"src/{app,environments}/**/*{.ts,.js,.json,.css,.scss}\"",
         "prettify-write": "prettier --config ./.prettierrc --write \"src/{app,environments}/**/*{.ts,.js,.json,.css,.scss}\"",
         "cleanup": "npm run prettify-write; npm run lint-write",
-        "cleanup-win": "npm run prettify-write & npm run lint-write"
+        "cleanup-win": "npm run prettify-write & npm run lint-write",
+        "electron-create-main": "tsc -p tsconfig.electron-main.json",
+        "electron-test": "npm run electron-create-main && electron . --debug",
+        "electron-build-debug": "ng build --output-path ./dist/os3",
+        "electron-build-lin": "npm run electron-create-main && electron-builder build -l",
+        "electron-build-win": "npm run electron-create-main && electron-builder build -w",
+        "electron-build-mac": "npm run electron-create-main && electron-builder build -m",
+        "electron-build-all": "npm run electron-create-main && electron-builder build -lwm"
     },
     "dependencies": {
         "@angular/animations": "~10.0.14",
@@ -60,6 +67,7 @@
         "chart.js": "^2.9.3",
         "core-js": "^3.6.5",
         "css-element-queries": "^1.2.3",
+        "electron-updater": "^4.3.5",
         "exceljs": "4.1.1",
         "file-saver": "^2.0.2",
         "jszip": "^3.5.0",
@@ -99,6 +107,8 @@
         "@types/node": "^14.6.2",
         "@types/yargs": "^15.0.4",
         "codelyzer": "^6.0.0",
+        "electron": "^11.2.3",
+        "electron-builder": "^22.9.1",
         "husky": "^4.2.3",
         "jasmine-core": "~3.6.0",
         "jasmine-spec-reporter": "~5.0.1",
@@ -115,5 +125,6 @@
         "tslint": "~6.1.3",
         "tsutils": "3.17.1",
         "typescript": "~3.9.7"
-    }
+    },
+    "main": "electron-main.js"
 }

--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -6,6 +6,7 @@ import { Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { first, tap } from 'rxjs/operators';
 
+import { AttachExternalServerService } from './core/core-services/attach-external-server.service';
 import { ChatNotificationService } from './site/chat/services/chat-notification.service';
 import { ConfigService } from './core/ui-services/config.service';
 import { ConstantsService } from './core/core-services/constants.service';
@@ -87,7 +88,8 @@ export class AppComponent {
         dataStoreUpgradeService: DataStoreUpgradeService, // to start it.
         routingState: RoutingStateService,
         votingBannerService: VotingBannerService, // needed for initialisation,
-        chatNotificationService: ChatNotificationService
+        chatNotificationService: ChatNotificationService,
+        attachExternalServerService: AttachExternalServerService
     ) {
         // manually add the supported languages
         translate.addLangs(['en', 'de', 'cs', 'ru']);

--- a/client/src/app/core/core-services/attach-external-server.service.spec.ts
+++ b/client/src/app/core/core-services/attach-external-server.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AttachExternalServerService } from './attach-external-server.service';
+
+describe('AttachExternalServerService', () => {
+    let service: AttachExternalServerService;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({});
+        service = TestBed.inject(AttachExternalServerService);
+    });
+
+    it('should be created', () => {
+        expect(service).toBeTruthy();
+    });
+});

--- a/client/src/app/core/core-services/attach-external-server.service.ts
+++ b/client/src/app/core/core-services/attach-external-server.service.ts
@@ -1,0 +1,100 @@
+import { Injectable } from '@angular/core';
+
+import { IpcRenderer } from 'electron';
+import { BehaviorSubject } from 'rxjs';
+
+import { StorageService } from './storage.service';
+
+const ELECTRON_NEW_SERVER_CHANNEL = 'newserver';
+const LAST_SERVER_URL_STORE_KEY = 'lastUsedServer';
+
+@Injectable({
+    providedIn: 'root'
+})
+export class AttachExternalServerService {
+    private _ipc: IpcRenderer | undefined = void 0;
+    private usingElectron: boolean;
+    private serverUrlSubject: BehaviorSubject<string> = new BehaviorSubject<string>('');
+
+    public serverUrlObservavle = this.serverUrlSubject.asObservable();
+
+    public get isElectronApp(): boolean {
+        return this.usingElectron;
+    }
+
+    public get extUrl(): string | null {
+        if (this.usingElectron) {
+            return this.serverUrlSubject.value;
+        } else {
+            return null;
+        }
+    }
+
+    public constructor(private storageService: StorageService) {
+        this.usingElectron = this.detectElectron();
+        if (this.usingElectron) {
+            this.registerIpc();
+        }
+
+        /**
+         * Restore the last server we used, otherwise refresh would throw us out
+         */
+        storageService.get<string>(LAST_SERVER_URL_STORE_KEY).then(lastUrl => {
+            if (lastUrl) {
+                this.serverUrlSubject.next(lastUrl);
+                this.announceNewServer(lastUrl);
+            }
+        });
+    }
+
+    public async setExtUrl(url: string): Promise<void> {
+        const prettyUrl = this.prettifyUrl(url);
+        this.serverUrlSubject.next(prettyUrl);
+        if (prettyUrl.trim()) {
+            await this.storageService.set(LAST_SERVER_URL_STORE_KEY, prettyUrl);
+            this.announceNewServer(prettyUrl);
+        }
+    }
+
+    private detectElectron(): boolean {
+        /**
+         * return true to debug in browser
+         */
+        // return true;
+        try {
+            if ((<any>window)?.require('electron')) {
+                return true;
+            }
+        } catch (e) {
+            return false;
+        }
+    }
+
+    private registerIpc(): void {
+        try {
+            this._ipc = window.require('electron').ipcRenderer;
+        } catch (e) {
+            console.warn(e);
+        }
+    }
+
+    private announceNewServer(url: string): void {
+        if (!this._ipc) {
+            return;
+        }
+        this._ipc.send(ELECTRON_NEW_SERVER_CHANNEL, url);
+    }
+
+    /**
+     * Cut everything from an OpenSlies URL thats not useful or would harm the other services
+     */
+    private prettifyUrl(url: string): string {
+        try {
+            const urlObject = new URL(url);
+            const prettyUrl = `${urlObject.protocol}//${urlObject.host}`;
+            return prettyUrl;
+        } catch (e) {
+            return url;
+        }
+    }
+}

--- a/client/src/app/core/core-services/communication-manager.service.ts
+++ b/client/src/app/core/core-services/communication-manager.service.ts
@@ -3,6 +3,7 @@ import { EventEmitter, Injectable } from '@angular/core';
 
 import { Observable } from 'rxjs';
 
+import { AttachExternalServerService } from 'app/core/core-services/attach-external-server.service';
 import { HttpService } from './http.service';
 import { OfflineBroadcastService, OfflineReason } from './offline-broadcast.service';
 import { OperatorService } from './operator.service';
@@ -60,7 +61,8 @@ export class CommunicationManagerService {
         private streamingCommunicationService: StreamingCommunicationService,
         private offlineBroadcastService: OfflineBroadcastService,
         private http: HttpService,
-        private operatorService: OperatorService
+        private operatorService: OperatorService,
+        private externalServer: AttachExternalServerService
     ) {
         this.offlineBroadcastService.goOfflineObservable.subscribe(() => this.closeConnections());
     }
@@ -72,6 +74,12 @@ export class CommunicationManagerService {
     ): Promise<() => void> {
         if (!params) {
             params = () => null;
+        }
+        /**
+         * external server
+         */
+        if (this.externalServer.extUrl) {
+            url = `${this.externalServer.extUrl}${url}`;
         }
 
         const streamContainer = new StreamContainer(url, messageHandler, params);

--- a/client/src/app/core/core-services/http.service.ts
+++ b/client/src/app/core/core-services/http.service.ts
@@ -4,6 +4,7 @@ import { Injectable } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { Subject } from 'rxjs';
 
+import { AttachExternalServerService } from 'app/core/core-services/attach-external-server.service';
 import { AutoupdateFormat } from '../definitions/autoupdate-format';
 import { AutoupdateThrottleService } from './autoupdate-throttle.service';
 import { HTTPMethod } from '../definitions/http-methods';
@@ -59,7 +60,8 @@ export class HttpService {
     public constructor(
         private http: HttpClient,
         private translate: TranslateService,
-        private OSStatus: OpenSlidesStatusService
+        private OSStatus: OpenSlidesStatusService,
+        private externalServer: AttachExternalServerService
     ) {
         this.defaultHeaders = new HttpHeaders().set('Content-Type', 'application/json');
     }
@@ -103,6 +105,13 @@ export class HttpService {
         }
         if (this.OSStatus.isPrioritizedClient) {
             url = '/prioritize' + url;
+        }
+
+        /**
+         * external server
+         */
+        if (this.externalServer.extUrl) {
+            url = `${this.externalServer.extUrl}${url}`;
         }
 
         const options = {

--- a/client/src/app/core/core-services/openslides.service.ts
+++ b/client/src/app/core/core-services/openslides.service.ts
@@ -2,7 +2,9 @@ import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 
 import { BehaviorSubject } from 'rxjs';
+import { distinctUntilChanged } from 'rxjs/operators';
 
+import { AttachExternalServerService } from './attach-external-server.service';
 import { CommunicationManagerService } from './communication-manager.service';
 import { DataStoreService } from './data-store.service';
 import { Deferred } from '../promises/deferred';
@@ -47,9 +49,19 @@ export class OpenSlidesService {
         private router: Router,
         private DS: DataStoreService,
         private communicationManager: CommunicationManagerService,
-        private offlineBroadcastService: OfflineBroadcastService
+        private offlineBroadcastService: OfflineBroadcastService,
+        private externalServer: AttachExternalServerService
     ) {
         this.bootup();
+
+        /**
+         * In electron, restart OpenSlides if a new backend was set
+         */
+        if (this.externalServer.isElectronApp) {
+            this.externalServer.serverUrlObservavle.pipe(distinctUntilChanged()).subscribe(newServerUrl => {
+                this.reboot();
+            });
+        }
     }
 
     public setStable(): void {

--- a/client/src/app/core/ui-services/login-data.service.ts
+++ b/client/src/app/core/ui-services/login-data.service.ts
@@ -9,6 +9,7 @@ import { ConstantsService } from '../core-services/constants.service';
 import { HttpService } from '../core-services/http.service';
 import { OpenSlidesStatusService } from '../core-services/openslides-status.service';
 import { StorageService } from '../core-services/storage.service';
+import { OS_DEFAULT_THEME } from './theme.service';
 
 interface SamlSettings {
     loginButtonText: string;
@@ -88,7 +89,7 @@ export class LoginDataService {
     /**
      * Holds the theme
      */
-    private readonly _theme = new BehaviorSubject<string>('');
+    private readonly _theme = new BehaviorSubject<string>(OS_DEFAULT_THEME);
 
     /**
      * Returns an observable for the theme

--- a/client/src/app/core/ui-services/theme.service.ts
+++ b/client/src/app/core/ui-services/theme.service.ts
@@ -3,27 +3,27 @@ import { Injectable } from '@angular/core';
 import { LoginDataService } from './login-data.service';
 
 /**
+ * Constant, that describes the default theme class.
+ */
+export const OS_DEFAULT_THEME = 'openslides-default-light-theme';
+
+/**
+ * Constant path of the logo with dark colors for bright themes.
+ */
+export const OS_DEFAULT_LOGO = '/assets/img/openslides-logo.svg';
+
+/**
+ * Constant path of the logo with white colors for dark themes.
+ */
+export const OS_DEFAULT_LOGO_DARK_THEME = '/assets/img/openslides-logo-dark.svg';
+
+/**
  * Service to set the theme for OpenSlides.
  */
 @Injectable({
     providedIn: 'root'
 })
 export class ThemeService {
-    /**
-     * Constant, that describes the default theme class.
-     */
-    public static DEFAULT_THEME = 'openslides-default-light-theme';
-
-    /**
-     * Constant path of the logo with dark colors for bright themes.
-     */
-    public static STANDARD_LOGO = '/assets/img/openslides-logo.svg';
-
-    /**
-     * Constant path of the logo with white colors for dark themes.
-     */
-    public static STANDARD_LOGO_DARK_THEME = '/assets/img/openslides-logo-dark.svg';
-
     /**
      * Holds the current theme as member.
      */
@@ -58,7 +58,7 @@ export class ThemeService {
         if (toRemove.length) {
             classList.remove(...toRemove); // Remove all old themes.
         }
-        classList.add(theme, ThemeService.DEFAULT_THEME); // Add the new theme.
+        classList.add(theme, OS_DEFAULT_THEME); // Add the new theme.
     }
 
     /**
@@ -70,9 +70,7 @@ export class ThemeService {
      */
     public getLogoRelativeToTheme(shouldDefault?: boolean): string {
         if (this.currentTheme) {
-            return this.currentTheme.includes('dark') && !shouldDefault
-                ? ThemeService.STANDARD_LOGO_DARK_THEME
-                : ThemeService.STANDARD_LOGO;
+            return this.currentTheme.includes('dark') && !shouldDefault ? OS_DEFAULT_LOGO_DARK_THEME : OS_DEFAULT_LOGO;
         } else {
             return null;
         }

--- a/client/src/app/site/login/components/login-mask/login-mask.component.html
+++ b/client/src/app/site/login/components/login-mask/login-mask.component.html
@@ -1,9 +1,21 @@
 <div class="form-wrapper">
-
     <!-- Install notice -->
     <div class="login-container" *ngIf="installationNotice">
-        <mat-card [innerHTML]="(installationNotice) | translate"></mat-card>
+        <mat-card [innerHTML]="installationNotice | translate"></mat-card>
     </div>
+
+    <!-- select-server form -->
+    <form [formGroup]="serverSelectForm" class="login-container" *ngIf="isElectronApp">
+        <mat-form-field>
+            <input
+                matInput
+                osAutofocus
+                required
+                placeholder="{{ 'OpenSlides Server URL' | translate }}"
+                formControlName="backendUrl"
+            />
+        </mat-form-field>
+    </form>
 
     <!-- login form -->
     <form [formGroup]="loginForm" class="login-container" (ngSubmit)="formLogin('default')">
@@ -27,14 +39,16 @@
                 [type]="!hide ? 'password' : 'text'"
                 [errorStateMatcher]="parentErrorStateMatcher"
             />
-            <mat-icon color="primary" matSuffix (click)="hide = !hide">{{ hide ? 'visibility_off' : 'visibility_on' }}</mat-icon>
+            <mat-icon color="primary" matSuffix (click)="hide = !hide">{{
+                hide ? 'visibility_off' : 'visibility_on'
+            }}</mat-icon>
 
             <mat-error>{{ loginErrorMsg | translate }}</mat-error>
         </mat-form-field>
 
         <!-- forgot password button -->
         <br />
-        <button mat-button color="primary" type="button" class="forgot-password-button" (click)="resetPassword()" >
+        <button mat-button color="primary" type="button" class="forgot-password-button" (click)="resetPassword()">
             {{ 'Forgot Password?' | translate }}
         </button>
 
@@ -42,13 +56,7 @@
         <br />
         <!-- TODO: Next to each other...-->
         <button mat-raised-button color="primary" class="login-button" type="submit">{{ 'Login' | translate }}</button>
-        <button
-            mat-stroked-button
-            *ngIf="areGuestsEnabled()"
-            class="login-button"
-            type="button"
-            (click)="guestLogin()"
-        >
+        <button mat-stroked-button *ngIf="areGuestsEnabled()" class="login-button" type="button" (click)="guestLogin()">
             {{ 'Login as guest' | translate }}
         </button>
         <a

--- a/client/src/app/site/mediafiles/components/mediafile-list/mediafile-list.component.html
+++ b/client/src/app/site/mediafiles/components/mediafile-list/mediafile-list.component.html
@@ -98,13 +98,7 @@
 >
     <!-- Icon column -->
     <div *pblNgridCellDef="'icon'; row as mediafile" class="fill clickable">
-        <a
-            class="detail-link"
-            target="_blank"
-            [routerLink]="mediafile.url"
-            *ngIf="!mediafile.is_directory && !isMultiSelect"
-        >
-        </a>
+        <ng-container [ngTemplateOutlet]="fileLinkTemplate" [ngTemplateOutletContext]="mediafile"></ng-container>
         <a class="detail-link" (click)="changeDirectory(mediafile.id)" *ngIf="mediafile.is_directory && !isMultiSelect">
         </a>
         <mat-icon class="file-icon">{{ mediafile.getIcon() }}</mat-icon>
@@ -112,15 +106,7 @@
 
     <!-- Title column -->
     <div *pblNgridCellDef="'title'; row as mediafile" class="fill clickable">
-        <a
-            class="detail-link"
-            target="_blank"
-            [routerLink]="mediafile.url"
-            *ngIf="!mediafile.is_directory && !isMultiSelect"
-        >
-        </a>
-        <a class="detail-link" (click)="changeDirectory(mediafile.id)" *ngIf="mediafile.is_directory && !isMultiSelect">
-        </a>
+        <ng-container [ngTemplateOutlet]="fileLinkTemplate" [ngTemplateOutletContext]="mediafile"></ng-container>
         <div class="innerTable">
             <div class="file-title ellipsis-overflow">
                 {{ mediafile.filename }}
@@ -377,4 +363,11 @@
             <span>{{ 'Cancel' | translate }}</span>
         </button>
     </div>
+</ng-template>
+
+<ng-template #fileLinkTemplate let-mediafile="mediafile">
+    <a class="detail-link" target="_blank" [href]="mediafile.url" *ngIf="!mediafile.is_directory && !isMultiSelect">
+    </a>
+    <a class="detail-link" (click)="changeDirectory(mediafile.id)" *ngIf="mediafile.is_directory && !isMultiSelect">
+    </a>
 </ng-template>

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -1,22 +1,20 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>OpenSlides</title>
+        <base href="./" />
 
-<head>
-    <meta charset="utf-8">
-    <title>OpenSlides</title>
-    <base href="/">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="robots" content="noindex" />
+        <meta name="google" content="notranslate" />
+        <link rel="icon" type="image/x-icon" href="assets/img/favicon.png" />
+        <link rel="manifest" href="/manifest.json" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    </head>
 
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="robots" content="noindex">
-    <meta name="google" content="notranslate">
-    <link rel="icon" type="image/x-icon" href="assets/img/favicon.png">
-    <link rel="manifest" href="/manifest.json" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-</head>
-
-<body class="general-theme">
-    <os-root></os-root>
-    <noscript>Please enable JavaScript to continue using this application.</noscript>
-</body>
-
+    <body class="general-theme">
+        <os-root></os-root>
+        <noscript>Please enable JavaScript to continue using this application.</noscript>
+    </body>
 </html>

--- a/client/tsconfig.electron-main.json
+++ b/client/tsconfig.electron-main.json
@@ -1,0 +1,14 @@
+{
+    "compilerOptions": {
+        "sourceMap": true,
+        "declaration": false,
+        "moduleResolution": "node",
+        "emitDecoratorMetadata": true,
+        "experimentalDecorators": true,
+        "target": "es5",
+        "types": ["node"],
+        "lib": ["es2017", "es2016", "es2015", "dom"]
+    },
+    "files": ["electron-main.ts"],
+    "exclude": ["node_modules", "**/*.spec.ts"]
+}

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -8,7 +8,6 @@
         "declaration": false,
         "module": "esnext",
         "moduleResolution": "node",
-        "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "importHelpers": true,
         "target": "es2015",


### PR DESCRIPTION
- Add electon packages
- Add electron-main.js as hook
- Add electron-main.ts config file
  - will automatically be compiled to .js
- Add electron-builder to create packages
- Add electron-builder.json for a maintainable build config
- Heavily optimize builder for angular projects
- Add build instructions to development.rst
- converts OpenSlides as optional electron application
- server switcher on the start page
  - enter some URL, makes it more pretty automatically
  - if the URL changed, reboot and OpenSlides and recall login info
    so the theme should directly apprear on the startpage
- always open links in new tabs
- resolve some django cookie problems to send valid requests as third
  party application
- Custom electron menu elements
  - Most importantly, "force reload" will wipe the local storrage
- Safe the last used server in indexDB
  - this was necessary to have reloading work
  - re-opening the application will enter the last used server for us
    (but no automatic login)
- "help" menu will forward to openslides.com and create issues
- use OpenSlides default theme if no other was found durgin login
  - no more white login page ever
- map file lookup to URL to call mediafiles and projector
- communicate between angular and electron using IPC

BUGS:
  - custom logo does not yet show

TODO:
  - dynamic updates of OpenSlides in Electron
  - dynamic updates of Electron itself