### PR TITLE
Add MI to export

### DIFF
--- a/server/openslides/core/export.py
+++ b/server/openslides/core/export.py
@@ -197,8 +197,7 @@ class OS4Exporter:
         self.migrate_projectors()
         self.migrate_meeting()
 
-        # Note: When returning self.all_data one has access to the original data to compare it to the export.
-        # return {"all": self.all_data, "export": self.to_list_format()}
+        self.data["_migration_index"] = 3
         return self.data
 
     def set_model(self, collection, model):


### PR DESCRIPTION
- has to be greater than 2 since `is_active_in_organisation_id` is already added
- has to be lower than 5 since `motion_state/weight` is not added
- has to be lower than 4 or higher than 9 since `motion/dont_set_identifier` is not present

=> MI of 3