### PR TITLE
Docker: Remove proxy as a default build target

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -19,7 +19,7 @@ DOCKER_TAG="latest"
 CONFIG="/etc/osinstancectl"
 OPTIONS=()
 BUILT_IMAGES=()
-DEFAULT_TARGETS=(server client proxy autoupdate)
+DEFAULT_TARGETS=(server client autoupdate)
 
 usage() {
   cat << EOF


### PR DESCRIPTION
The proxy image is not going to be subject to regular change and is
instead more similar to services such as the database.  Therefore, it
does not need to be a default build target of build.sh.