### PR TITLE
Add check in make stable update

### DIFF
--- a/dev/scripts/make-update.sh
+++ b/dev/scripts/make-update.sh
@@ -209,6 +209,7 @@ merge_stable_branches() {
 
       set_remote
       git checkout "$BRANCH_NAME"
+      check_current_branch
 
       git merge --no-ff "$mod_target_sha" --log --message "Merge main into $STABLE_BRANCH_NAME. Update $(date +%Y%m%d)"
     )


### PR DESCRIPTION
Without this check it can lead to confusing situations when local and remote stable branches are wrongfully diverging.