### PR TITLE
Pin debian based python docker images to bullseye

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -98,6 +98,8 @@ jobs:
             **/node_modules
           key: node_modules-${{ hashFiles('**/package-lock.json') }}
       - name: test client
+        env:
+          NODE_OPTIONS: "--openssl-legacy-provider"
         run: npm run test-silently
 
   build-client-debug:
@@ -114,6 +116,8 @@ jobs:
             **/node_modules
           key: node_modules-${{ hashFiles('**/package-lock.json') }}
       - name: build client debug
+        env:
+          NODE_OPTIONS: "--openssl-legacy-provider"
         run: npm run build-debug
 
   build-client-prod:
@@ -130,4 +134,6 @@ jobs:
             **/node_modules
           key: node_modules-${{ hashFiles('**/package-lock.json') }}
       - name: build client prod
+        env:
+          NODE_OPTIONS: "--openssl-legacy-provider"
         run: npm run build

--- a/server/docker/Dockerfile
+++ b/server/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim AS base
+FROM python:3.7-slim-bullseye AS base
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV DEBIAN_PRIORITY critical

--- a/server/docker/Dockerfile.dev
+++ b/server/docker/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM python:3.7-slim AS base
+FROM python:3.7-slim-bullseye AS base
 
 # Variables relevant for CMD
 ENV DJANGO_SETTINGS_MODULE settings


### PR DESCRIPTION
debian docker images are currently being migrated to version 12 (bookworm). This is currently leading to errors when building as the bookworm-based images are not stable yet. In order for the stable/3.4.x branch to stay stable (and buildable) we can keep using the debian bullseye images.