### PR TITLE
add vote-service to build-images workflow

### DIFF
--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -39,6 +39,9 @@ jobs:
           - name: openslides-auth
             directory: openslides-auth-service
 
+          - name: openslides-vote
+            directory: openslides-vote-service
+
           - name: openslides-icc
             directory: openslides-icc-service
 


### PR DESCRIPTION
An oversight during integrating the vote-service.
It of course needs to be built by github actions as well.