### PR TITLE
Fix user cannot see candidate names

### DIFF
--- a/client/src/app/site/assignments/components/assignment-detail/assignment-detail.component.html
+++ b/client/src/app/site/assignments/components/assignment-detail/assignment-detail.component.html
@@ -156,7 +156,7 @@
                         <!-- implicit item references into the component using ng-template slot -->
                         <ng-template let-item>
                             <div class="single-candidate-line">
-                                <span *ngIf="hasPerms('manage')"> {{ item.getTitle() }} </span>
+                                <span> {{ item.getTitle() }} </span>
 
                                 <span *ngIf="hasPerms('manage')">
                                     <button


### PR DESCRIPTION
Assignment detail view sort list `getTitle()` was hidden behind
"assignment_can_manage", thus users could not see the names of candidates