### PR TITLE
Update manage service

### DIFF
--- a/dev-commands/manage.sh
+++ b/dev-commands/manage.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker build openslides-manage-service/ --target manage --tag openslides-manage
+docker run --network host openslides-manage $@

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -12,8 +12,6 @@ services:
     volumes:
       - ../openslides-datastore-service/shared/shared:/app/shared
       - ../openslides-datastore-service/reader/reader:/app/reader
-    ports:
-      - 9010:9010
   datastore-writer:
     image: openslides-datastore-writer-dev
     depends_on:
@@ -29,8 +27,6 @@ services:
       - COMMAND=create_initial_data
       - DATASTORE_INITIAL_DATA_FILE=https://raw.githubusercontent.com/OpenSlides/OpenSlides/openslides4-dev/docs/example-data.json
       - OPENSLIDES_DEVELOPMENT=1
-    ports:
-      - 9011:9011
   postgres:
     image: postgres:11
     environment:
@@ -59,8 +55,6 @@ services:
       - OPENSLIDES_DEVELOPMENT=1
     volumes:
       - ../openslides-backend/openslides_backend:/app/openslides_backend
-    ports:
-      - 5678:5678
   autoupdate:
     image: openslides-autoupdate-dev
     depends_on:
@@ -93,8 +87,6 @@ services:
       - OPENSLIDES_DEVELOPMENT=1
     volumes:
       - ../openslides-auth-service/auth/src:/app/src
-    ports:
-      - 9004:9004
   cache:
     image: redis:latest
   media:
@@ -116,7 +108,7 @@ services:
     environment:
       - OPENSLIDES_DEVELOPMENT=1
     ports:
-    - "8001:8001"
+    - "9008:9008"
   message-bus:
     image: redis:latest
   proxy:


### PR DESCRIPTION
This updates the manage-tool.

The main change it the new tunnel command. It helps to access services inside the docker-compose network. It opens local ports and tunnels all data the the remote service inside the network.

I added a shell script to run the manage tool without go.  It is not necessary. It can be removed if you don't like it.

See:

`sh manage.sh help tunnel` to see how the tunnel works.

To open tunnels to all services, run:

```
`sh manage.sh tunnel
```

To open tunnels only to some services, run:
```
`sh manage.sh tunnel datastore-reader datastore-writer auth
```

Currently, the cache and the message-bus can not be tunneled at the same time. Both use the same port. I would like to change the port of the redis-cache to something else. Is that ok for you?

