### PR TITLE
Support http3

### DIFF
--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM caddy:2.3.0-alpine
+FROM caddy:2.6.4-alpine
 
 LABEL org.opencontainers.image.title="OpenSlides Proxy"
 LABEL org.opencontainers.image.description="The proxy is the entrypoint for traffic going into an OpenSlides instance."

--- a/proxy/caddy_base.json
+++ b/proxy/caddy_base.json
@@ -22,7 +22,6 @@
       "servers": {
         "srv0": {
           "listen": [":8000"],
-          "allow_h2c": true,
           "routes": [
             {
               "handle": [


### PR DESCRIPTION
@peb-adr I would like to test http3. Caddy 2.6 supports it. Could you install this version on a test service and give me direct access? (without any other proxy in between)