### PR TITLE
Fix stable-build propagation to manage-service

### DIFF
--- a/.github/workflows/build-images-stable.yml
+++ b/.github/workflows/build-images-stable.yml
@@ -10,3 +10,4 @@ jobs:
   build:
     name: 'Call build-images'
     uses: ./.github/workflows/build-images.yml
+    secrets: inherit


### PR DESCRIPTION
This was an oversight causing the build of stable 4.2.0 to fail.
Fixed it manually on branch `stable/4.2.x`. So this is bringing it into main.