### PR TITLE
Fixes #6030 - amending a list item does not show the change inline in…

### DIFF
--- a/client/src/app/core/ui-services/diff.service.ts
+++ b/client/src/app/core/ui-services/diff.service.ts
@@ -1866,18 +1866,34 @@ export class DiffService {
         // We only do this for P for now, as for more complex types like UL/LI that tend to be nestend,
         // information would get lost by this that we will need to recursively merge it again later on.
         let oldIsSplitAfter = false,
-            newIsSplitAfter = false;
+            newIsSplitAfter = false,
+            oldIsSplitBefore = false,
+            newIsSplitBefore = false;
         htmlOld = htmlOld.replace(
-            /(\s*<p[^>]+class\s*=\s*["'][^"']*)os-split-after/gi,
+            /(\s*<(?:p|ul|ol|li|blockquote|div)[^>]+class\s*=\s*["'][^"']*)os-split-after */gi,
             (match: string, beginning: string): string => {
                 oldIsSplitAfter = true;
                 return beginning;
             }
         );
         htmlNew = htmlNew.replace(
-            /(\s*<p[^>]+class\s*=\s*["'][^"']*)os-split-after/gi,
+            /(\s*<(?:p|ul|ol|li|blockquote|div)[^>]+class\s*=\s*["'][^"']*)os-split-after */gi,
             (match: string, beginning: string): string => {
                 newIsSplitAfter = true;
+                return beginning;
+            }
+        );
+        htmlOld = htmlOld.replace(
+            /(\s*<(?:p|ul|ol|li|blockquote|div)[^>]+class\s*=\s*["'][^"']*)os-split-before */gi,
+            (match: string, beginning: string): string => {
+                oldIsSplitBefore = true;
+                return beginning;
+            }
+        );
+        htmlNew = htmlNew.replace(
+            /(\s*<(?:p|ul|ol|li|blockquote|div)[^>]+class\s*=\s*["'][^"']*)os-split-before */gi,
+            (match: string, beginning: string): string => {
+                newIsSplitBefore = true;
                 return beginning;
             }
         );
@@ -2149,6 +2165,9 @@ export class DiffService {
 
         if (oldIsSplitAfter || newIsSplitAfter) {
             diff = this.addClassToLastNode(diff, 'os-split-after');
+        }
+        if (oldIsSplitBefore || newIsSplitBefore) {
+            diff = this.addClassToLastNode(diff, 'os-split-before');
         }
 
         this.diffCache.put(cacheKey, diff);


### PR DESCRIPTION
… diff box
https://github.com/OpenSlides/OpenSlides/issues/6030

This extends a previous workaround that was introduced only for split P-elements to other block elements like list items, and to list items that have an `os-split-before` element.
This is a bit of a quick-fix - I didn't really have the time to think into the whole subject of this os-split-before/after classes. They were introduced to detect when in change recommendations changes were made to single lines within larger list items (as they are line based, not paragraph based), so the patch should not affect paragraph-based amendments negatively. As for change recommendations, not too sure...