### PR TITLE
Add go workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .DS_Store
 .idea
 *.code-workspace
+go.work.sum
 
 # docs
 docs/modelsvalidator/modelsvalidator

--- a/.gitmodules
+++ b/.gitmodules
@@ -40,3 +40,6 @@
 [submodule "openslides-search-service"]
 	path = openslides-search-service
 	url = https://github.com/OpenSlides/openslides-search-service.git
+[submodule "openslides-go"]
+	path = lib/openslides-go
+	url = https://github.com/OpenSlides/openslides-go.git

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 DC_PATH=dev/docker
 SCRIPT_PATH=dev/scripts
 DC=docker compose -f $(DC_PATH)/docker-compose.dev.yml
+GO_VERSION=$(shell head -n 1 go.work)
 
 # Main command: start the dev server
 run-dev: | build-dev 
@@ -12,6 +13,7 @@ run-dev-otel: | build-dev
 
 # Build the docker dev images for all services in parallel
 build-dev:
+	sed -i "1s/.*/$(GO_VERSION)/" $(DC_PATH)/workspaces/*.work
 	$(SCRIPT_PATH)/submodules-do.sh 'make build-dev'
 
 # Run the tests of all services

--- a/dev/docker/docker-compose.dev.yml
+++ b/dev/docker/docker-compose.dev.yml
@@ -86,9 +86,9 @@ services:
       - OPENSLIDES_DEVELOPMENT=1
       - DATASTORE_TIMEOUT=30
     volumes:
-      - ../../openslides-autoupdate-service/cmd:/root/cmd
-      - ../../openslides-autoupdate-service/internal:/root/internal
-      - ../../openslides-autoupdate-service/pkg:/root/pkg
+      - ../../openslides-autoupdate-service/cmd:/root/openslides-autoupdate-service/cmd
+      - ../../openslides-autoupdate-service/internal:/root/openslides-autoupdate-service/internal
+      - ../../openslides-autoupdate-service/pkg:/root/openslides-autoupdate-service/pkg
       - ../../go.work:/root/go.work
       - ../../lib/openslides-go:/root/lib/openslides-go
       - ../../openslides-icc-service:/root/openslides-icc-service
@@ -107,8 +107,8 @@ services:
     environment:
       - OPENSLIDES_DEVELOPMENT=1
     volumes:
-      - ../../openslides-icc-service/cmd:/root/cmd
-      - ../../openslides-icc-service/internal:/root/internal
+      - ../../openslides-icc-service/cmd:/root/openslides-icc-service/cmd
+      - ../../openslides-icc-service/internal:/root/openslides-icc-service/internal
       - ../../go.work:/root/go.work
       - ../../lib/openslides-go:/root/lib/openslides-go
       - ../../openslides-autoupdate-service:/root/openslides-autoupdate-service
@@ -127,8 +127,8 @@ services:
     environment:
       - OPENSLIDES_DEVELOPMENT=1
     volumes:
-      - ../../openslides-search-service/cmd:/root/cmd
-      - ../../openslides-search-service/pkg:/root/pkg
+      - ../../openslides-search-service/cmd:/root/openslides-search-service/cmd
+      - ../../openslides-search-service/pkg:/root/openslides-search-service/pkg
       - ../../go.work:/root/go.work
       - ../../lib/openslides-go:/root/lib/openslides-go
       - ../../openslides-icc-service:/root/openslides-icc-service
@@ -205,8 +205,8 @@ services:
       - OPENSLIDES_DEVELOPMENT=1
       - VOTE_DISABLE_LOG=true
     volumes:
-      - ../../openslides-vote-service/cmd:/root/cmd
-      - ../../openslides-vote-service/internal:/root/internal
+      - ../../openslides-vote-service/cmd:/root/openslides-vote-service/cmd
+      - ../../openslides-vote-service/internal:/root/openslides-vote-service/internal
       - ../../go.work:/root/go.work
       - ../../lib/openslides-go:/root/lib/openslides-go
       - ../../openslides-icc-service:/root/openslides-icc-service

--- a/dev/docker/docker-compose.dev.yml
+++ b/dev/docker/docker-compose.dev.yml
@@ -89,6 +89,11 @@ services:
       - ../../openslides-autoupdate-service/cmd:/root/cmd
       - ../../openslides-autoupdate-service/internal:/root/internal
       - ../../openslides-autoupdate-service/pkg:/root/pkg
+      - ../../go.work:/root/go.work
+      - ../../lib/openslides-go:/root/lib/openslides-go
+      - ../../openslides-icc-service:/root/openslides-icc-service
+      - ../../openslides-vote-service:/root/openslides-vote-service
+      - ../../openslides-search-service:/root/openslides-search-service
     ports:
       - "9012:9012"
 
@@ -104,6 +109,11 @@ services:
     volumes:
       - ../../openslides-icc-service/cmd:/root/cmd
       - ../../openslides-icc-service/internal:/root/internal
+      - ../../go.work:/root/go.work
+      - ../../lib/openslides-go:/root/lib/openslides-go
+      - ../../openslides-autoupdate-service:/root/openslides-autoupdate-service
+      - ../../openslides-vote-service:/root/openslides-vote-service
+      - ../../openslides-search-service:/root/openslides-search-service
     ports:
       - "9007:9007"
 
@@ -119,6 +129,11 @@ services:
     volumes:
       - ../../openslides-search-service/cmd:/root/cmd
       - ../../openslides-search-service/pkg:/root/pkg
+      - ../../go.work:/root/go.work
+      - ../../lib/openslides-go:/root/lib/openslides-go
+      - ../../openslides-icc-service:/root/openslides-icc-service
+      - ../../openslides-vote-service:/root/openslides-vote-service
+      - ../../openslides-autoupdate-service:/root/openslides-autoupdate-service
     ports:
       - "9050:9050"
 
@@ -192,5 +207,10 @@ services:
     volumes:
       - ../../openslides-vote-service/cmd:/root/cmd
       - ../../openslides-vote-service/internal:/root/internal
+      - ../../go.work:/root/go.work
+      - ../../lib/openslides-go:/root/lib/openslides-go
+      - ../../openslides-icc-service:/root/openslides-icc-service
+      - ../../openslides-autoupdate-service:/root/openslides-autoupdate-service
+      - ../../openslides-search-service:/root/openslides-search-service
     ports:
       - "9013:9013"

--- a/dev/docker/docker-compose.dev.yml
+++ b/dev/docker/docker-compose.dev.yml
@@ -89,11 +89,8 @@ services:
       - ../../openslides-autoupdate-service/cmd:/root/openslides-autoupdate-service/cmd
       - ../../openslides-autoupdate-service/internal:/root/openslides-autoupdate-service/internal
       - ../../openslides-autoupdate-service/pkg:/root/openslides-autoupdate-service/pkg
-      - ../../go.work:/root/go.work
       - ../../lib/openslides-go:/root/lib/openslides-go
-      - ../../openslides-icc-service:/root/openslides-icc-service
-      - ../../openslides-vote-service:/root/openslides-vote-service
-      - ../../openslides-search-service:/root/openslides-search-service
+      - ./workspaces/autoupdate.work:/root/go.work
     ports:
       - "9012:9012"
 
@@ -109,11 +106,8 @@ services:
     volumes:
       - ../../openslides-icc-service/cmd:/root/openslides-icc-service/cmd
       - ../../openslides-icc-service/internal:/root/openslides-icc-service/internal
-      - ../../go.work:/root/go.work
       - ../../lib/openslides-go:/root/lib/openslides-go
-      - ../../openslides-autoupdate-service:/root/openslides-autoupdate-service
-      - ../../openslides-vote-service:/root/openslides-vote-service
-      - ../../openslides-search-service:/root/openslides-search-service
+      - ./workspaces/icc.work:/root/go.work
     ports:
       - "9007:9007"
 
@@ -129,11 +123,8 @@ services:
     volumes:
       - ../../openslides-search-service/cmd:/root/openslides-search-service/cmd
       - ../../openslides-search-service/pkg:/root/openslides-search-service/pkg
-      - ../../go.work:/root/go.work
       - ../../lib/openslides-go:/root/lib/openslides-go
-      - ../../openslides-icc-service:/root/openslides-icc-service
-      - ../../openslides-vote-service:/root/openslides-vote-service
-      - ../../openslides-autoupdate-service:/root/openslides-autoupdate-service
+      - ./workspaces/search.work:/root/go.work
     ports:
       - "9050:9050"
 
@@ -207,10 +198,7 @@ services:
     volumes:
       - ../../openslides-vote-service/cmd:/root/openslides-vote-service/cmd
       - ../../openslides-vote-service/internal:/root/openslides-vote-service/internal
-      - ../../go.work:/root/go.work
       - ../../lib/openslides-go:/root/lib/openslides-go
-      - ../../openslides-icc-service:/root/openslides-icc-service
-      - ../../openslides-autoupdate-service:/root/openslides-autoupdate-service
-      - ../../openslides-search-service:/root/openslides-search-service
+      - ./workspaces/vote.work:/root/go.work
     ports:
       - "9013:9013"

--- a/dev/docker/workspaces/autoupdate.work
+++ b/dev/docker/workspaces/autoupdate.work
@@ -1,0 +1,6 @@
+go 1.24.0
+
+use (
+	./lib/openslides-go
+	./openslides-autoupdate-service
+)

--- a/dev/docker/workspaces/icc.work
+++ b/dev/docker/workspaces/icc.work
@@ -1,0 +1,6 @@
+go 1.24.0
+
+use (
+	./lib/openslides-go
+	./openslides-icc-service
+)

--- a/dev/docker/workspaces/search.work
+++ b/dev/docker/workspaces/search.work
@@ -1,0 +1,6 @@
+go 1.24.0
+
+use (
+	./lib/openslides-go
+	./openslides-search-service
+)

--- a/dev/docker/workspaces/vote.work
+++ b/dev/docker/workspaces/vote.work
@@ -1,0 +1,6 @@
+go 1.24.0
+
+use (
+	./lib/openslides-go
+	./openslides-vote-service
+)

--- a/go.work
+++ b/go.work
@@ -1,0 +1,9 @@
+go 1.23.6
+
+use (
+	./lib/openslides-go
+	./openslides-autoupdate-service
+	./openslides-icc-service
+	./openslides-search-service
+	./openslides-vote-service
+)

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.23.6
+go 1.24.0
 
 use (
 	./lib/openslides-go


### PR DESCRIPTION
**This is a proposal** for how to integrate the `openslides-go` repo into our development setup. 

This requires changes to all go subrepo Dockerfiles which leads to the `development` being definitely not executable without additional mounts. So we might need to check if the `development` target is used somewhere else. 

Also we still need a solution for production builds. 

* [x] `make build-dev` not working