### PR TITLE
Fix export of logos and fonts

### DIFF
--- a/server/openslides/core/export.py
+++ b/server/openslides/core/export.py
@@ -1783,7 +1783,7 @@ class OS4Exporter:
             if not mediafile_id:
                 continue
 
-            replacement = place.split("_", 2)[1]
+            replacement = place.split("_", 1)[1].lower()
             mediafile = self.get_model("mediafile", mediafile_id)
             mediafile[f"used_as_{type}_$_in_meeting_id"].append(replacement)
             mediafile[f"used_as_{type}_${replacement}_in_meeting_id"] = 1


### PR DESCRIPTION
A small typo lead to the wrong replacements being used. All replacements in use:
```
"web_header"
"projector_main"
"projector_header"
"pdf_header_l"
"pdf_header_r"
"pdf_footer_l"
"pdf_footer_r"
"pdf_ballot_paper"
```
were cut after the first underscore, which lead to the web header logo in question being saved as `web` instead of `web_header`. Fixing existing instances which were imported with this error is only possible for this case: `web` can be unambigously translated to `web_header`, but for `projector` and `pdf` it is not clear what the original value was, so I would suggest to not do a migration for this and instead let users either reimport the instances or fix them manually, which is also not hard.