### PR TITLE
is_demo_user is no more read only

### DIFF
--- a/docs/models.yml
+++ b/docs/models.yml
@@ -115,7 +115,6 @@ user:
   last_email_send: timestamp
   is_demo_user:
     type: boolean
-    read_only: true
 
   # Organisation, meeting and committee
   organisation_management_level:


### PR DESCRIPTION
In OS4 is_demo_user can be changed with action user.update and OrganisationManagementLevel permission SUPERADMIN 