### PR TITLE
mediafile fields list_of_speakers_id and filename not required

### DIFF
--- a/docs/models.yml
+++ b/docs/models.yml
@@ -1848,7 +1848,6 @@ mediafile:
   filename:
     type: string
     descriptin: The uploaded filename. Will be used for downloading. Only writeable on create.
-    required: true
   mimetype: string
   pdf_information: JSON
   create_timestamp: timestamp
@@ -1877,7 +1876,6 @@ mediafile:
   list_of_speakers_id:
     type: relation
     to: list_of_speakers/content_object_id
-    required: true
     on_delete: CASCADE
     equal_fields: meeting_id
   projection_ids:


### PR DESCRIPTION
The fields cannot be required, because a mediafile directory is stored in the same entitie without having a filename or needing a list_of_speakers associated.
filename is checked in upload and a list_of_speakers is auto-created.
This PullRequest is necessary for [PR about required_field_validation](https://github.com/OpenSlides/openslides-backend/pull/430)