### PR TITLE
Make-dev and checkout usability update

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -13,28 +13,22 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Build osmanage binary and copy compose template
-        run: |
-          make -C openslides-cli osmanage
-          mv -f openslides-cli/osmanage dev/localprod/osmanage
-          cp -f openslides-cli/contrib/docker-compose.yml.tmpl dev/localprod/docker-compose.yml.tmpl
-
-      - name: Use example data instead of initial data
-        working-directory: "./openslides-backend/data/"
-        run: cp example-data.json initial-data.json
-
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
           version: latest
 
+      - name: Build osmanage binary and copy compose template
+        run: make localprod-build-local-manage
+
+      - name: Use example data instead of initial data
+        working-directory: "./openslides-backend/data/"
+        run: cp example-data.json initial-data.json
+
       - name: Start setup
-        working-directory: "./dev/localprod"
         run: |
-          ./setup.sh
-          echo -n "admin" > secrets/superadmin
-          docker compose build --parallel
-          docker compose up -d
+          make localprod-build
+          make localprod
 
       - name: Wait for dev setup
         uses: iFaxity/wait-on-action@v1.1.0
@@ -74,5 +68,4 @@ jobs:
 
       - name: Shut down setup
         if: always()
-        working-directory: "./dev/localprod"
-        run: docker compose down --volumes --remove-orphans
+        run: make localprod-stop

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -26,7 +26,7 @@ jobs:
         run: cp example-data.json initial-data.json
 
       - name: Start setup
-        run: make localprod
+        run: make localprod-detached
 
       - name: Wait for dev setup
         uses: iFaxity/wait-on-action@v1.1.0

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -26,9 +26,7 @@ jobs:
         run: cp example-data.json initial-data.json
 
       - name: Start setup
-        run: |
-          make localprod-build
-          make localprod
+        run: make localprod
 
       - name: Wait for dev setup
         uses: iFaxity/wait-on-action@v1.1.0

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ localprod run-localprod:
 
 localprod-stop:
 	@if [ ! -f "dev/localprod/docker-compose.yml" ]; then echo "No docker-compose.yml exists in dev/localprod. Have you run setup.sh yet?" && exit 1; fi
-	docker compose -f dev/localprod/docker-compose.yml down
+	docker compose -f dev/localprod/docker-compose.yml down --volumes --remove-orphans
 
 localprod-delete:
 	rm ./dev/localprod/osmanage

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,10 @@ localprod run-localprod:
 	@if [ ! -f "dev/localprod/docker-compose.yml" ]; then echo "No docker-compose.yml exists in dev/localprod. Have you run setup.sh yet?" && exit 1; fi
 	docker compose -f dev/localprod/docker-compose.yml up --build
 
+localprod-detached:
+	@if [ ! -f "dev/localprod/docker-compose.yml" ]; then echo "No docker-compose.yml exists in dev/localprod. Have you run setup.sh yet?" && exit 1; fi
+	docker compose -f dev/localprod/docker-compose.yml up --build -d
+
 localprod-stop:
 	@if [ ! -f "dev/localprod/docker-compose.yml" ]; then echo "No docker-compose.yml exists in dev/localprod. Have you run setup.sh yet?" && exit 1; fi
 	docker compose -f dev/localprod/docker-compose.yml down --volumes --remove-orphans

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ build build-prod:
 $(.SERVICE_TARGETS):
 	@echo ""
 
-.FLAGS := no-cache compose-local-branch no-log-prefix debug-dry-run
+.FLAGS := no-cache compose-adapt-branch no-log-prefix debug-dry-run
 
 $(.FLAGS):
 	@echo ""
@@ -30,7 +30,7 @@ devstop:
 	@sed -i "1s/.*/$(GO_VERSION)/" $(DOCKER_PATH)/workspaces/*.work
 	@bash $(MAKEFILE_PATH)/make-dev.sh "dev-stop" "$(filter-out $@, $(MAKECMDGOALS))"
 
-dev dev-help dev-detached dev-attached dev-stop dev-exec dev-enter dev-clean dev-build dev-log dev-log-attach dev-restart dev-full-restart dev-docker-reset:
+dev dev-help dev-detached dev-attached dev-stop dev-exec dev-transient dev-enter dev-clean dev-build dev-db dev-log dev-log-attach dev-restart dev-full-restart dev-docker-reset:
 	@sed -i "1s/.*/$(GO_VERSION)/" $(DOCKER_PATH)/workspaces/*.work
 	@bash $(MAKEFILE_PATH)/make-dev.sh $@ "$(filter-out $@, $(MAKECMDGOALS))"
 

--- a/dev/scripts/makefile/checkout.sh
+++ b/dev/scripts/makefile/checkout.sh
@@ -29,7 +29,20 @@ if [ -f  "$BRANCH_FILE_PATH/$BRANCH_FILE" ]; then info "Reading commit info from
 usage() {
   echo "\
 
-   ** Bash command structure: $(basename "$0") [REMOTE_NAME:upstream] [BRANCH_NAME:main] [BRANCH_FILE] {-p -l -a -m -u -g}
+   Calling checkout as a make target has a different parameter structure than calling it as a bash file
+
+
+   --> Bash command structure: $(basename "$0") [REMOTE_NAME:upstream] [BRANCH_NAME:main] [BRANCH_FILE:''] {-p -l -a -m -u -g}
+
+   --> Make target structure: make checkout REMOTE= BRANCH= FILE= PULL= LATEST= AUTO_FALLBACK= ALWAYS_MAIN= USE_HTTPS= GO_UPDATE=
+
+   All bash parameters and flags have a respective environment variable for the make target. They map as follows:
+   REMOTE is a shorthand for REMOTE_NAME, BRANCH for BRANCH_NAME, FILE for BRANCH_FILE, PULL for the -p flag, LATEST for -l,
+       AUTO_FALLBACK for -a, ALWAYS_MAIN for -m, USE_HTTPS for -u and GO_UPDATE for -g
+   For parameters representing flags, set their value to anything other than 0 to 'set' the flag
+
+
+   ### Parameters:
 
    By default $(basename "$0") will fetch the latest changes for every submodule and directly check out
    the REMOTE_NAME's BRANCH_NAME branch. This will leave them in a detached HEAD state.
@@ -59,15 +72,6 @@ usage() {
       CHECKOUT_MAIN_REPO_DEFAULT: (y/n) Whether to check out the main repository (default y)
 
    # All variables are optional! #
-
-
-   ** Make target structure: make checkout REMOTE= BRANCH= FILE= PULL= LATEST= AUTO_FALLBACK= ALWAYS_MAIN= USE_HTTPS= GO_UPDATE=
-
-   REMOTE is a shorthand for REMOTE_NAME, BRANCH for BRANCH_NAME, FILE for BRANCH_FILE, PULL for the -p flag, LATEST for -l,
-       AUTO_FALLBACK for -a, ALWAYS_MAIN for -m, USE_HTTPS for -u and GO_UPDATE for -g
-   For parameters representing flags, set their value to anything other than 0 to 'activate' the flag
-
-   The rest is identical to the bash-section
    "
 }
 
@@ -111,6 +115,8 @@ checkout() {
         local SOURCE=${3:-upstream}
         local BRANCH=${4:-main}
         local HASH=$5
+
+        local GIT_REMOTE_NOT_FOUND_ERR=0
 
         # Read from Branch File, if it exists
         if [[ -e "$BRANCH_FILE_PATH/$BRANCH_FILE" && ! -d "$BRANCH_FILE_PATH/$BRANCH_FILE" ]]
@@ -192,6 +198,16 @@ checkout() {
         else
             SOURCE=$(set_remote "upstream" "origin")
             echocmd git remote set-url "$SOURCE" "${CLONE_BASE}OpenSlides/${SUBMODULE}".git
+        fi
+
+        # Check if remote exists
+        GIT_REMOTE_NOT_FOUND_ERR=0
+        git ls-remote "$SOURCE" &>/dev/null || GIT_REMOTE_NOT_FOUND_ERR=1
+        if [ "$GIT_REMOTE_NOT_FOUND_ERR" == 1 ]
+        then
+            error "Remote $SOURCE does not exist"
+            git remote remove "$SOURCE"
+            exit 0
         fi
 
         # Fetch

--- a/dev/scripts/makefile/localprod-with-local-manage.sh
+++ b/dev/scripts/makefile/localprod-with-local-manage.sh
@@ -25,6 +25,7 @@ info "Entering $OS_LOCALPROD_PATH and executing setup.sh"
 (
   cd "$OS_LOCALPROD_PATH"
   ./setup.sh
+  echo -n "admin" > secrets/superadmin
 )
 
 info "Done"

--- a/dev/scripts/makefile/make-dev.sh
+++ b/dev/scripts/makefile/make-dev.sh
@@ -24,18 +24,19 @@ Environment Variables (can be set when invoking make target):
     SERVICE_COMPOSE_SETUP    : Specifies a service whose docker compose setup should be used instead of the main repositories docker compose setup
     EXEC_COMMAND             : Specifies the command which is executed with the dev-exec operation
 
-Example: make   dev-exec    auth     SERVICE_COMPOSE_SETUP=backend   EXEC_COMMAND='ls'
-                   ^          ^               ^                              ^
-                Param #1   Param #2      Env Variable                   Env Variable
-    ( This executes 'ls' in a auth-container created and maintained by a running backend compose setup )
+Example: make   dev-exec    auth     SERVICE_COMPOSE_SETUP=backend   EXEC_COMMAND='ls'   debug-dry-run
+                   ^          ^               ^                              ^                ^
+                Param #1   Param #2      Env Variable                   Env Variable      Long Flag
+    ( This executes 'ls' in a auth-container created and maintained by a running backend compose setup.
+      Because of the 'debug-dry-run' long flag, a dry run is executed. )
 
 Long Flags:
     no-cache             : Prevents use of cache when building docker images
-    compose-local-branch : Compose setups pull service images from the main branch by default.
-                           When 'compose-local-branch' is set to true, the checked out branch of the service will be pulled instead.
+    compose-adapt-branch : Compose setups pull service images from the main branch by default.
+                           When 'compose-adapt-branch' is set to true, the checked out branch of the service will be pulled instead.
                            Example: Backend-Service is locally checked-out to 'feature/xyz'.
                            Its dev compose setup pulls 'auth' from github by referencing 'openslides-auth-service.git#main'.
-                           If 'compose-local-branch' is set to true, the path 'openslides-auth-service.git#feature/xyz' will be used instead.
+                           If 'compose-adapt-branch' is set to true, the path 'openslides-auth-service.git#feature/xyz' will be used instead.
     no-log-prefix        : When printing container logs, the associated container name is omitted
     debug-dry-run        : Prints all commands that would run but prevents their actual execution
 
@@ -43,7 +44,10 @@ Available dev operations:
     dev              : Builds and starts development images.
     dev-help         : Print help.
     dev-detached     : Builds and starts development images with detach flag. This causes started containers to run in the background.
-    dev-attached     : Builds and starts development images; enters shell of started image.
+    dev-attached     : Builds and starts development images; enters shell of started container.
+                          If a docker compose file is declared, the CONTAINER parameter determines
+                          the specific container id you will enter (default value is equal the service name)
+    dev-transient   : Builds and starts development images; enters shell of started container. Stops any currently runnign containers after exiting shell
                           If a docker compose file is declared, the CONTAINER parameter determines
                           the specific container id you will enter (default value is equal the service name)
     dev-restart      : Restarts all containers. If CONTAINER is set, only the specified service will be restarted
@@ -57,6 +61,7 @@ Available dev operations:
                           If a docker compose file is declared, the CONTAINER parameter determines
                           the specific container id you will enter (default value is equal the service name).
     dev-build        : Builds all images. If CONTAINER is set, only the image for the specified container will be build
+    dev-db           : Special exec command that starts an interactive postgres session
     dev-log          : Prints docker compose log output. If CONTAINER is set, only the specified container will be logged
     dev-log-attach   : Prints docker compose log output and attaches console to the containers log output feed.
                        If CONTAINER is set, only the specified container will be logged
@@ -260,6 +265,7 @@ exec_func()
 {
     local TARGET_CONTAINER="$CONTAINER"
     local FUNC=$EXEC_COMMAND
+    local PAGER_VALUE="$1"
 
     # Special case: A submodules docker compose setup is used and no specific container has been declared.
     # Example: "Calling 'make dev-exec' while in ./openslides-backend"
@@ -286,11 +292,11 @@ exec_func()
     then
         # Compose
         # shellcheck disable=SC2086
-        echocmd docker compose -f "${COMPOSE_FILE}" exec "${TARGET_CONTAINER}" ${FUNC}
+        echocmd docker compose -f "${COMPOSE_FILE}" exec -e PAGER="$PAGER_VALUE" "${TARGET_CONTAINER}" ${FUNC}
     else
         # Single Container
         # shellcheck disable=SC2086
-        echocmd docker exec "$CONTAINER_TAG" $FUNC
+        echocmd docker exec -e PAGER="$PAGER_VALUE" "$CONTAINER_TAG" $FUNC
     fi
 }
 
@@ -336,6 +342,8 @@ log()
                 # shellcheck disable=SC2086
                 echocmd docker compose -f "$COMPOSE_FILE" logs ${LOG_PREFIX} ${CONNECT_FLAG}
                 exit 0
+            else
+                CONTAINER_LIST+=("$TARGET_CONTAINER")
             fi
         else
             # Submodule case
@@ -343,7 +351,7 @@ log()
         fi
 
         # shellcheck disable=SC2086
-        echocmd docker compose -f "$COMPOSE_FILE" logs ${TARGET_CONTAINER} ${LOG_PREFIX} ${CONNECT_FLAG}
+        echocmd docker compose -f "$COMPOSE_FILE" logs ${CONTAINER_LIST[@]} ${LOG_PREFIX} ${CONNECT_FLAG}
     else
         # Single Container
 
@@ -364,14 +372,15 @@ CONTAINER=$2
 # Extract flags here
 TEMP_SERVICE=$CONTAINER
 CONTAINER=""
+CONTAINER_LIST=()
 # shellcheck disable=SC2034
 for CMD in $TEMP_SERVICE; do
     case "$CMD" in
         "no-cache")      NO_CACHE=true ;;
-        "compose-local-branch") USE_LOCAL_BRANCH_FOR_COMPOSE=true ;;
+        "compose-adapt-branch") ADAPT_BRANCH_FOR_COMPOSE=true ;;
         "no-log-prefix") LOG_PREFIX="--no-log-prefix" ;;
         "debug-dry-run") DEBUG_DRY_RUN=1 ;;
-        *)               CONTAINER="$CMD" ;;
+        *)               CONTAINER="$CMD" && CONTAINER_LIST+=("$CMD");;
     esac
 done
 
@@ -420,14 +429,14 @@ else info "Running $FUNCTION"; fi
 
 # Compose dev branch checkout
 export COMPOSE_REFERENCE_BRANCH="main"
-if [ -n "$USE_LOCAL_BRANCH_FOR_COMPOSE" ]
+if [ -n "$ADAPT_BRANCH_FOR_COMPOSE" ]
 then
     if [ -n "$SERVICE_COMPOSE_SETUP" ]
     then
         if [ -z "$SERVICE_FOLDER" ]
         then
             error "No folder found for service '$CONTAINER'. Please check if the \$CONTAINER parameter has been properly set and refers to an existing service."
-            warn "'compose-local-branch' only works for submodule services, not for main!"
+            warn "'compose-adapt-branch' only works for submodule services, not for main!"
             exit 1
         fi
         COMPOSE_REFERENCE_BRANCH=$(git -C "$SERVICE_FOLDER" branch --show-current)
@@ -449,6 +458,7 @@ case "$FUNCTION" in
     "help")             help ;;
     "detached")         build && run "-d" && info "Containers started" ;;
     "attached")         build && run "-d" && attach ;;
+    "transient")       build && run "-d" && attach && stop ;;
     "full-restart")     stop && build && run ;;
     "restart")          restart ;;
     "stop")             stop ;;
@@ -456,6 +466,7 @@ case "$FUNCTION" in
     "exec")             exec_func ;;
     "enter")            attach ;;
     "build")            build ;;
+    "db")               CONTAINER="postgres" && EXEC_COMMAND="psql -U openslides" && exec_func "less -S";;
     "log")              log ;;
     "log-attach")       log 1 ;;
     "docker-reset")     docker_reset ;;


### PR DESCRIPTION
Implementing feedback and feature request that emerged from the last team meeting.
Features:
- Multiple containers can be supplied as parameters when calling `dev-log`, allowing multi-container logging
- Adding a command which starts an interactive postgres-session
- Adding a command that starts the docker compose setup, attaches to a container and stops the compose setup after the user exits the interactive console

Other changes & bugfixes:
- Test-integration workflow now uses `localprod` make targets
- Reworded `checkout` help message
- `make-dev` help message includes new commands and its example command now includes a long flag
- In `checkout`, if a declared remote does not exist, a non-panic error is thrown and the added remote gets removed again
- Renamed `compose-local-branch` to `compose-adapt-branch`