### PR TITLE
Fix `db.sh` and hardcode password

### DIFF
--- a/dev/scripts/db.sh
+++ b/dev/scripts/db.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 cd "$(dirname $0)"
-docker-compose -f $HOME/../docker/docker-compose.dev.yml exec datastore-writer psql -h postgres -U openslides
+docker-compose -f ../docker/docker-compose.dev.yml exec datastore-writer psql postgresql://openslides:openslides@postgres/openslides


### PR DESCRIPTION
The `db.sh` used a wrong path to the docker compose file. Also, since it is only intended for the dev setup where the password is always `openslides`, I hardcoded it so one does not have to enter it every time.