### PR TITLE
Fix: Adding buildx to development requirements

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-You need `git`, `bash`, `docker`, `docker compose` (v2), `make` and `openssl` installed.
+You need `git`, `bash`, `docker`, `docker compose` (v2), `docker buildx`, `make` and `openssl` installed.
 
 `go` is needed to install https://github.com/FiloSottile/mkcert (but it is not a requirement to start the development server). The development setup uses HTTPS per default. OpenSlides does not work with HTTP anymore since features are required (like http2) that only work in a secure environment.
 


### PR DESCRIPTION
The `buildx` plugin for docker has not been part of the requirements list, even though it is necessary for `Dockerfile` `target` functionality