### PR TITLE
build.sh: Set VERSION as build-arg for services

### DIFF
--- a/dev/docker/build.sh
+++ b/dev/docker/build.sh
@@ -97,6 +97,8 @@ SELECTED_TARGETS=($@)
 [[ "${#SELECTED_TARGETS[@]}" -ge 1 ]] || SELECTED_TARGETS=("${DEFAULT_TARGETS[@]}")
 [[ "${SELECTED_TARGETS[@]}" != "all" ]] || SELECTED_TARGETS=("${!TARGETS[@]}")
 
+OPTIONS+=(--build-arg "VERSION=$DOCKER_TAG")
+
 for i in "${SELECTED_TARGETS[@]}"; do
 
   loc="${TARGETS[$i]}"
@@ -126,10 +128,6 @@ for i in "${SELECTED_TARGETS[@]}"; do
     printf '\t"commit-abbrev": "%s",\n' "$(git rev-parse --abbrev-ref HEAD)"
     printf '}\n'
   } > version.json
-  if [[ -w "$CLIENT_VERSION_TXT" ]]; then
-    client_dev_version="$(< "$CLIENT_VERSION_TXT")"
-    printf "$DOCKER_TAG ($(date +%Y-%m-%d))" > "$CLIENT_VERSION_TXT"
-  fi
 
   # Special instructions for local services
   build_script="${loc}/build.sh"
@@ -139,9 +137,6 @@ for i in "${SELECTED_TARGETS[@]}"; do
     docker build --tag "$img" --pull "${OPTIONS[@]}" "$loc"
   fi
   rm version.json
-  if [[ -w "$CLIENT_VERSION_TXT" ]]; then
-    echo "$client_dev_version" > "$CLIENT_VERSION_TXT"
-  fi
 
   BUILT_IMAGES+=("$img ON")
 done


### PR DESCRIPTION
Goes hand in hand with https://github.com/OpenSlides/openslides-client/pull/3251 and https://github.com/OpenSlides/openslides-backend/pull/2182.

Injecting the version string into the services filesystem when building is now done from within the `Dockerfile` and passed as `--build-arg VERSON=xxx`.
This also makes it more easily expandable to other services - like the backend right now.