### PR TITLE
Prometheus

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -29,6 +29,13 @@ services:
       - ./postgresql.dev.conf:/etc/postgresql/postgresql.conf
     command: postgres -c 'config_file=/etc/postgresql/postgresql.conf'
 
+  prometheus:
+    image: prom/prometheus:v2.24.0
+    volumes:
+    - ../prometheus/prometheus.dev.yml:/etc/prometheus/prometheus.yml
+    ports:
+    - 9090:9090
+
   autoupdate:
     image: os3-autoupdate-dev
     environment:

--- a/prometheus/prometheus.dev.yml
+++ b/prometheus/prometheus.dev.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 5s
+  scrape_timeout: 5s
+  evaluation_interval: 15s
+
+scrape_configs:
+- job_name: openslides3-autoupdate
+  static_configs:
+  - targets:
+    - autoupdate:8002


### PR DESCRIPTION
This PR requires this brach on the autoupdate-service: https://github.com/OpenSlides/openslides3-autoupdate-service/pull/110

It starts a prometheus container in the dev-setup and opens the port 9090 to access it