### PR TITLE
Changed portmapping according to https-use

### DIFF
--- a/caddy/entrypoint
+++ b/caddy/entrypoint
@@ -4,6 +4,10 @@ set -e
 
 if [[ -f "/certs/key.pem" ]] && [[ -f "/certs/cert.pem" ]]; then
     cat <<EOF >> /etc/caddy/endpoint
+http:// {
+    redir https://{host}{uri}:443
+}
+
 https://:8000 {
     tls /certs/cert.pem /certs/key.pem
 EOF

--- a/docker/docker-compose.yml.m4
+++ b/docker/docker-compose.yml.m4
@@ -107,7 +107,8 @@ services:
       - front
       - back
     ports:
-      - "127.0.0.1:ifenvelse(`EXTERNAL_HTTP_PORT', 8000):8000"
+      ifelse(read_env(`EXTERNAL_HTTP_PORT'),, ,- "ifenvelse(`EXTERNAL_HTTP_PORT', 8000):8000" )
+      ifelse(read_env(`EXTERNAL_HTTP_PORT'),, ,ifelse(read_env(`EXTERNAL_HTTP_PORT'), "443",, - "80:80"))
 
   server:
     << : *default-osserver


### PR DESCRIPTION
As with https://github.com/OpenSlides/OpenSlides/issues/5941 I tried to fix the Problem with http not being redirected automatically  when a TLS-cert is being used.

The code checks for the EXTERNAL_HTTP_PORT-variable and maps it to port 8000.
If it's not set, it maps ports 8000:8000.
If the EXTERNAL_HTTP_PORT is port 443, it additionally maps ports 80:80.

In the caddyfile, it adds a redirect (HTTP -> HTTPS) if TLS is used.


Feel free to change it based on the global needs of the project.


Yours
Michael