### PR TITLE
Docker: Remove server command override examples

### DIFF
--- a/docker/docker-compose.yml.m4
+++ b/docker/docker-compose.yml.m4
@@ -111,12 +111,6 @@ services:
 
   server:
     << : *default-osserver
-    # Below is the default command.  You can uncomment it to override the
-    # number of workers, for example:
-    # command: "gunicorn -w 8 --preload -b 0.0.0.0:8000 openslides.wsgi"
-    #
-    # Uncomment the following line to use daphne instead of gunicorn:
-    # command: "daphne -b 0.0.0.0 -p 8000 openslides.wsgi"
     depends_on:
       - server-setup
     environment:

--- a/docker/docker-stack.yml.m4
+++ b/docker/docker-stack.yml.m4
@@ -110,13 +110,6 @@ services:
 
   server:
     << : *default-osserver
-    # Below is the default command.  You can uncomment it to override the
-    # number of workers, for example:
-    # command: "gunicorn -w 8 --preload -b 0.0.0.0:8000
-    #   -k uvicorn.workers.UvicornWorker openslides.asgi:application"
-    #
-    # Uncomment the following line to use daphne instead of gunicorn:
-    # command: "daphne -b 0.0.0.0 -p 8000 openslides.asgi:application"
     environment:
       << : *default-osserver-env
     secrets:


### PR DESCRIPTION
The YAML configuration files include comments outlining how to override
the server image's default command.  They are supposed to help with, for
example, replacing gunicorn with daphne.

These comments have diverged from the actual command used in current
images.  Furthermore, at least to my knowledge, the setup has not been
used or tested with daphne in a long time.  For these reasons, this
patch removes the comments without a replacement.

If there still is, in fact, a use case for the instructions, they would
need to be updated and their location should be reconsidered.