### PR TITLE
Use backend directory structure

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -14,7 +14,7 @@ jobs:
           submodules: recursive
 
       - name: Use example data instead of initial data
-        working-directory: "./openslides-backend/global/data/"
+        working-directory: "./openslides-backend/data/"
         run: cp example-data.json initial-data.json
 
       - name: Start setup

--- a/dev/docker/docker-compose.dev.yml
+++ b/dev/docker/docker-compose.dev.yml
@@ -72,7 +72,8 @@ services:
       - ../../openslides-backend/openslides_backend:/app/openslides_backend
       - ../../openslides-backend/tests:/app/tests
       - ../../openslides-backend/cli:/app/cli
-      - ../../openslides-backend/global:/app/global
+      - ../../openslides-backend/data:/app/data
+      - ../../openslides-backend/meta:/app/meta
       - ../../openslides-backend/scripts:/app/scripts
 
   autoupdate:

--- a/dev/scripts/set-ds.sh
+++ b/dev/scripts/set-ds.sh
@@ -3,5 +3,5 @@
 set -e
 cd "$(dirname $0)"
 
-DATA=${1:-../../openslides-backend/global/data/example-data.json}
+DATA=${1:-../../openslides-backend/data/example-data.json}
 docker compose -f ../docker/docker-compose.dev.yml exec -T datastore-writer python cli/import_data_only.py < "$DATA"


### PR DESCRIPTION
Since the backend directory structure will change as per OpenSlides/openslides-backend#2604 we need some adaptions in the main repository. 
This means that the docker global volume will be split and paths to the data and meta directory change.