### PR TITLE
Fix missing zip extension when filename had a dot

### DIFF
--- a/client/src/app/core/repositories/mediafiles/mediafile-repository.service.ts
+++ b/client/src/app/core/repositories/mediafiles/mediafile-repository.service.ts
@@ -147,7 +147,7 @@ export class MediafileRepositoryService extends BaseIsListOfSpeakersContentObjec
             }
         }
         const archive = await zip.generateAsync({ type: 'blob' });
-        saveAs(archive, archiveName);
+        saveAs(archive, `${archiveName}.zip`);
     }
 
     public getDirectoryBehaviorSubject(): BehaviorSubject<ViewMediafile[]> {

--- a/client/src/app/site/mediafiles/components/mediafile-list/mediafile-list.component.ts
+++ b/client/src/app/site/mediafiles/components/mediafile-list/mediafile-list.component.ts
@@ -461,9 +461,6 @@ export class MediafileListComponent extends BaseListViewComponent<ViewMediafile>
     }
 
     public downloadMultiple(mediafiles: ViewMediafile[] = this.dataSource.source): void {
-        /**
-         * TODO: naming the files is discussable
-         */
         const eventName = this.configService.instant<string>('general_event_name');
         const dirName = this.directory?.filename ?? this.translate.instant('Files');
         const archiveName = `${eventName} - ${dirName}`.trim();


### PR DESCRIPTION
fixes #6034 
while exporting mediafiles, the zip extension was missing if the file
name hat a dot