### PR TITLE
proxy: check ALLOWED_HOSTS only for client requests

### DIFF
--- a/proxy/caddy_base.json
+++ b/proxy/caddy_base.json
@@ -27,27 +27,6 @@
             {
               "handle": [
                 {
-                  "body": "Misdirected Request",
-                  "close": true,
-                  "handler": "static_response",
-                  "status_code": 421
-                }
-              ],
-              "match": [
-                {
-                  "not": [
-                    {
-                      "header": {
-                        "Host": []
-                      }
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "handle": [
-                {
                   "flush_interval": -1,
                   "handler": "reverse_proxy",
                   "upstreams": [
@@ -153,6 +132,23 @@
               "handle": [
                 {
                   "handler": "reverse_proxy",
+                  "upstreams": [
+                    {
+                      "dial": "$VOTE_HOST:$VOTE_PORT"
+                    }
+                  ]
+                }
+              ],
+              "match": [
+                {
+                  "path": ["/system/vote*"]
+                }
+              ]
+            },
+            {
+              "handle": [
+                {
+                  "handler": "reverse_proxy",
                   "flush_interval": -1,
                   "transport": {
                     "protocol": "http",
@@ -176,17 +172,21 @@
             {
               "handle": [
                 {
-                  "handler": "reverse_proxy",
-                  "upstreams": [
-                    {
-                      "dial": "$VOTE_HOST:$VOTE_PORT"
-                    }
-                  ]
+                  "body": "Misdirected Request",
+                  "close": true,
+                  "handler": "static_response",
+                  "status_code": 421
                 }
               ],
               "match": [
                 {
-                  "path": ["/system/vote*"]
+                  "not": [
+                    {
+                      "header": {
+                        "Host": []
+                      }
+                    }
+                  ]
                 }
               ]
             },

--- a/proxy/entrypoint
+++ b/proxy/entrypoint
@@ -57,10 +57,10 @@ fi
 ### ALLOWED HOSTS ###
 if [ -n "$ALLOWED_HOSTS" ]; then
   for host in $ALLOWED_HOSTS; do
-    jq_write ".apps.http.servers.srv0.routes[0].match[0].not[0].header.Host += [\"$host\"]"
+    jq_write ".apps.http.servers.srv0.routes[-2].match[0].not[0].header.Host += [\"$host\"]"
   done
 else
-  jq_write "del(.apps.http.servers.srv0.routes[0])"
+  jq_write "del(.apps.http.servers.srv0.routes[-2])"
 fi
 
 exec "$@"


### PR DESCRIPTION
This feature is only intended to identify misdirected browser requests.
The other routes are called by services/tools which will not necessarily
set the 'Host' header and thus break.