### PR TITLE
Use local example data copy instead of GitHub link

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,14 @@ switch-to-dev:
 run-backend: | switch-to-test
 	$(DC) exec backend ./entrypoint.sh bash --rcfile .bashrc
 
+# Stop all backend-related services so that the backend dev setup can start
+stop-backend:
+	$(DC) stop backend datastore-reader datastore-writer auth vote postgres redis icc autoupdate search
+
+# Restart all backend-related services
+start-backend:
+	$(DC) up -d backend datastore-reader datastore-writer auth vote postgres redis icc autoupdate search
+
 # Stop the dev server
 stop-dev:
 	$(DC) down --volumes --remove-orphans

--- a/dev/docker/docker-compose.dev.yml
+++ b/dev/docker/docker-compose.dev.yml
@@ -23,9 +23,10 @@ services:
     volumes:
       - ../../openslides-datastore-service/datastore:/app/datastore
       - ../../openslides-datastore-service/cli:/app/cli
+      - ../../openslides-backend/global/data:/app/data
     environment:
       - COMMAND=create_initial_data
-      - DATASTORE_INITIAL_DATA_FILE=https://raw.githubusercontent.com/OpenSlides/openslides-backend/main/global/data/example-data.json
+      - DATASTORE_INITIAL_DATA_FILE=/app/data/example-data.json
       - OPENSLIDES_DEVELOPMENT=1
     ports:
       - 9011:9011


### PR DESCRIPTION
So that e.g. the staging branch (which does not incoorporate the newest migrations which are already present in the example data of the main branch) can start.

Also added two helper commands to the Makefile which enable to stop only the backend-related services, so a backend dev setup can be started side-by-side with the client without having to rebuild the client when switching back.