### PR TITLE
Fix mat-table no flex class

### DIFF
--- a/client/src/app/site/motions/modules/category/components/category-detail/category-detail.component.html
+++ b/client/src/app/site/motions/modules/category/components/category-detail/category-detail.component.html
@@ -22,7 +22,7 @@
             <span>{{ getLevelDashes(category) }}</span>
             {{ category.prefixedName }}
         </h2>
-        <table class="os-headed-listview-table" mat-table [dataSource]="dataSources[category.id]">
+        <mat-table class="os-headed-listview-table" [dataSource]="dataSources[category.id]">
             <!-- title column -->
             <ng-container matColumnDef="title">
                 <mat-header-cell *matHeaderCellDef>
@@ -67,7 +67,7 @@
 
             <mat-header-row *matHeaderRowDef="getColumnDefinition()"></mat-header-row>
             <mat-row *matRowDef="let row; columns: getColumnDefinition()"> </mat-row>
-        </table>
+        </mat-table>
     </div>
 </mat-card>
 

--- a/client/src/app/site/motions/modules/motion-import/motion-import-list.component.html
+++ b/client/src/app/site/motions/modules/motion-import/motion-import-list.component.html
@@ -119,7 +119,7 @@
         </mat-select>
     </div>
     <div class="table-container">
-        <table mat-table [dataSource]="dataSource" matSort>
+        <mat-table [dataSource]="dataSource" matSort>
             <!-- Status column -->
             <ng-container matColumnDef="status" sticky>
                 <mat-header-cell *matHeaderCellDef class="first-column"></mat-header-cell>
@@ -289,6 +289,6 @@
 
             <mat-header-row *matHeaderRowDef="getColumnDefinition()"></mat-header-row>
             <mat-row [ngClass]="getStateClass(row)" *matRowDef="let row; columns: getColumnDefinition()"> </mat-row>
-        </table>
+        </mat-table>
     </div>
 </mat-card>

--- a/client/src/app/site/motions/modules/statute-paragraph/components/statute-import-list/statute-import-list.component.html
+++ b/client/src/app/site/motions/modules/statute-paragraph/components/statute-import-list/statute-import-list.component.html
@@ -111,7 +111,7 @@
         </mat-select>
     </div>
     <div class="table-container">
-        <table mat-table [dataSource]="dataSource" matSort>
+        <mat-table [dataSource]="dataSource" matSort>
             <!-- Status column -->
             <ng-container matColumnDef="status" sticky>
                 <mat-header-cell *matHeaderCellDef class="first-column"></mat-header-cell>
@@ -168,6 +168,6 @@
             </ng-container>
             <mat-header-row *matHeaderRowDef="getColumnDefinition()"></mat-header-row>
             <mat-row [ngClass]="getStateClass(row)" *matRowDef="let row; columns: getColumnDefinition()"> </mat-row>
-        </table>
+        </mat-table>
     </div>
 </mat-card>

--- a/client/src/app/site/topics/components/topic-import-list/topic-import-list.component.html
+++ b/client/src/app/site/topics/components/topic-import-list/topic-import-list.component.html
@@ -149,7 +149,7 @@
         </mat-select>
     </div>
     <div class="table-container">
-        <table mat-table [dataSource]="dataSource" matSort>
+        <mat-table [dataSource]="dataSource" matSort>
             <!-- Status column -->
             <ng-container matColumnDef="status" class="first-column" sticky>
                 <mat-header-cell *matHeaderCellDef></mat-header-cell>
@@ -228,6 +228,6 @@
 
             <mat-header-row *matHeaderRowDef="getColumnDefinition()"></mat-header-row>
             <mat-row [ngClass]="getStateClass(row)" *matRowDef="let row; columns: getColumnDefinition()"> </mat-row>
-        </table>
+        </mat-table>
     </div>
 </mat-card>

--- a/client/src/app/site/users/components/group-list/group-list.component.html
+++ b/client/src/app/site/users/components/group-list/group-list.component.html
@@ -18,7 +18,7 @@
             </mat-expansion-panel-header>
 
             <div class="scrollable-perm-matrix">
-                <table mat-table [dataSource]="getTableDataSource(app.permissions)">
+                <mat-table [dataSource]="getTableDataSource(app.permissions)">
                     <ng-container matColumnDef="perm" sticky>
                         <mat-header-cell *matHeaderCellDef>{{ 'Permissions' | translate }}</mat-header-cell>
                         <mat-cell *matCellDef="let perm">
@@ -48,7 +48,7 @@
 
                     <mat-header-row *matHeaderRowDef="headerRowDef"></mat-header-row>
                     <mat-row *matRowDef="let row; columns: headerRowDef"></mat-row>
-                </table>
+                </mat-table>
             </div>
         </mat-expansion-panel>
     </mat-accordion>

--- a/client/src/app/site/users/components/group-list/group-list.component.scss
+++ b/client/src/app/site/users/components/group-list/group-list.component.scss
@@ -1,6 +1,6 @@
 @import '~assets/styles/tables.scss';
 
-table {
+.mat-table {
     .mat-cell {
         min-width: 80px;
     }


### PR DESCRIPTION
After upgrading angular material, mat table had a different set of
classes which would break a view