### PR TITLE
Issue473 meeting.reference projector id and user.username required

### DIFF
--- a/docs/models.yml
+++ b/docs/models.yml
@@ -877,6 +877,7 @@ meeting:
   reference_projector_id:
     type: relation
     to: projector/used_as_reference_projector_meeting_id
+    required: true
   list_of_speakers_countdown_id:
     type: relation
     to: projector_countdown/used_as_list_of_speaker_countdown_meeting_id

--- a/docs/models.yml
+++ b/docs/models.yml
@@ -91,7 +91,9 @@ organisation:
 
 user:
   id: number
-  username: string
+  username:
+    type: string
+    required: true
   title: string
   first_name: string
   last_name: string


### PR DESCRIPTION
Just the required setting for meeting.reference_projector_id plus user.username
Closes OpenSlides/openslides-backend#473