### PR TITLE
Avoid triggering errors with pg_isready

### DIFF
--- a/server/docker/entrypoint-db-setup
+++ b/server/docker/entrypoint-db-setup
@@ -24,7 +24,11 @@ source /run/secrets/django || true
 }
 export SECRET_KEY="$DJANGO_SECRET_KEY"
 
-until pg_isready -h "${DATABASE_HOST:-pgbouncer}" -p "${DATABASE_PORT:-5432}"; do
+export PGHOST="${DATABASE_HOST:-pgbouncer}"
+export PGPORT="${DATABASE_PORT:-5432}"
+export PGDATABASE="${DATABASE_NAME:-openslides}"
+export PGUSER="${DATABASE_USER:-openslides}"
+until pg_isready; do
   echo "Waiting for Postgres cluster to become available..."
   sleep 3
 done


### PR DESCRIPTION
pg_isready was not connecting to the configured database or as the
configured user.  While that did not cause problems here, it did trigger
error messages on the database side.