### PR TITLE
stop-voting shows prompt

### DIFF
--- a/client/src/app/site/assignments/modules/assignment-poll/components/assignment-poll/assignment-poll.component.html
+++ b/client/src/app/site/assignments/modules/assignment-poll/components/assignment-poll/assignment-poll.component.html
@@ -48,7 +48,7 @@
                 <button
                     mat-stroked-button
                     [ngClass]="pollStateActions[poll.state].css"
-                    (click)="changeState(poll.nextState)"
+                    (click)="nextPollState()"
                     [disabled]="stateChangePending"
                 >
                     <mat-icon> {{ pollStateActions[poll.state].icon }}</mat-icon>

--- a/client/src/app/site/assignments/modules/assignment-poll/components/assignment-poll/assignment-poll.component.ts
+++ b/client/src/app/site/assignments/modules/assignment-poll/components/assignment-poll/assignment-poll.component.ts
@@ -8,6 +8,7 @@ import { TranslateService } from '@ngx-translate/core';
 
 import { OperatorService } from 'app/core/core-services/operator.service';
 import { AssignmentPollRepositoryService } from 'app/core/repositories/assignments/assignment-poll-repository.service';
+import { ChoiceService } from 'app/core/ui-services/choice.service';
 import { PromptService } from 'app/core/ui-services/prompt.service';
 import { VotingService } from 'app/core/ui-services/voting.service';
 import { VotingPrivacyWarningComponent } from 'app/shared/components/voting-privacy-warning/voting-privacy-warning.component';
@@ -82,6 +83,7 @@ export class AssignmentPollComponent
         translate: TranslateService,
         dialog: MatDialog,
         promptService: PromptService,
+        choiceService: ChoiceService,
         repo: AssignmentPollRepositoryService,
         pollDialog: AssignmentPollDialogService,
         private pollService: AssignmentPollService,
@@ -90,7 +92,7 @@ export class AssignmentPollComponent
         private operator: OperatorService,
         private votingService: VotingService
     ) {
-        super(titleService, matSnackBar, translate, dialog, promptService, repo, pollDialog);
+        super(titleService, matSnackBar, translate, dialog, promptService, choiceService, repo, pollDialog);
     }
 
     public ngOnInit(): void {

--- a/client/src/app/site/motions/modules/motion-poll/motion-poll/motion-poll.component.html
+++ b/client/src/app/site/motions/modules/motion-poll/motion-poll/motion-poll.component.html
@@ -50,7 +50,7 @@
         <button
             mat-stroked-button
             [ngClass]="pollStateActions[poll.state].css"
-            (click)="changeState(poll.nextState)"
+            (click)="nextPollState()"
             [disabled]="stateChangePending"
         >
             <mat-icon> {{ pollStateActions[poll.state].icon }}</mat-icon>

--- a/client/src/app/site/motions/modules/motion-poll/motion-poll/motion-poll.component.ts
+++ b/client/src/app/site/motions/modules/motion-poll/motion-poll/motion-poll.component.ts
@@ -7,6 +7,7 @@ import { TranslateService } from '@ngx-translate/core';
 
 import { OperatorService, Permission } from 'app/core/core-services/operator.service';
 import { MotionPollRepositoryService } from 'app/core/repositories/motions/motion-poll-repository.service';
+import { ChoiceService } from 'app/core/ui-services/choice.service';
 import { PromptService } from 'app/core/ui-services/prompt.service';
 import { VotingPrivacyWarningComponent } from 'app/shared/components/voting-privacy-warning/voting-privacy-warning.component';
 import { infoDialogSettings } from 'app/shared/utils/dialog-settings';
@@ -68,6 +69,7 @@ export class MotionPollComponent extends BasePollComponent<ViewMotionPoll, Motio
         titleService: Title,
         matSnackBar: MatSnackBar,
         promptService: PromptService,
+        choiceService: ChoiceService,
         pollDialog: MotionPollDialogService,
         protected dialog: MatDialog,
         protected pollRepo: MotionPollRepositoryService,
@@ -76,7 +78,7 @@ export class MotionPollComponent extends BasePollComponent<ViewMotionPoll, Motio
         private pdfService: MotionPollPdfService,
         private operator: OperatorService
     ) {
-        super(titleService, matSnackBar, translate, dialog, promptService, pollRepo, pollDialog);
+        super(titleService, matSnackBar, translate, dialog, promptService, choiceService, pollRepo, pollDialog);
     }
 
     public openVotingWarning(): void {

--- a/client/src/app/site/polls/services/base-poll-repository.service.ts
+++ b/client/src/app/site/polls/services/base-poll-repository.service.ts
@@ -56,26 +56,22 @@ export abstract class BasePollRepositoryService<
         return viewModel;
     }
 
-    public changePollState(poll: BasePoll): Promise<void> {
+    public changePollState(poll: BasePoll, targetState: PollState): Promise<void> {
         const path = this.restPath(poll);
-        switch (poll.state) {
+        switch (targetState) {
             case PollState.Created:
-                return this.http.post(`${path}/start/`);
+                return this.http.post(`${path}/reset/`);
             case PollState.Started:
-                return this.http.post(`${path}/stop/`);
+                return this.http.post(`${path}/start/`);
             case PollState.Finished:
-                return this.http.post(`${path}/publish/`);
+                return this.http.post(`${path}/stop/`);
             case PollState.Published:
-                return this.resetPoll(poll);
+                return this.http.post(`${path}/publish/`);
         }
     }
 
     private restPath(poll: BasePoll): string {
         return `/rest/${poll.collectionString}/${poll.id}`;
-    }
-
-    public resetPoll(poll: BasePoll): Promise<void> {
-        return this.http.post(`${this.restPath(poll)}/reset/`);
     }
 
     public pseudoanonymize(poll: BasePoll): Promise<void> {

--- a/server/openslides/poll/views.py
+++ b/server/openslides/poll/views.py
@@ -164,8 +164,12 @@ class BasePollViewSet(ModelViewSet):
     @transaction.atomic
     def publish(self, request, pk):
         poll = self.get_locked_object()
-        if poll.state != BasePoll.STATE_FINISHED:
+        if poll.state not in (BasePoll.STATE_STARTED, BasePoll.STATE_FINISHED):
             raise ValidationError({"detail": "Wrong poll state"})
+
+        # stop poll if needed
+        if poll.state == BasePoll.STATE_STARTED:
+            poll.stop()
 
         poll.state = BasePoll.STATE_PUBLISHED
         poll.save()


### PR DESCRIPTION
Stop voting shows options to either simply stop, publish directly or
abort. Was done using choice service.
Alter vote repo to simply choose with voting state to adress rather than
calculate the next state