### PR TITLE
Adjusted models

### DIFF
--- a/docker/initial-data.json
+++ b/docker/initial-data.json
@@ -346,6 +346,7 @@
             "meeting.can_see_frontpage",
             "meeting.can_see_history",
             "motion.can_manage",
+            "poll.can_manage",
             "projector.can_manage",
             "tag.can_manage",
             "user.can_manage",

--- a/docs/example-data.json
+++ b/docs/example-data.json
@@ -482,6 +482,7 @@
             "meeting.can_see_frontpage",
             "meeting.can_see_history",
             "motion.can_manage",
+            "poll.can_manage",
             "projector.can_manage",
             "tag.can_manage",
             "user.can_manage",

--- a/docs/models.yml
+++ b/docs/models.yml
@@ -904,6 +904,7 @@ group:
       - motion.can_see
       - motion.can_see_internal
       - motion.can_support
+      - poll.can_manage
       - projector.can_manage
       - projector.can_see
       - tag.can_manage
@@ -1443,8 +1444,12 @@ motion_block:
 
 motion_change_recommendation:
   id: number
-  rejected: boolean
-  internal: boolean
+  rejected:
+    type: boolean
+    default: false
+  internal:
+    type: boolean
+    default: false
   type:
     type: string
     enum:
@@ -1498,11 +1503,22 @@ motion_state:
       - motion.can_manage_metadata
       - motion.can_manage
       - is_submitter
-  allow_support: boolean
-  allow_create_poll: boolean
-  allow_submitter_edit: boolean
-  set_number: boolean
-  show_state_extension_field: boolean
+    default: []
+  allow_support:
+    type: boolean
+    default: false
+  allow_create_poll:
+    type: boolean
+    default: false
+  allow_submitter_edit:
+    type: boolean
+    default: false
+  set_number:
+    type: boolean
+    default: true
+  show_state_extension_field:
+    type: boolean
+    default: false
   merge_amendment_into_final:
     type: string
     enum:
@@ -1510,7 +1526,9 @@ motion_state:
     - undefined
     - do_merge
     default: undefined
-  show_recommendation_extension_field: boolean
+  show_recommendation_extension_field:
+    type: boolean
+    default: false
 
   next_state_ids:
     type: relation-list

--- a/docs/permission.yml
+++ b/docs/permission.yml
@@ -10,10 +10,19 @@ agenda_item:
     can_manage:
         can_see_internal:
             can_see:
+assignment:
+    can_manage:
+        can_nominate_other:
+            can_see:
+    can_nominate_self:
+        can_see:
 list_of_speakers:
     can_manage:
         can_see:
     can_be_speaker:
+        can_see:
+mediafile:
+    can_manage:
         can_see:
 meeting:
     can_manage_settings:
@@ -22,11 +31,6 @@ meeting:
     can_see_autopilot:
     can_see_livestream:
     can_see_history:
-projector:
-    can_manage:
-        can_see:
-tag:
-    can_manage:
 motion:
     can_manage:
         can_manage_metadata:
@@ -41,15 +45,13 @@ motion:
             can_see:
     can_support:
         can_see:
-assignment:
+poll:
     can_manage:
-        can_nominate_other:
-            can_see:
-    can_nominate_self:
-        can_see:
-mediafile:
+projector:
     can_manage:
         can_see:
+tag:
+    can_manage:
 user:
     can_manage:
         can_see_extra_data:


### PR DESCRIPTION
- Added new permissions poll.can_manage
- Reorder permissions.yml alphabetically
- provide some more default values

@normanjaeckel Maybe we should also add `poll.can_see` for non assignment/motion polls.