### PR TITLE
PR6246 mediafile.list_of_speakers not required, because of directories

### DIFF
--- a/.github/workflows/md5_check_initial-data.yml
+++ b/.github/workflows/md5_check_initial-data.yml
@@ -21,4 +21,4 @@ jobs:
         run: md5sum docker/initial-data.json
 
       - name: Validate and protect initial-data.json
-        run: echo "eb70fc8581fc011b5da4b022068564b9  docker/initial-data.json" | md5sum -c -
+        run: echo "1bd1aa2d687de8b21cabe0274c3e6779  docker/initial-data.json" | md5sum -c -

--- a/docker/initial-data.json
+++ b/docker/initial-data.json
@@ -1,5 +1,5 @@
 {
-    "_migration_index": 5,
+    "_migration_index": 7,
     "organization": {
         "1": {
             "id": 1,

--- a/docs/models.yml
+++ b/docs/models.yml
@@ -2882,7 +2882,7 @@ mediafile:
     on_delete: CASCADE
     equal_fields: meeting_id
     restriction_mode: B
-    required: false
+    required: true
   projection_ids:
     type: relation-list
     to: projection/content_object_id

--- a/docs/models.yml
+++ b/docs/models.yml
@@ -2882,7 +2882,7 @@ mediafile:
     on_delete: CASCADE
     equal_fields: meeting_id
     restriction_mode: B
-    required: true
+    required: false
   projection_ids:
     type: relation-list
     to: projection/content_object_id


### PR DESCRIPTION
The directories of mediafiles are also stored in the mediafile collection, but they don't have list_of_speakers associated to them. That's the reason the `list_of_speakers`-field cannot be set to required.
On uploading a media**file** there will be always a list_of_speakers.