### PR TITLE
Fix typo in de.po

### DIFF
--- a/i18n/de.po
+++ b/i18n/de.po
@@ -3517,7 +3517,7 @@ msgid ""
 "here."
 msgstr ""
 "Teilnehmende und Administratoren werden vollständig kopiert und lassen sich "
-"hier nicht bearbeitet."
+"hier nicht bearbeiten."
 
 msgid "Participants created"
 msgstr "Teilnehmende erstellt"


### PR DESCRIPTION
There is a german typo mistake.

Should be "bearbeiten" not "bearbeitet"