### PR TITLE
Remove permission service

### DIFF
--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -47,9 +47,6 @@ jobs:
           - name: openslides-manage
             directory: openslides-manage-service
 
-          - name: openslides-permission
-            directory: openslides-permission-service
-
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,6 +13,7 @@
 [submodule "openslides-autoupdate-service"]
 	path = openslides-autoupdate-service
 	url = https://github.com/OpenSlides/openslides-autoupdate-service.git
+	branch = main
 [submodule "openslides-auth-service"]
 	path = openslides-auth-service
 	url = https://github.com/OpenSlides/openslides-auth-service.git
@@ -21,10 +22,6 @@
 	path = openslides-media-service
 	url = https://github.com/OpenSlides/openslides-media-service.git
 	branch = openslides4-dev
-[submodule "openslides-permission-service"]
-	path = openslides-permission-service
-	url = https://github.com/OpenSlides/openslides-permission-service.git
-	branch = master
 [submodule "openslides-manage-service"]
 	path = openslides-manage-service
 	url = https://github.com/OpenSlides/openslides-manage-service.git

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -10,7 +10,6 @@ TARGETS=(
   [backend]="$HOME/../openslides-backend/"
   [auth]="$HOME/../openslides-auth-service/"
   [autoupdate]="$HOME/../openslides-autoupdate-service/"
-  [permission]="$HOME/../openslides-permission-service/"
   [manage]="$HOME/../openslides-manage-service/"
   [datastore-reader]="$HOME/../openslides-datastore-service/reader"
   [datastore-writer]="$HOME/../openslides-datastore-service/writer"

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -55,7 +55,6 @@ services:
       - datastore-reader
       - datastore-writer
       - auth
-      - permission
     env_file: services.env
     environment:
       - OPENSLIDES_DEVELOPMENT=1
@@ -88,18 +87,6 @@ services:
     volumes:
       - ../openslides-icc-service/cmd:/root/cmd
       - ../openslides-icc-service/internal:/root/internal
-
-  permission:
-    image: openslides-permission-dev
-    depends_on:
-      - datastore-reader
-    env_file: services.env
-    environment:
-      - OPENSLIDES_DEVELOPMENT=1
-    volumes:
-      - ../openslides-permission-service/cmd:/app/cmd
-      - ../openslides-permission-service/internal:/app/internal
-      - ../openslides-permission-service/pkg:/app/pkg
 
   auth:
     image: openslides-auth-dev


### PR DESCRIPTION
The permission-service is (hopefully) not used anymore. At least the repo was archived some time ago: https://github.com/openslides/openslides-permission-service

