### PR TITLE
Enable pytest in docker

### DIFF
--- a/server/setup.cfg
+++ b/server/setup.cfg
@@ -34,6 +34,7 @@ disallow_untyped_defs = true
 
 [tool:pytest]
 DJANGO_SETTINGS_MODULE = tests.settings
+addopts = --ds=tests.settings
 testpaths = tests/
 filterwarnings =
   ignore:RemovedInDjango30Warning

--- a/server/tests/settings.py
+++ b/server/tests/settings.py
@@ -70,9 +70,6 @@ MEDIA_ROOT = os.path.join(OPENSLIDES_USER_DATA_PATH, "")
 
 PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]
 
-# Deactivate restricted_data_cache
-RESTRICTED_DATA_CACHE = False
-
 REST_FRAMEWORK = {"TEST_REQUEST_DEFAULT_FORMAT": "json"}
 
 ENABLE_ELECTRONIC_VOTING = True


### PR DESCRIPTION
The DJANGO_SETTINGS_MODULE is set in the develop container, so the
tests.settings from the setup.cfg was ignored. Executing pytest with

    DJANGO_SETTINGS_MODULE=tests.settings pytest

works fine. The line added in the setup.cfg takes over precedence: It
auto-adds the --ds parameter which has a higher precedence than the
environment variable.

Also removed an unnecessary setting.