### PR TITLE
Docker: Bind to 0.0.0.0 for Docker Swarm

### DIFF
--- a/docker/docker-stack.yml.m4
+++ b/docker/docker-stack.yml.m4
@@ -125,8 +125,8 @@ services:
       - front
       - back
     ports:
-      ifelse(EXTERNAL_HTTP_PORT,,,- "127.0.0.1:EXTERNAL_HTTP_PORT:8000")
-      ifelse(EXTERNAL_HTTPS_PORT,,,- "127.0.0.1:EXTERNAL_HTTPS_PORT:8001")
+      ifelse(EXTERNAL_HTTP_PORT,,,- "0.0.0.0:EXTERNAL_HTTP_PORT:8000")
+      ifelse(EXTERNAL_HTTPS_PORT,,,- "0.0.0.0:EXTERNAL_HTTPS_PORT:8001")
     deploy:
       restart_policy:
         condition: on-failure


### PR DESCRIPTION
Swarm uses a cluster-wide ingress network and does not permit binding
ports to localhost.  It simply ignores such a binding and prints
a warning instead.

This patch fixes this recent regression to avoid the warning.