### PR TITLE
doc: AutoHTTPS requires disabling LocalHTTPS

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -183,6 +183,7 @@ integrated certificate retrieval. Add the following lines to your setup
 configuration YAML file and of course use your own domain instead of the
 example:
 
+    enableLocalHTTPS: false
     enableAutoHTTPS: true
     services:
       proxy:


### PR DESCRIPTION
https://github.com/OpenSlides/OpenSlides/blob/5da8a6a529b06875ee94b8f2afcbc8411d62d735/proxy/entrypoint#L30

skips the ` if [ -n "$ENABLE_AUTO_HTTPS" ]; then` check if LocalHTTPS is not disabled.