### PR TITLE
Fix `ds-set.sh` for arbitrary large files

### DIFF
--- a/dev/scripts/set-ds.sh
+++ b/dev/scripts/set-ds.sh
@@ -4,7 +4,8 @@ set -e
 cd "$(dirname $0)"
 
 # first argument is the example data
-DATA=$(cat ${1:-../../openslides-backend/global/data/example-data.json})
+DATA=${1:-../../openslides-backend/global/data/example-data.json}
 ./clear-ds.sh
+docker compose -f ../docker/docker-compose.dev.yml cp $DATA datastore-writer:/data.json
 docker compose -f ../docker/docker-compose.dev.yml exec datastore-writer \
-    bash -c "source export-database-variables.sh; echo '$DATA' > /data.json; export DATASTORE_INITIAL_DATA_FILE=/data.json; python cli/create_initial_data.py"
+    bash -c "source export-database-variables.sh; export DATASTORE_INITIAL_DATA_FILE=/data.json; python cli/create_initial_data.py"


### PR DESCRIPTION
With sufficient large files the script currently just fails with `argument list too long`. 