### PR TITLE
Hotfix: Prevent auto accept in bash scripts

### DIFF
--- a/dev/scripts/util.sh
+++ b/dev/scripts/util.sh
@@ -40,7 +40,7 @@ ask() {
   shift 1
   local QUERY="$*"
 
-  if [ "$ASK_AUTO_DO_DEFAULT" == 0 ]
+  if [ -z "$ASK_AUTO_DO_DEFAULT" ]
   then
     read -rp $'\n'"$QUERY $REPLY_OPT: "
   fi


### PR DESCRIPTION
A bug has caused the ask bash function to automatically accept the default value without user input