### PR TITLE
Bugfix: Projector in dev docker compose setup

### DIFF
--- a/dev/docker/docker-compose.dev.yml
+++ b/dev/docker/docker-compose.dev.yml
@@ -167,6 +167,11 @@ services:
       - "9050:9050"
 
   projector:
+    build:
+        context: ../../openslides-projector-service
+        target: "dev"
+        args:
+            CONTEXT: "dev"
     image: openslides-projector-dev
     depends_on:
       - autoupdate


### PR DESCRIPTION
Projector-service has been missing in the dev-environment compose file, causing errors