### PR TITLE
Exclude `/system/action/internal` from backend matcher in proxy

### DIFF
--- a/proxy/caddy_base.json
+++ b/proxy/caddy_base.json
@@ -72,7 +72,10 @@
               ],
               "match": [
                 {
-                  "path": ["/system/action*"]
+                  "path": ["/system/action*"],
+                  "not": [
+                      { "path": ["/system/action/internal*"] }
+                  ]
                 }
               ]
             },


### PR DESCRIPTION
The backend provides the route `/system/action/internal/handle_request` for stack internal access to actions, protected by a password. For additional security, the proxy shouldn't even match this route, since it should only be called from inside the stack.

I did not test this since I wasn't sure how and didn't want to invest too much time. @peb-adr it would be nice if you could confirm that this works as intended.