### PR TITLE
Fix vote delegation update error

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -19,6 +19,8 @@ services:
     depends_on:
       - redis
       - postgres
+    stdin_open: true
+    tty: true
 
   postgres:
     image: postgres:11


### PR DESCRIPTION
It was wrongly checked that the user must not have delegated his own vote in order to receive vote delegations even when the list of received delegations was empty.