### PR TITLE
Add login errors for inactive users

### DIFF
--- a/server/openslides/global_settings.py
+++ b/server/openslides/global_settings.py
@@ -99,17 +99,20 @@ STATICFILES_DIRS = [os.path.join(MODULE_DIR, "static")] + [
 STATIC_ROOT = os.path.join(OPENSLIDES_USER_DATA_DIR, "collected-static")
 
 # Files
-# https://docs.djangoproject.com/en/1.10/topics/files/
+# https://docs.djangoproject.com/en/2.2/topics/files/
 MEDIA_ROOT = os.path.join(OPENSLIDES_USER_DATA_DIR, "media", "")
 
+MEDIA_URL = "/media/"
 
 # Sessions and user authentication
-# https://docs.djangoproject.com/en/1.10/topics/http/sessions/
-# https://docs.djangoproject.com/en/1.10/topics/auth/
+# https://docs.djangoproject.com/en/2.2/topics/http/sessions/
+# https://docs.djangoproject.com/en/2.2/topics/auth/
 
 AUTH_USER_MODEL = "users.User"
 
 AUTH_GROUP_MODEL = "users.Group"
+
+AUTHENTICATION_BACKENDS = ["openslides.utils.auth_backend.ModelBackend"]
 
 SESSION_COOKIE_NAME = "OpenSlidesSessionID"
 
@@ -126,13 +129,6 @@ PASSWORD_HASHERS = [
     "django.contrib.auth.hashers.BCryptSHA256PasswordHasher",
     "django.contrib.auth.hashers.BCryptPasswordHasher",
 ]
-
-
-# Files
-# https://docs.djangoproject.com/en/1.10/topics/files/
-
-MEDIA_URL = "/media/"
-
 
 # Enable updating the last_login field for users on every login.
 ENABLE_LAST_LOGIN_FIELD = False

--- a/server/openslides/utils/auth_backend.py
+++ b/server/openslides/utils/auth_backend.py
@@ -1,0 +1,14 @@
+from typing import Any
+
+from django.contrib.auth.backends import ModelBackend as _ModelBackend
+
+
+class ModelBackend(_ModelBackend):
+    def user_can_authenticate(self, user: Any) -> bool:
+        """
+        Overwrite the default check for is_active.
+        This allows us to do the check it later to distinguish between a user
+        have not the right credentials and having the right credentials but
+        not being active.
+        """
+        return True


### PR DESCRIPTION
@emanuelschuetze I suspect that client translations for "You are not active." and "Please login via your identity provider." are missing (Note that I added a dot at the end of the second string).