### PR TITLE
Add manage service

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,3 +24,6 @@
 [submodule "openslides-permission-service"]
 	path = openslides-permission-service
 	url = git@github.com:OpenSlides/openslides-permission-service.git
+[submodule "openslides-manage-service"]
+	path = openslides-manage-service
+	url = git@github.com:OpenSlides/openslides-manage-service.git

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -93,6 +93,12 @@ services:
     env_file: services.env
     volumes:
       - ../openslides-media-service/src:/app/src
+  manage:
+    image: openslides-manage-dev
+    depends_on:
+    - auth
+    - datastore
+    env_file: services.env
   message-bus:
     image: redis:latest
   haproxy:

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -97,8 +97,10 @@ services:
     image: openslides-manage-dev
     depends_on:
     - auth
-    - datastore
+    - datastore-writer
     env_file: services.env
+    ports:
+    - "8001:8001"
   message-bus:
     image: redis:latest
   haproxy:

--- a/docker/docker-compose.yml.m4
+++ b/docker/docker-compose.yml.m4
@@ -43,6 +43,10 @@ define(`MEDIA_IMAGE',
 ifenvelse(`DEFAULT_DOCKER_REGISTRY', openslides)/dnl
 ifenvelse(`DOCKER_OPENSLIDES_MEDIA_NAME', openslides-media):dnl
 ifenvelse(`DOCKER_OPENSLIDES_MEDIA_TAG', latest))
+define(`MANAGE_IMAGE',
+ifenvelse(`DEFAULT_DOCKER_REGISTRY', openslides)/dnl
+ifenvelse(`DOCKER_OPENSLIDES_MANAGE_NAME', openslides-manage):dnl
+ifenvelse(`DOCKER_OPENSLIDES_MANAGE_TAG', latest))
 
 define(`PROJECT_DIR', ifdef(`PROJECT_DIR',PROJECT_DIR,.))
 define(`ADMIN_SECRET_AVAILABLE', `syscmd(`test -f 'PROJECT_DIR`/secrets/admin.env')sysval')
@@ -168,6 +172,16 @@ services:
       - frontend
       - backend
       - postgres
+
+  manage:
+    image: MANAGE_IMAGE
+    depends_on:
+    - auth
+    - datastore
+    env_file: services.env
+    networks:
+    - backend
+    - auth
 
 # Setup: host <-uplink-> haproxy <-frontend-> services that are reachable from the client <-backend-> services that are internal-only
 # There are special networks for some services only, e.g. postgres only for the postgresql, datastore reader and datastore writer

--- a/docker/docker-compose.yml.m4
+++ b/docker/docker-compose.yml.m4
@@ -177,7 +177,7 @@ services:
     image: MANAGE_IMAGE
     depends_on:
     - auth
-    - datastore
+    - datastore-writer
     env_file: services.env
     networks:
     - backend


### PR DESCRIPTION
This PR introduces a new service for management command.

To be used, it opens the port 8001. In production, this port has to be protected by htaccess or some other methods.

To use the management service, there is a helper-tool called `manage` You can find/build it in the openslides-manage-service with:

```
go build ./cmd/manage
./manage
```