### PR TITLE
Enable OpenTelemetry in services via env var

### DIFF
--- a/dev/docker/dc.otel.dev.yml
+++ b/dev/docker/dc.otel.dev.yml
@@ -11,3 +11,15 @@ services:
     image: jaegertracing/all-in-one
     ports:
     - "16686:16686"
+
+  backend:
+    environment:
+      - OPENTELEMETRY_ENABLED=1
+
+  datastore-reader:
+    environment:
+      - OPENTELEMETRY_ENABLED=1
+
+  datastore-writer:
+    environment:
+      - OPENTELEMETRY_ENABLED=1


### PR DESCRIPTION
`datastore-reader` and `datastore-writer` now log correctly with this change, the backend does not. This should be investigated further.