### PR TITLE
Don't show diff view on slides if no change recos exist

### DIFF
--- a/client/src/app/core/repositories/motions/motion-repository.service.ts
+++ b/client/src/app/core/repositories/motions/motion-repository.service.ts
@@ -1186,4 +1186,40 @@ export class MotionRepositoryService extends BaseIsAgendaItemAndListOfSpeakersCo
             }).length > 0
         );
     }
+
+    /**
+     * Tries to determine the realistic CR-Mode from a given CR mode
+     */
+    public determineCrMode(
+        mode: ChangeRecoMode,
+        hasChangingObjects: boolean,
+        isModifiedFinalVersion: boolean,
+        isParagraphBasedAmendment: boolean,
+        hasChangeRecommendations: boolean
+    ): ChangeRecoMode {
+        if (mode === ChangeRecoMode.Final) {
+            if (isModifiedFinalVersion) {
+                return ChangeRecoMode.ModifiedFinal;
+                /**
+                 * Because without change recos you cannot escape the final version anymore
+                 */
+            } else if (!hasChangingObjects) {
+                return ChangeRecoMode.Original;
+            }
+        } else if (mode === ChangeRecoMode.Changed && !hasChangingObjects) {
+            /**
+             * Because without change recos you cannot escape the changed version view
+             * You will not be able to automatically change to the Changed view after creating
+             * a change reco. The autoupdate has to come "after" this routine
+             */
+            return ChangeRecoMode.Original;
+        } else if (mode === ChangeRecoMode.Diff && !hasChangeRecommendations && isParagraphBasedAmendment) {
+            /**
+             * The Diff view for paragraph-based amendments is only relevant for change recommendations;
+             * the regular amendment changes are shown in the "original" view.
+             */
+            return ChangeRecoMode.Original;
+        }
+        return mode;
+    }
 }

--- a/client/src/app/slides/motions/motion/motion-slide.component.ts
+++ b/client/src/app/slides/motions/motion/motion-slide.component.ts
@@ -69,7 +69,6 @@ export class MotionSlideComponent
         this.lnMode = value.data.line_numbering_mode;
         this.lineLength = value.data.line_length;
         this.preamble = value.data.preamble;
-        this.crMode = value.element.mode || 'original';
 
         this.textDivStyles.width = value.data.show_meta_box ? 'calc(100% - 250px)' : '100%';
 
@@ -80,6 +79,14 @@ export class MotionSlideComponent
         }
 
         this.recalcUnifiedChanges();
+
+        this.crMode = this.motionRepo.determineCrMode(
+            value.element.mode || 'original',
+            this.allChangingObjects.length > 0,
+            !!this.data.data.modified_final_version,
+            this.isParagraphBasedAmendment(),
+            this.data.data.change_recommendations.length > 0
+        );
     }
 
     public get data(): SlideData<MotionSlideData> {


### PR DESCRIPTION
Moves the logic to decide which crMode to use to the class shared between desktop view and slides.
This should fix the slides showing an empty view when projecting the diff mode of an amendment but no change recommendation exists. The original version will be shown instead.