### PR TITLE
Open port 5678 for debugpy in dev

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -56,6 +56,10 @@ services:
       - datastore-writer
       - auth
     env_file: services.env
+    ports:
+        - "9002:9002"
+        - "9003:9003"
+        - "5678:5678"
     environment:
       - OPENSLIDES_DEVELOPMENT=1
       - EMAIL_HOST=mailhog


### PR DESCRIPTION
Enables VSCode etc. to debug the backend in dev-setup via port 5678 using debugpy

To attach to running backend copy following lines into launch.json and select the "attach" in VSCode-Debugselection

        {
            "name": "Python: attach",
            "type": "python",
            "request": "attach",
            "connect": {
                "host": "localhost",
                "port": 5678
            },
            "pathMappings": [
                {
                    "localRoot": "${workspaceFolder}/openslides-backend",
                    "remoteRoot": "/app"
                }
            ]
        },`
`