### PR TITLE
Use ENV for redis in db-setup and fix defaults

### DIFF
--- a/server/docker/entrypoint-db-setup
+++ b/server/docker/entrypoint-db-setup
@@ -24,7 +24,7 @@ source /run/secrets/django || true
 }
 export SECRET_KEY="$DJANGO_SECRET_KEY"
 
-until pg_isready -h "${DATABASE_HOST:-postgres}" -p "${DATABASE_PORT:-5432}"; do
+until pg_isready -h "${DATABASE_HOST:-pgbouncer}" -p "${DATABASE_PORT:-5432}"; do
   echo "Waiting for Postgres cluster to become available..."
   sleep 3
 done

--- a/server/docker/entrypoint-db-setup
+++ b/server/docker/entrypoint-db-setup
@@ -24,14 +24,14 @@ source /run/secrets/django || true
 }
 export SECRET_KEY="$DJANGO_SECRET_KEY"
 
-until pg_isready -h "${DATABASE_HOST}" -p "${DATABASE_PORT:-5432}"; do
+until pg_isready -h "${DATABASE_HOST:-postgres}" -p "${DATABASE_PORT:-5432}"; do
   echo "Waiting for Postgres cluster to become available..."
   sleep 3
 done
 
 # Wait for redis
-wait-for-it redis:6379
-wait-for-it redis-slave:6379
+wait-for-it "${REDIS_HOST:-redis}:${REDIS_PORT:-6379}"
+wait-for-it "${REDIS_SLAVE_HOST:-redis-slave}:${REDIS_SLAVE_PORT:-6379}"
 
 echo 'running migrations'
 python -u manage.py migrate


### PR DESCRIPTION
* Add default value for `DATABASE_HOST`
* Use ENV for `wait-for-it` redis and redis-slave

Signed-off-by: Adrian Nöthlich <git@promasu.tech>