### PR TITLE
Fix an error where the workflow would break agenda

### DIFF
--- a/client/src/app/core/core-services/projector.service.ts
+++ b/client/src/app/core/core-services/projector.service.ts
@@ -76,7 +76,7 @@ export class ProjectorService {
      */
     public isProjected(obj: Projectable | ProjectorElementBuildDeskriptor | IdentifiableProjectorElement): boolean {
         const element = this.getProjectorElement(obj);
-        if (element.getIdentifiers) {
+        if (element?.getIdentifiers) {
             return this.DS.getAll<Projector>('core/projector').some(projector => {
                 return projector.isElementShown(element);
             });


### PR DESCRIPTION
If the projected element was null due to workflow restrictions, the
agenda list would throw an error