### PR TITLE
Fix projection name in example data

### DIFF
--- a/docs/example-data.json
+++ b/docs/example-data.json
@@ -2620,7 +2620,7 @@
         "history_projector_id": null,
         "content_object_id": "meeting/1",
         "stable": true,
-        "type": "current-list-of-speakers",
+        "type": "current_list_of_speakers",
         "weight": 1,
         "options": {},
         "meeting_id": 1


### PR DESCRIPTION
Small fix in the example data.

The correct slide-name is documented here: https://github.com/OpenSlides/OpenSlides/wiki/Projector-System

This is kind of a blocker for me. Therefore I merge it right away.