### PR TITLE
Restrict Chat message length in client

### DIFF
--- a/client/src/app/site/chat/components/chat-tabs/chat-tabs.component.html
+++ b/client/src/app/site/chat/components/chat-tabs/chat-tabs.component.html
@@ -25,7 +25,14 @@
 <!-- send chat -->
 <form [formGroup]="newMessageForm" (ngSubmit)="send()" *ngIf="chatGroupsExist && canSendInSelectedChat" [@collapse]>
     <mat-form-field appearance="outline" class="chat-form-field">
-        <input class="chat-input" type="text" matInput formControlName="text" />
+        <input #chatinput autocomplete="off" type="text" matInput formControlName="text" />
+        <mat-hint align="end" *ngIf="chatinput.value?.length >= chatMessageMaxLength - 100">
+            <span> {{ chatinput.value?.length || 0 }}/{{ chatMessageMaxLength }} </span>
+
+            <span class="warn" *ngIf="chatinput.value?.length > chatMessageMaxLength">
+                ({{ chatMessageMaxLength - chatinput.value?.length }})
+            </span>
+        </mat-hint>
         <mat-label>{{ 'Message' | translate }}</mat-label>
         <button
             mat-icon-button
@@ -33,7 +40,7 @@
             type="submit"
             color="accent"
             matTooltip=" {{ 'Send' | translate }}"
-            [disabled]="isChatMessageEmpty()"
+            [disabled]="!chatinput.value?.trim()?.length || newMessageForm.invalid"
         >
             <mat-icon>send</mat-icon>
         </button>

--- a/client/src/app/site/chat/components/chat-tabs/chat-tabs.component.scss
+++ b/client/src/app/site/chat/components/chat-tabs/chat-tabs.component.scss
@@ -1,7 +1,3 @@
 .chat-form-field {
     width: 100%;
 }
-
-.chat-input {
-    // todo
-}


### PR DESCRIPTION
Restricts Chat Messages in client to enforce a maximum length of 512
characters
enhance chat form validation
show chat message length and characters left if close to the limit of
512