### PR TITLE
add local production setup

### DIFF
--- a/localprod/.gitignore
+++ b/localprod/.gitignore
@@ -1,0 +1,4 @@
+db-data/
+secrets/
+openslides*
+docker-compose.yml

--- a/localprod/README.md
+++ b/localprod/README.md
@@ -1,0 +1,35 @@
+# Local production setup
+
+This folder allows you to use the
+[manage-tool](https://github.com/OpenSlides/openslides-manage-service) to launch
+the local repository state as a production setup.
+The `config.yml` instructs the manage-tool to include build tags for all service
+images.
+
+## Usage
+
+Run
+
+    ./setup.sh
+
+It will download the latest manage-tool (the `openslides`-executable) - if not
+present already - and setup this directory like a production environment using\
+the `config.yml`.
+
+Now run
+
+    docker-compose up --build
+
+After all services are up initial data needs to be set to be able to login.
+In a different terminal run
+
+    ./openslides initial-data
+
+This will add the superadmin account with the password provided from
+`secrets/superadmin` (default: superadmin)
+
+Access https://localhost:8000/ as you would expect.
+
+To clear the database run
+
+    rm -r db-data/*

--- a/localprod/config.yml
+++ b/localprod/config.yml
@@ -1,0 +1,53 @@
+
+defaults:
+  containerRegistry: local
+  tag: prod
+
+services:
+  proxy:
+    additionalContent:
+      build: ../proxy/
+  client:
+    additionalContent:
+      build: ../openslides-client/
+  backend:
+    additionalContent:
+      build: ../openslides-backend/
+  datastoreReader:
+    additionalContent: {
+      build: {
+        context: ../openslides-datastore-service/,
+        args: {
+          MODULE: reader,
+          PORT: 9010
+        }
+      }
+    }
+  datastoreWriter:
+    additionalContent: {
+      build: {
+        context: ../openslides-datastore-service/,
+        args: {
+          MODULE: writer,
+          PORT: 9011
+        }
+      }
+    }
+  autoupdate:
+    additionalContent:
+      build: ../openslides-autoupdate-service/
+  auth:
+    additionalContent:
+      build: ../openslides-auth-service/
+  vote:
+    additionalContent:
+      build: ../openslides-vote-service/
+  media:
+    additionalContent:
+      build: ../openslides-media-service/
+  icc:
+    additionalContent:
+      build: ../openslides-icc-service/
+  manage:
+    additionalContent:
+      build: ../openslides-manage-service/

--- a/localprod/setup.sh
+++ b/localprod/setup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+[[ -f ./openslides ]] ||
+  wget https://github.com/OpenSlides/openslides-manage-service/releases/download/latest/openslides
+
+[[ -x ./openslides ]] ||
+  chmod +x ./openslides
+
+./openslides setup .
+./openslides config --config config.yml .


### PR DESCRIPTION
As @GabrielInTheWorld suggested, this is an easy way of using the manage-tool to build the local repository into a production-like setup.

closes https://github.com/OpenSlides/openslides-manage-service/issues/123